### PR TITLE
fix: expand tenant view output

### DIFF
--- a/pkg/cmd/target/azure-web-app/create/create.go
+++ b/pkg/cmd/target/azure-web-app/create/create.go
@@ -150,7 +150,7 @@ func createRun(opts *CreateOptions) error {
 	endpoint.WebAppName = opts.WebApp.Value
 	endpoint.ResourceGroupName = opts.ResourceGroup.Value
 	endpoint.WebAppSlotName = opts.Slot.Value
-	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, shared.DistinctRoles(opts.Roles.Value))
+	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, util.DistinctStrings(opts.Roles.Value))
 
 	err = shared.ConfigureTenant(deploymentTarget, opts.CreateTargetTenantFlags, opts.CreateTargetTenantOptions)
 	if err != nil {

--- a/pkg/cmd/target/cloud-region/create/create.go
+++ b/pkg/cmd/target/cloud-region/create/create.go
@@ -111,7 +111,7 @@ func createRun(opts *CreateOptions) error {
 		endpoint.DefaultWorkerPoolID = workerPoolId
 	}
 
-	target := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, shared.DistinctRoles(opts.Roles.Value))
+	target := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, util.DistinctStrings(opts.Roles.Value))
 	err = shared.ConfigureTenant(target, opts.CreateTargetTenantFlags, opts.CreateTargetTenantOptions)
 	if err != nil {
 		return err

--- a/pkg/cmd/target/listening-tentacle/create/create.go
+++ b/pkg/cmd/target/listening-tentacle/create/create.go
@@ -131,7 +131,7 @@ func createRun(opts *CreateOptions) error {
 		endpoint.ProxyID = proxy.GetID()
 	}
 
-	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, shared.DistinctRoles(opts.Roles.Value))
+	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, util.DistinctStrings(opts.Roles.Value))
 	machinePolicy, err := machinescommon.FindMachinePolicy(opts.GetAllMachinePoliciesCallback, opts.MachinePolicy.Value)
 	if err != nil {
 		return err

--- a/pkg/cmd/target/shared/role.go
+++ b/pkg/cmd/target/shared/role.go
@@ -73,16 +73,3 @@ func getAllMachineRoles(client client.Client) ([]string, error) {
 	}
 	return roles, nil
 }
-
-func DistinctRoles(roles []string) []string {
-	rolesMap := make(map[string]bool)
-	result := []string{}
-	for _, r := range roles {
-		if _, ok := rolesMap[r]; !ok {
-			rolesMap[r] = true
-			result = append(result, r)
-		}
-	}
-
-	return result
-}

--- a/pkg/cmd/target/shared/role_test.go
+++ b/pkg/cmd/target/shared/role_test.go
@@ -8,16 +8,6 @@ import (
 	"testing"
 )
 
