### PR TITLE
feat: add project view command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,11 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/muesli/reflow v0.3.0
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035
 )
 
@@ -41,7 +41,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.3.1 // indirect
 	github.com/spf13/afero v1.8.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035
 )
 
@@ -40,6 +41,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.3.1 // indirect
 	github.com/spf13/afero v1.8.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.6.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.7.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.6.1 h1:jnMWqsSo7/Ir7aX5ozhGmyOG8QfDmg7tjMnYydbCG7M=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.6.1/go.mod h1:XWqxyDUVElUlTaPqyCBblukpsHSnPcAKkAHgJgbsIAs=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.7.0 h1:WGUL5cUMhnuQ9285aorzJVVUbBr9uIu72xDzd605exo=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.7.0/go.mod h1:XWqxyDUVElUlTaPqyCBblukpsHSnPcAKkAHgJgbsIAs=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
 github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -385,6 +387,7 @@ golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/MakeNowJust/heredoc/v2"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/project/list"
+	cmdView "github.com/OctopusDeploy/cli/pkg/cmd/project/view"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -26,6 +27,7 @@ func NewCmdProject(f factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
+	cmd.AddCommand(cmdView.NewCmdView(f))
 
 	return cmd
 }

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -1,0 +1,106 @@
+package view
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/usage"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+)
+
+const (
+	FlagWeb = "web"
+)
+
+type ViewFlags struct {
+	Web *flag.Flag[bool]
+}
+
+func NewViewFlags() *ViewFlags {
+	return &ViewFlags{
+		Web: flag.New[bool](FlagWeb, false),
+	}
+}
+
+type ViewOptions struct {
+	Client   *client.Client
+	Host     string
+	out      io.Writer
+	idOrName string
+	flags    *ViewFlags
+}
+
+func NewCmdView(f factory.Factory) *cobra.Command {
+	viewFlags := NewViewFlags()
+	cmd := &cobra.Command{
+		Args:  usage.ExactArgs(1),
+		Use:   "view {<name> | <id> | <slug>}",
+		Short: "View a project in an instance of Octopus Deploy",
+		Long:  "View a project in an instance of Octopus Deploy",
+		Example: fmt.Sprintf(heredoc.Doc(`
+			$ %s project view Projects-9000
+			$ %s project view 'Deploy Web App'
+			$ %s project view deploy-web-app
+		`), constants.ExecutableName, constants.ExecutableName, constants.ExecutableName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.GetSpacedClient()
+			if err != nil {
+				return err
+			}
+
+			opts := &ViewOptions{
+				client,
+				os.Getenv(constants.EnvOctopusHost),
+				cmd.OutOrStdout(),
+				args[0],
+				viewFlags,
+			}
+
+			return viewRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&viewFlags.Web.Value, viewFlags.Web.Name, "w", false, "Open in web browser")
+
+	return cmd
+}
+
+func viewRun(opts *ViewOptions) error {
+	project, err := opts.Client.Projects.GetByIdOrName(opts.idOrName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(opts.out, "%s %s\n", output.Bold(project.Name), output.Dimf("(%s)", project.GetID()))
+
+	cacBranch := "Not version controlled"
+	if project.IsVersionControlled {
+		cacBranch = project.PersistenceSettings.(*projects.GitPersistenceSettings).DefaultBranch
+	}
+	fmt.Fprintf(opts.out, "Version control branch: %s\n", output.Cyan(cacBranch))
+	if len(project.Description) == 0 {
+		fmt.Fprintln(opts.out, output.Dim(constants.NoDescription))
+	} else {
+		fmt.Fprintln(opts.out, output.Dim(project.Description))
+	}
+
+	url := opts.Host + project.Links["Web"]
+
+	// footer
+	fmt.Fprintf(opts.out, "View this project in Octopus Deploy: %s\n", output.Blue(url))
+
+	if opts.flags.Web.Value {
+		browser.OpenURL(url)
+	}
+
+	return nil
+}

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -46,8 +46,8 @@ func NewCmdView(f factory.Factory) *cobra.Command {
 		Short: "View a project in an instance of Octopus Deploy",
 		Long:  "View a project in an instance of Octopus Deploy",
 		Example: fmt.Sprintf(heredoc.Doc(`
-			$ %s project view Projects-9000
 			$ %s project view 'Deploy Web App'
+			$ %s project view Projects-9000
 			$ %s project view deploy-web-app
 		`), constants.ExecutableName, constants.ExecutableName, constants.ExecutableName),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -80,7 +80,7 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(opts.out, "%s %s\n", output.Bold(project.Name), output.Dimf("(%s)", project.GetID()))
+	fmt.Fprintf(opts.out, "%s %s\n", output.Bold(project.Name), output.Dimf("(%s)", project.Slug))
 
 	cacBranch := "Not version controlled"
 	if project.IsVersionControlled {

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"io"
-	"os"
 )
 
 const (
@@ -58,7 +57,7 @@ func NewCmdView(f factory.Factory) *cobra.Command {
 
 			opts := &ViewOptions{
 				client,
-				os.Getenv(constants.EnvOctopusHost),
+				f.GetCurrentHost(),
 				cmd.OutOrStdout(),
 				args[0],
 				viewFlags,

--- a/pkg/cmd/space/view/view.go
+++ b/pkg/cmd/space/view/view.go
@@ -3,7 +3,6 @@ package view
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -44,7 +43,7 @@ func NewCmdView(f factory.Factory) *cobra.Command {
 			}
 
 			opts.Client = client
-			opts.Host = os.Getenv(constants.EnvOctopusHost)
+			opts.Host = f.GetCurrentHost()
 			opts.IO = cmd.OutOrStdout()
 			opts.Selector = args[0]
 

--- a/pkg/cmd/space/view/view.go
+++ b/pkg/cmd/space/view/view.go
@@ -44,7 +44,7 @@ func NewCmdView(f factory.Factory) *cobra.Command {
 			}
 
 			opts.Client = client
-			opts.Host = os.Getenv("OCTOPUS_HOST")
+			opts.Host = os.Getenv(constants.EnvOctopusHost)
 			opts.IO = cmd.OutOrStdout()
 			opts.Selector = args[0]
 
@@ -70,7 +70,7 @@ func printHumanSpacePreview(host string, space *spaces.Space, out io.Writer) err
 
 	// metadata
 	if len(space.Description) == 0 {
-		fmt.Fprintln(out, output.Dim("No description provided"))
+		fmt.Fprintln(out, output.Dim(constants.NoDescription))
 
 	} else {
 		fmt.Fprintln(out, output.Dim(space.Description))

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -47,6 +47,10 @@ const (
 	EnvCI            = "CI"
 )
 
+const (
+	NoDescription = "No description provided"
+)
+
 // IsProgrammaticOutputFormat tells you if it is acceptable for your command to
 // print miscellaneous output to stdout, such as progress messages.
 // If your command is capable of printing such things, you should check the output format


### PR DESCRIPTION
[sc-18973]

Depends on https://github.com/OctopusDeploy/go-octopusdeploy/pull/145

Help output:
```
View a project in an instance of Octopus Deploy

USAGE
 octopus project view {<name> | <id> | <slug>} [flags]

FLAGS
 -w, --web   Open in web browser

INHERITED FLAGS
 -h, --help                   Show help for command
     --no-prompt              disable prompting in interactive mode
 -f, --output-format string   Output Format (Valid values are 'json', 'table', 'basic'. Defaults to table)
 -s, --space string           Set Space

EXAMPLE
 $ octopus project view Projects-9000
 $ octopus project view 'Deploy Web App'
 $ octopus project view deploy-web-app
```

View command output using the `slug` as the project identifier
```
❯ ./octopus project view with-cac -s Default
with cac (Projects-321)
Version control branch: main
description (is this branch specific)

View this project in Octopus Deploy: https://b.testoctopus.app/app#/Spaces-1/projects/Projects-321
```

With colour formatting:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/5336529/194002264-e8bcab58-fa39-400f-be51-d3ca872242da.png">


`--web` also successfully opens the project URL in the default web browser
