### PR TITLE
fix: no prompt if only a single channel

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -861,7 +861,7 @@ func AskQuestions(octopus *octopusApiClient.Client, stdout io.Writer, asker ques
 
 	var selectedChannel *channels.Channel
 	if options.ChannelName == "" {
-		selectedChannel, err = selectors.Channel(octopus, asker, "Select the channel in which the release will be created", selectedProject)
+		selectedChannel, err = selectors.Channel(octopus, asker, stdout, "Select the channel in which the release will be created", selectedProject)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -388,7 +388,7 @@ func AskQuestions(octopus *octopusApiClient.Client, stdout io.Writer, asker ques
 	var selectedRelease *releases.Release
 	if options.ReleaseVersion == "" {
 		// first we want to ask them to pick a channel just to narrow down the search space for releases (not sent to server)
-		selectedChannel, err := selectors.Channel(octopus, asker, "Select channel", selectedProject)
+		selectedChannel, err := selectors.Channel(octopus, asker, stdout, "Select channel", selectedProject)
 		if err != nil {
 			return err
 		}

--- a/pkg/question/selectors/channels.go
+++ b/pkg/question/selectors/channels.go
@@ -2,16 +2,19 @@ package selectors
 
 import (
 	"fmt"
+	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
 	octopusApiClient "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"io"
 	"strings"
 )
 
-func Channel(octopus *octopusApiClient.Client, ask question.Asker, questionText string, project *projects.Project) (*channels.Channel, error) {
+func Channel(octopus *octopusApiClient.Client, ask question.Asker, io io.Writer, questionText string, project *projects.Project) (*channels.Channel, error) {
 	existingChannels, err := octopus.Projects.GetChannels(project)
 	if len(existingChannels) == 1 {
+		fmt.Fprintf(io, "Selecting only available channel '%s'.\n", output.Cyan(existingChannels[0].Name))
 		return existingChannels[0], nil
 	}
 	if err != nil {

--- a/pkg/question/selectors/channels.go
+++ b/pkg/question/selectors/channels.go
@@ -11,6 +11,9 @@ import (
 
 func Channel(octopus *octopusApiClient.Client, ask question.Asker, questionText string, project *projects.Project) (*channels.Channel, error) {
 	existingChannels, err := octopus.Projects.GetChannels(project)
+	if len(existingChannels) == 1 {
+		return existingChannels[0], nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
there is a redundant prompt if there is only a single channel

before:
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/5336529/207222087-82024b74-d5b5-464b-b372-c030a65add3a.png">


after:
<img width="1708" alt="image" src="https://user-images.githubusercontent.com/5336529/207222151-a9ebbce9-d5fc-4956-9847-646f798abee5.png">