-func TestDistinctRoles_EmptyList(t *testing.T) {
-	result := shared.DistinctRoles([]string{})
-	assert.Empty(t, result)
-}
-
-func TestDistinctRoles_DuplicateValues(t *testing.T) {
-	result := shared.DistinctRoles([]string{"a", "b", "a"})
-	assert.Equal(t, []string{"a", "b"}, result)
-}
-
 func TestPromptRoles_FlagsSupplied(t *testing.T) {
 	pa := []*testutil.PA{}
 

--- a/pkg/cmd/target/ssh/create/create.go
+++ b/pkg/cmd/target/ssh/create/create.go
@@ -141,7 +141,7 @@ func createRun(opts *CreateOptions) error {
 		endpoint.ProxyID = proxy.GetID()
 	}
 
-	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, shared.DistinctRoles(opts.Roles.Value))
+	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, util.DistinctStrings(opts.Roles.Value))
 	machinePolicy, err := machinescommon.FindMachinePolicy(opts.GetAllMachinePoliciesCallback, opts.MachinePolicy.Value)
 	if err != nil {
 		return err

--- a/pkg/cmd/tenant/list/list.go
+++ b/pkg/cmd/tenant/list/list.go
@@ -77,6 +77,7 @@ func listRun(cmd *cobra.Command, f factory.Factory) error {
 				projectEnvironments = append(projectEnvironments, ProjectEnvironment{Project: projectEntity, Environments: environments})
 			}
 
+			t.Links = nil // ensure the links collection is not serialised
 			return TenantAsJson{
 				Tenant:              t,
 				ProjectEnvironments: projectEnvironments,

--- a/pkg/cmd/tenant/list/list.go
+++ b/pkg/cmd/tenant/list/list.go
@@ -6,14 +6,22 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/spf13/cobra"
 )
 
+type ProjectEnvironment struct {
+	Project      output.IdAndName   `json:"Project"`
+	Environments []output.IdAndName `json:"Environments"`
+}
+
 type TenantAsJson struct {
-	Id          string `json:"Id"`
-	Name        string `json:"Name"`
-	Description string `json:"Description"`
+	Id                  string               `json:"Id"`
+	Name                string               `json:"Name"`
+	Description         string               `json:"Description"`
+	Tags                []string             `json:"Tags"`
+	ProjectEnvironments []ProjectEnvironment `json:"ProjectEnvironments"`
 }
 
 func NewCmdList(f factory.Factory) *cobra.Command {
@@ -45,22 +53,78 @@ func listRun(cmd *cobra.Command, f factory.Factory) error {
 		return err
 	}
 
+	environmentMap, err := getEnvironmentMap(client)
+	if err != nil {
+		return err
+	}
+
+	projectMap, err := getProjectMap(client)
+	if err != nil {
+		return err
+	}
+
 	return output.PrintArray(allTenants, cmd, output.Mappers[*tenants.Tenant]{
 		Json: func(t *tenants.Tenant) any {
+			projectEnvironments := []ProjectEnvironment{}
+
+			for p := range t.ProjectEnvironments {
+				projectEntity := output.IdAndName{Id: p, Name: projectMap[p]}
+				environments, err := resolveEntities(t.ProjectEnvironments[p], environmentMap)
+				if err != nil {
+					return err
+				}
+				projectEnvironments = append(projectEnvironments, ProjectEnvironment{Project: projectEntity, Environments: environments})
+			}
+
 			return TenantAsJson{
-				Id:          t.GetID(),
-				Name:        t.Name,
-				Description: t.Description,
+				Id:                  t.GetID(),
+				Name:                t.Name,
+				Description:         t.Description,
+				Tags:                t.TenantTags,
+				ProjectEnvironments: projectEnvironments,
 			}
 		},
 		Table: output.TableDefinition[*tenants.Tenant]{
-			Header: []string{"NAME", "DESCRIPTION", "ID"},
+			Header: []string{"NAME", "DESCRIPTION", "ID", "TAGS"},
 			Row: func(t *tenants.Tenant) []string {
-				return []string{output.Bold(t.Name), t.Description, t.GetID()}
+				return []string{output.Bold(t.Name), t.Description, output.Dim(t.GetID()), output.FormatAsList(t.TenantTags)}
 			},
 		},
 		Basic: func(t *tenants.Tenant) string {
 			return t.Name
 		},
 	})
+}
+
+func resolveEntities(keys []string, lookup map[string]string) ([]output.IdAndName, error) {
+	var entities []output.IdAndName
+	for _, k := range keys {
+		entities = append(entities, output.IdAndName{Id: k, Name: lookup[k]})
+	}
+
+	return entities, nil
+}
+
+func getEnvironmentMap(client *client.Client) (map[string]string, error) {
+	environmentMap := make(map[string]string)
+	allEnvs, err := client.Environments.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range allEnvs {
+		environmentMap[e.GetID()] = e.GetName()
+	}
+	return environmentMap, nil
+}
+
+func getProjectMap(client *client.Client) (map[string]string, error) {
+	projectMap := make(map[string]string)
+	allEnvs, err := client.Projects.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range allEnvs {
+		projectMap[e.GetID()] = e.GetName()
+	}
+	return projectMap, nil
 }

--- a/pkg/cmd/tenant/list/list.go
+++ b/pkg/cmd/tenant/list/list.go
@@ -20,11 +20,8 @@ type ProjectEnvironment struct {
 }
 
 type TenantAsJson struct {
-	Id                  string               `json:"Id"`
-	Name                string               `json:"Name"`
-	Description         string               `json:"Description"`
-	Tags                []string             `json:"Tags"`
-	ProjectEnvironments []ProjectEnvironment `json:"ProjectEnvironments"`
+	*tenants.Tenant
+	ProjectEnvironments []ProjectEnvironment
 }
 
 func NewCmdList(f factory.Factory) *cobra.Command {
@@ -81,10 +78,7 @@ func listRun(cmd *cobra.Command, f factory.Factory) error {
 			}
 
 			return TenantAsJson{
-				Id:                  t.GetID(),
-				Name:                t.Name,
-				Description:         t.Description,
-				Tags:                t.TenantTags,
+				Tenant:              t,
 				ProjectEnvironments: projectEnvironments,
 			}
 		},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -164,3 +164,16 @@ func Empty[T any](items []T) bool {
 func Any[T any](items []T) bool {
 	return !Empty(items)
 }
+
+func DistinctStrings(items []string) []string {
+	itemsMap := make(map[string]bool)
+	result := []string{}
+	for _, r := range items {
+		if _, ok := itemsMap[r]; !ok {
+			itemsMap[r] = true
+			result = append(result, r)
+		}
+	}
+
+	return result
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -389,3 +389,13 @@ func TestEmpty_ZeroItems(t *testing.T) {
 func TestEmpty_SomeItems(t *testing.T) {
 	assert.False(t, util.Empty([]string{"value"}))
 }
+
+func TestDistinctStrings_EmptyList(t *testing.T) {
+	result := util.DistinctStrings([]string{})
+	assert.Empty(t, result)
+}
+
+func TestDistinctStrings_DuplicateValues(t *testing.T) {
+	result := util.DistinctStrings([]string{"a", "b", "a"})
+	assert.Equal(t, []string{"a", "b"}, result)
+}


### PR DESCRIPTION
This change is to support filtering tenants by tag using `jq`

json before:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/5336529/207503733-39365427-5ed6-41d2-9492-6ead75ca0ad2.png">

json after:
![image](https://user-images.githubusercontent.com/5336529/207531744-50803f72-6248-4149-849d-f60bea5487f0.png)

* note: the change to pull all fields from the api means that we end up with the default json serialisation on the client model. In the case of the Tenants, the `TenantTags` field is marked as `omitempty` so an empty array ends up being left out. Previously we were ending up with the default values of an empty array in the json, making the contract more stable.

![image](https://user-images.githubusercontent.com/5336529/207531955-398ba6de-98f1-4d5b-bba5-9499e6dd256d.png)




table before:
![image](https://user-images.githubusercontent.com/5336529/207503868-8b448539-df01-435b-a20e-28779b87752d.png)


table after:
![image](https://user-images.githubusercontent.com/5336529/207503902-5069d501-8fad-4217-a8d2-ea9b5e183f23.png)
