### PR TITLE
fix version shortcut on release create

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -164,7 +164,7 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&createFlags.PackageVersion.Value, createFlags.PackageVersion.Name, "", "", "Default version to use for all Packages")
 	flags.StringVarP(&createFlags.ReleaseNotes.Value, createFlags.ReleaseNotes.Name, "n", "", "Release notes to attach")
 	flags.StringVarP(&createFlags.ReleaseNotesFile.Value, createFlags.ReleaseNotesFile.Name, "", "", "Release notes to attach (from file)")
-	flags.StringVarP(&createFlags.Version.Value, createFlags.Version.Name, "", "", "Override the Release Version")
+	flags.StringVarP(&createFlags.Version.Value, createFlags.Version.Name, "v", "", "Override the Release Version")
 	flags.BoolVarP(&createFlags.IgnoreExisting.Value, createFlags.IgnoreExisting.Name, "x", false, "If a release with the same version exists, do nothing instead of failing.")
 	flags.BoolVarP(&createFlags.IgnoreChannelRules.Value, createFlags.IgnoreChannelRules.Name, "", false, "Allow creation of a release where channel rules would otherwise prevent it.")
 	flags.StringSliceVarP(&createFlags.PackageVersionSpec.Value, createFlags.PackageVersionSpec.Name, "", []string{}, "Version specification a specific packages.\nFormat as {package}:{version}, {step}:{version} or {package-ref-name}:{packageOrStep}:{version}\nYou may specify this multiple times")


### PR DESCRIPTION
Our example text contained the shortcut for `--version` but we didn't implement it

before:
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/5336529/207212105-a32d9d2b-a876-4996-8ba5-fba95f8a1657.png">


after:
<img width="1420" alt="image" src="https://user-images.githubusercontent.com/5336529/207212185-799a4231-0035-4f6d-9b3b-87b60c6afb61.png">
