### PR TITLE
fix: extended release output

### DIFF
--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1381,7 +1381,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 			_, err := testutil.ReceivePair(cmdReceiver)
 			assert.Nil(t, err)
 
-			assert.Equal(t, "{\"Channel\":\"Alpha channel\",\"Version\":\"1.2.3\"}\n", stdOut.String())
+			assert.Equal(t, "{\"ReleaseNotes\":\"\",\"Assembled\":\"0001-01-01T00:00:00Z\",\"Channel\":\"Alpha channel\",\"Version\":\"1.2.3\"}\n", stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},
 

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 var rootResource = testutil.NewRootResource()
@@ -87,11 +88,11 @@ func TestReleaseList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				VERSION    CHANNEL
-				2.1        Default Channel
-				2.0        Default Channel
-				2.0-beta2  Beta Channel
-				2.0-beta1  Beta Channel
+				VERSION    CHANNEL          CREATED
+				2.1        Default Channel  Mon, 01 Jan 0001 00:00:00 +0000
+				2.0        Default Channel  Mon, 01 Jan 0001 00:00:00 +0000
+				2.0-beta2  Beta Channel     Mon, 01 Jan 0001 00:00:00 +0000
+				2.0-beta1  Beta Channel     Mon, 01 Jan 0001 00:00:00 +0000
 				`), stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},
@@ -131,11 +132,11 @@ func TestReleaseList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				VERSION    CHANNEL
-				2.1        Default Channel
-				2.0        Default Channel
-				2.0-beta2  Beta Channel
-				2.0-beta1  Beta Channel
+				VERSION    CHANNEL          CREATED
+				2.1        Default Channel  Mon, 01 Jan 0001 00:00:00 +0000
+				2.0        Default Channel  Mon, 01 Jan 0001 00:00:00 +0000
+				2.0-beta2  Beta Channel     Mon, 01 Jan 0001 00:00:00 +0000
+				2.0-beta1  Beta Channel     Mon, 01 Jan 0001 00:00:00 +0000
 				`), stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},
@@ -167,8 +168,8 @@ func TestReleaseList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				VERSION  CHANNEL
-				2.1      Default Channel
+				VERSION  CHANNEL          CREATED
+				2.1      Default Channel  Mon, 01 Jan 0001 00:00:00 +0000
 				`), stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},
@@ -200,8 +201,8 @@ func TestReleaseList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				VERSION  CHANNEL
-				2.1      Default Channel
+				VERSION  CHANNEL          CREATED
+				2.1      Default Channel  Mon, 01 Jan 0001 00:00:00 +0000
 				`), stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},
@@ -232,15 +233,20 @@ func TestReleaseList(t *testing.T) {
 			assert.Nil(t, err)
 
 			type x struct {
-				Channel string
-				Version string
+				Assembled    time.Time
+				Channel      string
+				Version      string
+				ReleaseNotes string
 			}
 			parsedStdout, err := testutil.ParseJsonStrict[[]x](stdOut)
 			assert.Nil(t, err)
 
+			expectedTime, _ := time.Parse(time.RFC1123Z, "Mon, 01 Jan 0001 00:00:00")
 			assert.Equal(t, []x{{
-				Channel: defaultChannel.Name,
-				Version: "2.1",
+				Channel:      defaultChannel.Name,
+				Version:      "2.1",
+				ReleaseNotes: "",
+				Assembled:    expectedTime,
 			}}, parsedStdout)
 			assert.Equal(t, "", stdErr.String())
 		}},


### PR DESCRIPTION
this is to support filtering releases by assembled date. Thought I would include release notes as a xmas gift

json before:
![image](https://user-images.githubusercontent.com/5336529/207780654-1daf5908-a7a5-4afa-ab38-64169ec8b2d6.png)


json after:
![image](https://user-images.githubusercontent.com/5336529/207778810-7edaf867-a5b8-4631-ac4d-a0531d4d2e5b.png)


table before:
![image](https://user-images.githubusercontent.com/5336529/207780682-82fa843c-9f12-429a-ba11-a0270307c4a1.png)

table after:
![image](https://user-images.githubusercontent.com/5336529/207778863-538ffe41-bf12-4edd-aab0-42c3a00c07d3.png)
