### PR TITLE
fix: cli#71 - config system was leaking env vars into the config file when it shouldn't have 

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,6 @@ project_name: octopus
 
 release:
   prerelease: auto
-  draft: true # we publish during the Octopus deployment
   name_template: "Octopus CLI {{.Version}}"
 
 before:

--- a/cmd/octopus/main.go
+++ b/cmd/octopus/main.go
@@ -23,8 +23,10 @@ func main() {
 	// if there is a missing or invalid .env file anywhere, we don't care, just ignore it
 	_ = godotenv.Load()
 
-	config.Setup()
-	config.SetupEnv()
+	if err := config.Setup(); err != nil {
+		fmt.Println(err)
+		os.Exit(3)
+	}
 	arg := os.Args[1:]
 	cmdToRun := ""
 	if len(arg) > 0 {

--- a/cmd/octopus/main.go
+++ b/cmd/octopus/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/briandowns/spinner"
+	"github.com/spf13/viper"
 	"os"
 	"time"
 
@@ -23,7 +24,7 @@ func main() {
 	// if there is a missing or invalid .env file anywhere, we don't care, just ignore it
 	_ = godotenv.Load()
 
-	if err := config.Setup(); err != nil {
+	if err := config.Setup(viper.GetViper()); err != nil {
 		fmt.Println(err)
 		os.Exit(3)
 	}

--- a/pkg/cmd/config/get/get.go
+++ b/pkg/cmd/config/get/get.go
@@ -31,7 +31,7 @@ func NewCmdGet(f factory.Factory) *cobra.Command {
 
 func getRun(isPromptEnabled bool, ask question.Asker, key string, out io.Writer) error {
 	if key != "" {
-		if !config.ValidateKey(key) {
+		if !config.IsValidKey(key) {
 			return fmt.Errorf("the key '%s' is not a valid", key)
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,21 +2,18 @@ package config
 
 import (
 	"fmt"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"github.com/OctopusDeploy/cli/pkg/constants"
-	"github.com/OctopusDeploy/cli/pkg/util"
-	"github.com/spf13/viper"
 )
 
 const configName = "cli_config"
 const defaultConfigFileType = "json"
 const appData = "AppData"
-
-// var configPath string
 
 func SetupConfigFile(v *viper.Viper, configPath string) {
 	v.SetConfigName(configName)
@@ -40,34 +37,40 @@ func setDefaults(v *viper.Viper) {
 	}
 }
 
-func Setup() error {
-	// we use the global static viper through all the CLI, EXCEPT when writing config files, which is done in pkg/cmd/set, not here
-	setDefaults(viper.GetViper())
-
-	// bind environment variables
-	if err := viper.BindEnv(constants.ConfigApiKey, constants.EnvOctopusApiKey); err != nil {
+func bindEnvironment(v *viper.Viper) error {
+	if err := v.BindEnv(constants.ConfigApiKey, constants.EnvOctopusApiKey); err != nil {
 		return err
 	}
-	if err := viper.BindEnv(constants.ConfigHost, constants.EnvOctopusHost); err != nil {
+	if err := v.BindEnv(constants.ConfigHost, constants.EnvOctopusHost); err != nil {
 		return err
 	}
-	if err := viper.BindEnv(constants.ConfigSpace, constants.EnvOctopusSpace); err != nil {
+	if err := v.BindEnv(constants.ConfigSpace, constants.EnvOctopusSpace); err != nil {
 		return err
 	}
 	// Envs will take precedence in the specified order
-	if err := viper.BindEnv(constants.ConfigEditor, constants.EnvVisual, constants.EnvEditor); err != nil {
+	if err := v.BindEnv(constants.ConfigEditor, constants.EnvVisual, constants.EnvEditor); err != nil {
 		return err
 	}
-	if err := viper.BindEnv(constants.ConfigNoPrompt, constants.EnvCI); err != nil {
+	if err := v.BindEnv(constants.ConfigNoPrompt, constants.EnvCI); err != nil {
+		return err
+	}
+	return nil
+}
+
+func Setup(v *viper.Viper) error {
+	setDefaults(v)
+
+	// bind environment variables
+	if err := bindEnvironment(v); err != nil {
 		return err
 	}
 
 	// read the config file
 	configPath, err := getConfigPath()
 	if err == nil {
-		SetupConfigFile(viper.GetViper(), configPath)
+		SetupConfigFile(v, configPath)
 
-		if err := viper.ReadInConfig(); err != nil {
+		if err := v.ReadInConfig(); err != nil {
 			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 				// Do nothing, config file will be created on `config set` cmd
 				// This is to avoid issues with CI tools that may not have access
@@ -116,8 +119,12 @@ func getConfigPath() (string, error) {
 	return configPath, nil
 }
 
-func ValidateKey(key string) bool {
+func IsValidKey(key string) bool {
+	// Deliberate reach-out to the global viper instance here.
+	// A key is valid if the global viper knows about it; our 'newViper' doesn't know about anything
+	validKeys := viper.AllKeys()
+
 	key = strings.TrimSpace(key)
 	key = strings.ToLower(key)
-	return util.SliceContains(viper.AllKeys(), key)
+	return util.SliceContains(validKeys, key)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,17 +59,13 @@ func bindEnvironment(v *viper.Viper) error {
 
 func Setup(v *viper.Viper) error {
 	setDefaults(v)
-
-	// bind environment variables
 	if err := bindEnvironment(v); err != nil {
 		return err
 	}
 
-	// read the config file
 	configPath, err := getConfigPath()
 	if err == nil {
 		SetupConfigFile(v, configPath)
-
 		if err := v.ReadInConfig(); err != nil {
 			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 				// Do nothing, config file will be created on `config set` cmd

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ func SetupConfigFile(v *viper.Viper, configPath string) {
 	v.AddConfigPath(configPath)
 }
 
-func SetupDefaults(v *viper.Viper) {
+func setDefaults(v *viper.Viper) {
 	v.SetDefault(constants.ConfigHost, "")
 	v.SetDefault(constants.ConfigApiKey, "")
 	v.SetDefault(constants.ConfigSpace, "")
@@ -42,7 +42,7 @@ func SetupDefaults(v *viper.Viper) {
 
 func Setup() error {
 	// we use the global static viper through all the CLI, EXCEPT when writing config files, which is done in pkg/cmd/set, not here
-	SetupDefaults(viper.GetViper())
+	setDefaults(viper.GetViper())
 
 	// bind environment variables
 	if err := viper.BindEnv(constants.ConfigApiKey, constants.EnvOctopusApiKey); err != nil {
@@ -117,6 +117,7 @@ func getConfigPath() (string, error) {
 }
 
 func ValidateKey(key string) bool {
-	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.TrimSpace(key)
+	key = strings.ToLower(key)
 	return util.SliceContains(viper.AllKeys(), key)
 }


### PR DESCRIPTION
If you bindEnv/flags etc into viper, then it WILL write them to the config file, by design.

This was already handled by using a secondary viper inside 'config set'; however the global viper would also write the config file on startup as part of it's code to check that the file existed. This is how the env vars leaked into it.

Fix: 
- The global viper can pick up all the env vars and flags and only read. It must NOT write to or create the file
- The local viper inside 'config set' can read, write and create the file, but it must NOT pickup env vars and flags.

Root cause:
The code which created the file as part of reading it was trying to be helpful. It wasn't easy to pick up, as it was nested inside a few layers... Better to be explicit about when the file is created and avoid magic behaviour.