### PR TITLE
Use the GitHub API instead of the GitHub CLI to create the PR

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Extract octopus.exe
       id: extract_exe
       shell: bash
-      run: unzip -d . ./artifacts/*Windows_x86_64.zip octopus.exe
+      run: unzip -d . ./artifacts/*windows_amd64.zip octopus.exe
 
     - name: Build MSI
       id: buildmsi
@@ -99,7 +99,7 @@ jobs:
         MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
       # note the wixproj deliberately logs "::set-output name=msi::$(TargetPath)" so this step has an output called 'msi'
       run: |
-        name="octopus_${{ needs.goreleaser.outputs.version }}_Windows_x86_64"
+        name="octopus_${{ needs.goreleaser.outputs.version }}_windows_amd64"
         version="$(echo -e ${{ needs.goreleaser.outputs.version }} | sed 's/-.*$//')"
         "${MSBUILD_PATH}\MSBuild.exe" ./build/windows/octopus.wixproj -p:SourceDir="$PWD" -p:OutputPath="$PWD" -p:OutputName="$name" -p:ProductVersion="$version"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,9 +25,6 @@ builds:
 archives:
   - replacements:
       darwin: macOS
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
     format_overrides:
       - goos: windows
         format: zip

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -66,27 +66,20 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                 param(
                     [String]$packageVersion, # e.g. "0.2.2"
                     [String]$extractedPath # e.g.  "C:\Users\Orion\Downloads\octopus-cli.0.2.2"
+                    [String]$githubtoken
                 )
                 
                 $origin="https://github.com/OctopusDeploy/homebrew-taps"
-                $gh = "gh" # github cli
                 
                 if ($OctopusParameters) {
-                    write-host "using OctopusParameters"
-                    # we are running inside an octopus tentacle
                     $packageVersion = $OctopusParameters["Octopus.Action.Package[cli].PackageVersion"]
                     $extractedPath = $OctopusParameters["Octopus.Action.Package[cli].ExtractedPath"]
                 
-                    $ghExtractedPath = $OctopusParameters["Octopus.Action.Package[gh_linux_amd64].ExtractedPath"]
-                    write-host "dbg: ghExtractedPath = $ghExtractedPath"
-                    $ghVersion = $OctopusParameters["Octopus.Action.Package[gh_linux_amd64].PackageVersion"]
-                    write-host "dbg: ghVersion = $ghVersion"
-                    $gh = Join-Path -Path $ghExtractedPath "gh_${ghVersion}_linux_amd64" "bin" "gh"
-                    write-host "dbg: gh = $gh"
-                    chmod +x $gh
-
                     $githubtoken = $OctopusParameters["Publish:HomeBrew:ApiKey"]
                     $origin="https://${githubtoken}@github.com/OctopusDeploy/homebrew-taps"
+
+                    git config user.name $OctopusParameters["Publish:HomeBrew:Username"]
+                    git config user.email $OctopusParameters["Publish:HomeBrew:UserEmail"]
                 }
                 
                 if (!$packageVersion || !$extractedPath) {
@@ -98,7 +91,7 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                 
                 git clone --depth 1 $origin octopus-homebrew-taps
                 cd octopus-homebrew-taps
-                
+
                 $branchName = "bump-octopus-cli-$packageVersion"
                 git checkout -b $branchName
                 
@@ -119,18 +112,20 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                     -replace "macos_arm_sha256 = `".*`"", "macos_arm_sha256 = `"$macos_arm_sha256`"" `
                     -replace "linux_intel_sha256 = `".*`"", "linux_intel_sha256 = `"$linux_intel_sha256`"" `
                     -replace "linux_arm_sha256 = `".*`"", "linux_arm_sha256 = `"$linux_arm_sha256`"") | Set-Content $formulaFile
-                
-                if ($OctopusParameters) {
-                    git config user.name $OctopusParameters["Publish:HomeBrew:Username"]
-                    git config user.email $OctopusParameters["Publish:HomeBrew:UserEmail"]
-                    $env:GH_TOKEN = $githubtoken
-                }
+
                 git commit -a -m "octopus-cli $packageVersion"
-                
                 git push --set-upstream origin $branchName
-                
-                &($gh) pr create --head $branchName --title "octopus-cli $packageVersion" --body "automatically generated"
-                
+
+                if ($githubtoken) {
+                    $baseBranch = $(git symbolic-ref "refs/remotes/origin/HEAD") -replace "refs/remotes/origin/", ""
+
+                    curl -X POST `
+                        -H "Accept: application/vnd.github+json" `
+                        -H "Authorization: Bearer $githubtoken" `
+                        https://api.github.com/repos/OctopusDeploy/homebrew-taps/pulls `
+                        -d @{title = "octopus-cli $packageVersion";body = "automatically generated";head = $branchName;base = $baseBranch} | ConvertTo-Json
+                }
+
                 cd ..
             EOT
             Octopus.Action.Script.ScriptSource = "Inline"
@@ -147,17 +142,6 @@ step "create-pull-request-to-update-formula-in-homebrew" {
             acquisition_location = "Server"
             feed = "octopus-server-built-in"
             package_id = "octopus-cli"
-            properties = {
-                Extract = "True"
-                Purpose = ""
-                SelectionMode = "immediate"
-            }
-        }
-
-        packages "gh_linux_amd64" {
-            acquisition_location = "Server"
-            feed = "octopus-server-built-in"
-            package_id = "gh_linux_amd64"
             properties = {
                 Extract = "True"
                 Purpose = ""

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -119,11 +119,10 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                 if ($githubtoken) {
                     $baseBranch = $(git symbolic-ref "refs/remotes/origin/HEAD") -replace "refs/remotes/origin/", ""
 
-                    curl -X POST `
-                        -H "Accept: application/vnd.github+json" `
-                        -H "Authorization: Bearer $githubtoken" `
-                        https://api.github.com/repos/OctopusDeploy/homebrew-taps/pulls `
-                        -d @{title = "octopus-cli $packageVersion";body = "automatically generated";head = $branchName;base = $baseBranch} | ConvertTo-Json
+                    Invoke-RestMethod -Method POST `
+                        -Headers @{"Accept" = "application/vnd.github+json";"Authorization" = "Bearer $githubtoken"} `
+                        -Uri https://api.github.com/repos/OctopusDeploy/homebrew-taps/pulls `
+                        -Body @{title = "octopus-cli $packageVersion";body = "automatically generated";head = $branchName;base = $baseBranch}
                 }
 
                 cd ..

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -95,14 +95,14 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                 $branchName = "bump-octopus-cli-$packageVersion"
                 git checkout -b $branchName
                 
-                $macos_intel_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_macOS_x86_64.tar.gz").Hash.ToLowerInvariant()
+                $macos_intel_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_macOS_amd64.tar.gz").Hash.ToLowerInvariant()
                 write-host "macos_intel_sha256=$macos_intel_sha256"
                 $macos_arm_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_macOS_arm64.tar.gz").Hash.ToLowerInvariant()
                 write-host "macos_arm_sha256=$macos_arm_sha256"
                 
-                $linux_intel_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_Linux_x86_64.tar.gz").Hash.ToLowerInvariant()
+                $linux_intel_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_linux_amd64.tar.gz").Hash.ToLowerInvariant()
                 write-host "linux_intel_sha256=$linux_intel_sha256"
-                $linux_arm_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_Linux_arm64.tar.gz").Hash.ToLowerInvariant()
+                $linux_arm_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_linux_arm64.tar.gz").Hash.ToLowerInvariant()
                 write-host "linux_arm_sha256=$linux_arm_sha256"
                 
                 $formulaFile="octopus-cli.rb"

--- a/build/tools/chocolateyInstall.ps1
+++ b/build/tools/chocolateyInstall.ps1
@@ -6,8 +6,8 @@ $logMsi = Join-Path -Path $env:TEMP -ChildPath ("{0}-{1}-MsiInstall.log" -f $env
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     fileType       = 'MSI'
-    silentArgs     = "/qn /norestart `"$logMsi`""
-    file64         = Join-Path -Path $toolsDir -ChildPath "octopus_$($env:ChocolateyPackageVersion)_windows_amd64.msi"
+    silentArgs     = "/qn /norestart /log `"$logMsi`""
+    file64         = Join-Path -Path $toolsDir -ChildPath "octopus_$($env:ChocolateyPackageVersion)_Windows_x86_64.msi"
 }
 
 Install-ChocolateyInstallPackage @packageArgs

--- a/build/tools/chocolateyInstall.ps1
+++ b/build/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     fileType       = 'MSI'
     silentArgs     = "/qn /norestart /log `"$logMsi`""
-    file64         = Join-Path -Path $toolsDir -ChildPath "octopus_$($env:ChocolateyPackageVersion)_Windows_x86_64.msi"
+    file64         = Join-Path -Path $toolsDir -ChildPath "octopus_$($env:ChocolateyPackageVersion)_windows_amd64.msi"
 }
 
 Install-ChocolateyInstallPackage @packageArgs


### PR DESCRIPTION
While using `gh` is nice, the fact that we have to maintain a package that contains it (even if that's just getting the package from the release on GitHub and uploading it to Octopus) makes it a less optimal solution.

The script can still be run locally but will only create the PR for the update if you pass in a GitHub PAT.