### PR TITLE
fix: deployment-target list alias

### DIFF
--- a/pkg/cmd/target/azure-web-app/list/list.go
+++ b/pkg/cmd/target/azure-web-app/list/list.go
@@ -18,7 +18,9 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List Azure Web App deployment targets in an instance of Octopus Deploy.",
 		Example: fmt.Sprintf(heredoc.Doc(`
 			$ %s deployment-target azure-web-app list
+			$ %s deployment-target azure-web-app ls
 		`), constants.ExecutableName),
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			dependencies := cmd.NewDependencies(f, c)
 			options := list.NewListOptions(dependencies, c, machines.MachinesQuery{DeploymentTargetTypes: []string{"AzureWebApp"}})

--- a/pkg/cmd/target/cloud-region/list/list.go
+++ b/pkg/cmd/target/cloud-region/list/list.go
@@ -18,7 +18,9 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List Cloud Region deployment targets in an instance of Octopus Deploy.",
 		Example: fmt.Sprintf(heredoc.Doc(`
 			$ %s deployment-target cloud-region list
+			$ %s deployment-target cloud-region ls
 		`), constants.ExecutableName),
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			dependencies := cmd.NewDependencies(f, c)
 			options := list.NewListOptions(dependencies, c, machines.MachinesQuery{DeploymentTargetTypes: []string{"CloudRegion"}})

--- a/pkg/cmd/target/list/list.go
+++ b/pkg/cmd/target/list/list.go
@@ -39,7 +39,9 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List deployment targets in an instance of Octopus Deploy.",
 		Example: fmt.Sprintf(heredoc.Doc(`
 			$ %s deployment-target list
+			$ %s deployment-target ls
 		`), constants.ExecutableName),
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			return ListRun(NewListOptions(cmd.NewDependencies(f, c), c, machines.MachinesQuery{}))
 		},

--- a/pkg/cmd/target/listening-tentacle/list/list.go
+++ b/pkg/cmd/target/listening-tentacle/list/list.go
@@ -18,7 +18,9 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List Listening Tentacle deployment targets in an instance of Octopus Deploy.",
 		Example: fmt.Sprintf(heredoc.Doc(`
 			$ %s deployment-target listening-tentacle list
+			$ %s deployment-target listening-tentacle ls
 		`), constants.ExecutableName),
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			dependencies := cmd.NewDependencies(f, c)
 			options := list.NewListOptions(dependencies, c, machines.MachinesQuery{DeploymentTargetTypes: []string{"TentaclePassive"}})

--- a/pkg/cmd/target/polling-tentacle/list/list.go
+++ b/pkg/cmd/target/polling-tentacle/list/list.go
@@ -18,7 +18,9 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List Polling Tentacle deployment targets in an instance of Octopus Deploy.",
 		Example: fmt.Sprintf(heredoc.Doc(`
 			$ %s deployment-target polling-tentacle list
+			$ %s deployment-target polling-tentacle ls
 		`), constants.ExecutableName),
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			dependencies := cmd.NewDependencies(f, c)
 			options := list.NewListOptions(dependencies, c, machines.MachinesQuery{DeploymentTargetTypes: []string{"TentacleActive"}})

--- a/pkg/cmd/target/ssh/list/list.go
+++ b/pkg/cmd/target/ssh/list/list.go
@@ -18,7 +18,9 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List SSH deployment targets in an instance of Octopus Deploy.",
 		Example: fmt.Sprintf(heredoc.Doc(`
 			$ %s deployment-target ssh list
+			$ %s deployment-target ssh ls
 		`), constants.ExecutableName),
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			dependencies := cmd.NewDependencies(f, c)
 			options := list.NewListOptions(dependencies, c, machines.MachinesQuery{DeploymentTargetTypes: []string{"Ssh"}})


### PR DESCRIPTION
Missed adding 'ls' alias to all deployment target list commands

![image](https://user-images.githubusercontent.com/5336529/202112050-6358c6cf-7913-4369-831b-e90f1db89559.png)
