### PR TITLE
feat: user list and user delete

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -14,6 +14,7 @@ import (
 	deploymentTargetCmd "github.com/OctopusDeploy/cli/pkg/cmd/target"
 	taskCmd "github.com/OctopusDeploy/cli/pkg/cmd/task"
 	tenantCmd "github.com/OctopusDeploy/cli/pkg/cmd/tenant"
+	userCmd "github.com/OctopusDeploy/cli/pkg/cmd/user"
 	"github.com/OctopusDeploy/cli/pkg/cmd/version"
 	workerCmd "github.com/OctopusDeploy/cli/pkg/cmd/worker"
 	workerPoolCmd "github.com/OctopusDeploy/cli/pkg/cmd/workerpool"
@@ -55,6 +56,7 @@ func NewCmdRoot(f factory.Factory, clientFactory apiclient.ClientFactory, askPro
 	// configuration
 	cmd.AddCommand(configCmd.NewCmdConfig(f))
 	cmd.AddCommand(spaceCmd.NewCmdSpace(f))
+	cmd.AddCommand(userCmd.NewCmdUser(f))
 	cmd.AddCommand(releaseCmd.NewCmdRelease(f))
 	cmd.AddCommand(runbookCmd.NewCmdRunbook(f))
 

--- a/pkg/cmd/user/delete/delete.go
+++ b/pkg/cmd/user/delete/delete.go
@@ -1,0 +1,126 @@
+package delete
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/users"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+type DeleteOptions struct {
+	Client       *client.Client
+	Ask          question.Asker
+	NoPrompt     bool
+	UsernameOrId string
+	*question.ConfirmFlags
+}
+
+func NewCmdDelete(f factory.Factory) *cobra.Command {
+	confirmFlags := question.NewConfirmFlags()
+	cmd := &cobra.Command{
+		Use:     "delete {<name> | <id>}",
+		Short:   "Delete a user",
+		Long:    "Delete a user in Octopus Deploy",
+		Aliases: []string{"del", "rm", "remove"},
+		Example: heredoc.Docf(`
+			$ %[1]s user delete someusername
+			$ %[1]s user rm Users-123
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			octopus, err := f.GetSpacedClient(apiclient.NewRequester(c))
+			if err != nil {
+				return err
+			}
+
+			if len(args) == 0 {
+				args = append(args, "")
+			}
+
+			opts := &DeleteOptions{
+				Client:       octopus,
+				Ask:          f.Ask,
+				NoPrompt:     !f.IsPromptEnabled(),
+				UsernameOrId: args[0],
+				ConfirmFlags: confirmFlags,
+			}
+
+			return deleteRun(opts)
+		},
+	}
+
+	question.RegisterConfirmDeletionFlag(cmd, &confirmFlags.Confirm.Value, "user")
+
+	return cmd
+}
+
+func deleteRun(opts *DeleteOptions) error {
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	if opts.UsernameOrId == "" {
+		return fmt.Errorf("user identifier is required but was not provided")
+	}
+
+	// first we find by username
+	// filter is not an exact match so it might find more than one row, but unlikely to find more than 2
+	candidates, err := opts.Client.Users.Get(users.UsersQuery{Filter: opts.UsernameOrId, Take: 9999})
+	if err != nil {
+		return err
+	}
+
+	var itemToDelete *users.User = nil
+	for _, candidate := range candidates.Items {
+		if strings.EqualFold(opts.UsernameOrId, candidate.Username) {
+			itemToDelete = candidate
+			break
+		}
+	}
+	if itemToDelete == nil { // couldn't match by username, try Id
+		itemToDelete, err = opts.Client.Users.GetByID(opts.UsernameOrId)
+		if err != nil {
+			return err // can't find a user to delete. Give up
+		}
+	}
+
+	if opts.Confirm.Value {
+		return deleteUser(opts.Client, itemToDelete)
+	} else {
+		return question.DeleteWithConfirmation(opts.Ask, "user", itemToDelete.DisplayName, itemToDelete.ID, func() error {
+			return deleteUser(opts.Client, itemToDelete)
+		})
+	}
+}
+
+func PromptMissing(opts *DeleteOptions) error {
+	if opts.UsernameOrId == "" {
+		existingUsers, err := opts.Client.Users.GetAll()
+		if err != nil {
+			return err
+		}
+		itemToDelete, err := selectors.Select(opts.Ask, "Select the user you wish to delete:", func() ([]*users.User, error) {
+			return existingUsers, nil
+		}, func(item *users.User) string {
+			return item.DisplayName
+		})
+		if err != nil {
+			return err
+		}
+		opts.UsernameOrId = itemToDelete.GetID()
+	}
+
+	return nil
+}
+
+func deleteUser(client *client.Client, user *users.User) error {
+	return client.Users.DeleteByID(user.GetID())
+}

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -1,0 +1,69 @@
+package list
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/users"
+	"github.com/spf13/cobra"
+)
+
+type UserAsJson struct {
+	Id          string `json:"Id"`
+	Name        string `json:"Name"`
+	UserName    string `json:"UserName"`
+	Description string `json:"Description"`
+}
+
+func NewCmdList(f factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List users",
+		Long:  "List users in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s user list
+			$ %[1]s user ls
+		`, constants.ExecutableName),
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listRun(cmd, f)
+		},
+	}
+
+	return cmd
+}
+
+func listRun(cmd *cobra.Command, f factory.Factory) error {
+	client, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
+	if err != nil {
+		return err
+	}
+
+	allUsers, err := client.Users.GetAll()
+	if err != nil {
+		return err
+	}
+
+	return output.PrintArray(allUsers, cmd, output.Mappers[*users.User]{
+		Json: func(t *users.User) any {
+			return UserAsJson{
+				Id:       t.GetID(),
+				Name:     t.DisplayName,
+				UserName: t.Username,
+				// TODO other fields like isService, etc
+			}
+		},
+		Table: output.TableDefinition[*users.User]{
+			// TODO other fields like isService, etc
+			Header: []string{"USERNAME", "NAME", "ID"},
+			Row: func(t *users.User) []string {
+				return []string{output.Bold(t.Username), t.DisplayName, t.GetID()}
+			},
+		},
+		Basic: func(t *users.User) string {
+			return t.Username
+		},
+	})
+}

--- a/pkg/cmd/user/user.go
+++ b/pkg/cmd/user/user.go
@@ -1,0 +1,29 @@
+package user
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/user/list"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdUser(f factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "user <command>",
+		Short: "Manage users",
+		Long:  "Manage user in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s user list
+			$ %[1]s user ls
+		`, constants.ExecutableName),
+		Annotations: map[string]string{
+			annotations.IsCore: "true",
+		},
+	}
+
+	cmd.AddCommand(cmdList.NewCmdList(f))
+
+	return cmd
+}

--- a/pkg/cmd/user/user.go
+++ b/pkg/cmd/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	cmdDelete "github.com/OctopusDeploy/cli/pkg/cmd/user/delete"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/user/list"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
@@ -24,6 +25,7 @@ func NewCmdUser(f factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f))
 
 	return cmd
 }


### PR DESCRIPTION
Adds simple implementations of `user list` and `user delete`, suitable for enabling deletion of users via a script. More advanced/interactive use-cases may be implemented at some unspecified future time.