### PR TITLE
Generate new homebrew formula file as part of goreleaser release

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -64,6 +64,7 @@ jobs:
           dist/*.tar.gz
           dist/*.rpm
           dist/*.deb
+          dist/*.rb
 
   msi:
     needs: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,3 +60,26 @@ signs:
 
 changelog:
   skip: true
+
+brews:
+  - name: "octopus-cli"
+
+    tap:
+      owner: OctopusDeploy
+      name: homebrew-taps
+
+    homepage: "https://github.com/OctopusDeploy/cli"
+    description: "The New CLI (octopus) for Octopus Deploy, a user-friendly DevOps tool for developers that supports release management, deployment automation, and operations runbooks"
+    license: "Apache-2.0"
+
+    skip_upload: true
+
+    test: |
+      system "#{bin}/octopus", "--help"
+
+    install: |
+      bin.install "octopus"
+      # future: enhance the CLI to generate completion scripts, and install them as follows
+      # bash_completion.install "completions/octopus.bash" => "octopus"
+      # zsh_completion.install "completions/octopus.zsh" => "_octopus"
+      # fish_completion.install "completions/octopus.fish"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -92,7 +92,7 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                 git clone --depth 1 $origin octopus-homebrew-taps
                 cd octopus-homebrew-taps
 
-                $branchName = "bump-octopus-cli-$packageVersion"
+                $branchName = "releases/$packageVersion"
                 git checkout -b $branchName
                 
                 Copy-Item -Path "$extractedPath/*" -Filter "*.rb" -Destination "." -Force

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -95,23 +95,7 @@ step "create-pull-request-to-update-formula-in-homebrew" {
                 $branchName = "bump-octopus-cli-$packageVersion"
                 git checkout -b $branchName
                 
-                $macos_intel_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_macOS_amd64.tar.gz").Hash.ToLowerInvariant()
-                write-host "macos_intel_sha256=$macos_intel_sha256"
-                $macos_arm_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_macOS_arm64.tar.gz").Hash.ToLowerInvariant()
-                write-host "macos_arm_sha256=$macos_arm_sha256"
-                
-                $linux_intel_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_linux_amd64.tar.gz").Hash.ToLowerInvariant()
-                write-host "linux_intel_sha256=$linux_intel_sha256"
-                $linux_arm_sha256 = (Get-FileHash -Algorithm SHA256 "$extractedPath/octopus_${packageVersion}_linux_arm64.tar.gz").Hash.ToLowerInvariant()
-                write-host "linux_arm_sha256=$linux_arm_sha256"
-                
-                $formulaFile="octopus-cli.rb"
-                ((Get-Content $formulaFile) `
-                    -replace "version `".*`"", "version `"$packageVersion`"" `
-                    -replace "macos_intel_sha256 = `".*`"", "macos_intel_sha256 = `"$macos_intel_sha256`"" `
-                    -replace "macos_arm_sha256 = `".*`"", "macos_arm_sha256 = `"$macos_arm_sha256`"" `
-                    -replace "linux_intel_sha256 = `".*`"", "linux_intel_sha256 = `"$linux_intel_sha256`"" `
-                    -replace "linux_arm_sha256 = `".*`"", "linux_arm_sha256 = `"$linux_arm_sha256`"") | Set-Content $formulaFile
+                Copy-Item -Path "$extractedPath/*" -Filter "*.rb" -Destination "." -Force
 
                 git commit -a -m "octopus-cli $packageVersion"
                 git push --set-upstream origin $branchName

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -38,8 +38,8 @@ goreleaser --> msi --> generate-packages-and-publish
 subgraph "goreleaser"
     build --> uploadToGHA
     
-    build[Build CLI binaries for all architectures including deb, rpm]
-    uploadToGHA[Upload binaries+linux packages to GHA artifact]
+    build[Build CLI binaries for all architectures including deb, rpm and generate homebrew formula]
+    uploadToGHA[Upload binaries+linux packages+homebrew formula to GHA artifact]
 end
 subgraph "msi"
     fetch --> buildmsi --> signmsi --> attachMSIToRelease --> uploadMSIToGHA


### PR DESCRIPTION
`goreleaser` has an option to generate a homebrew formula file as part of the `release` command. I've put together this PR as a way of showing the team what output it would produce, if we think it's not appropriate then we can just close it.

The file is more verbose than what is currently in the `octopus-cli.rb` file due to some changes GoReleaser made to their homebrew implementation where they put the `install` definition inside each of the architecture block instead of a single definition towards the end of the file.

Example output of `octopus-cli.rb` running `goreleaser release`:
```
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class OctopusCli < Formula
  desc "The New CLI (octopus) for Octopus Deploy, a user-friendly DevOps tool for developers that supports release management, deployment automation, and operations runbooks"
  homepage "https://github.com/OctopusDeploy/cli"
  version "0.2.5-SNAPSHOT-131e2c2"
  license "Apache-2.0"

  on_macos do
    if Hardware::CPU.arm?
      url "https://github.com/OctopusDeploy/cli/releases/download/v0.2.5/octopus_0.2.5-SNAPSHOT-131e2c2_macOS_arm64.tar.gz"
      sha256 "d96ab652e52fde82ff359af0f7c92e58e2ed8efc639f86c0b216b1ecffb7eacb"

      def install
        bin.install "octopus"
        # future: enhance the CLI to generate completion scripts, and install them as follows
        # bash_completion.install "completions/octopus.bash" => "octopus"
        # zsh_completion.install "completions/octopus.zsh" => "_octopus"
        # fish_completion.install "completions/octopus.fish"
      end
    end
    if Hardware::CPU.intel?
      url "https://github.com/OctopusDeploy/cli/releases/download/v0.2.5/octopus_0.2.5-SNAPSHOT-131e2c2_macOS_amd64.tar.gz"
      sha256 "c5ce9eaaa5562510d35a2294d9357a6b32799999a6efe5e3aa7f1d10086f60c0"

      def install
        bin.install "octopus"
        # future: enhance the CLI to generate completion scripts, and install them as follows
        # bash_completion.install "completions/octopus.bash" => "octopus"
        # zsh_completion.install "completions/octopus.zsh" => "_octopus"
        # fish_completion.install "completions/octopus.fish"
      end
    end
  end

  on_linux do
    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
      url "https://github.com/OctopusDeploy/cli/releases/download/v0.2.5/octopus_0.2.5-SNAPSHOT-131e2c2_linux_arm64.tar.gz"
      sha256 "93e501d76c24c069c4f114e059bad4835d1afd42049e34b10f54de6a6479513a"

      def install
        bin.install "octopus"
        # future: enhance the CLI to generate completion scripts, and install them as follows
        # bash_completion.install "completions/octopus.bash" => "octopus"
        # zsh_completion.install "completions/octopus.zsh" => "_octopus"
        # fish_completion.install "completions/octopus.fish"
      end
    end
    if Hardware::CPU.intel?
      url "https://github.com/OctopusDeploy/cli/releases/download/v0.2.5/octopus_0.2.5-SNAPSHOT-131e2c2_linux_amd64.tar.gz"
      sha256 "777e22f5399af01cd9631a59bee1e068d3f2dd809d4f8680b18ff5962f016431"

      def install
        bin.install "octopus"
        # future: enhance the CLI to generate completion scripts, and install them as follows
        # bash_completion.install "completions/octopus.bash" => "octopus"
        # zsh_completion.install "completions/octopus.zsh" => "_octopus"
        # fish_completion.install "completions/octopus.fish"
      end
    end
  end

  test do
    system "#{bin}/octopus", "--help"
  end
end
```