### PR TITLE
chore: cleanup project create

### DIFF
--- a/pkg/cmd/project/convert/convert.go
+++ b/pkg/cmd/project/convert/convert.go
@@ -220,6 +220,18 @@ func PromptForConfigAsCode(opts *ConvertOptions) (cmd.Dependable, error) {
 		opts.GitStorage.Value = selectedOption.Value
 	}
 
+	if opts.GitStorage.Value == GitStorageLibrary {
+		err := promptLibraryGitCredentials(opts, opts.GetAllGitCredentialsCallback)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := promptProjectGitCredentials(opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if opts.GitUrl.Value == "" {
 		if err := opts.Ask(&survey.Input{
 			Message: "Git URL",
@@ -301,18 +313,6 @@ func PromptForConfigAsCode(opts *ConvertOptions) (cmd.Dependable, error) {
 		}, &opts.GitInitialCommitMessage.Value, survey.WithValidator(survey.ComposeValidators(
 			survey.MaxLength(50),
 		))); err != nil {
-			return nil, err
-		}
-	}
-
-	if opts.GitStorage.Value == GitStorageLibrary {
-		err := promptLibraryGitCredentials(opts, opts.GetAllGitCredentialsCallback)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err := promptProjectGitCredentials(opts)
-		if err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cmd/project/convert/convert_test.go
+++ b/pkg/cmd/project/convert/convert_test.go
@@ -12,6 +12,8 @@ import (
 func TestPromptForConfigAsCode_UsingCacWithProjectStorage(t *testing.T) {
 	pa := []*testutil.PA{
 		testutil.NewSelectPrompt("Select where to store the Git credentials", "", []string{"Library", "Project"}, "Project"),
+		testutil.NewInputPrompt("Git username", "The Git username.", "user1"),
+		testutil.NewPasswordPrompt("Git password", "The Git password.", "password"),
 		testutil.NewInputPrompt("Git URL", "The URL of the Git repository to store configuration.", "https://github.com/blah.git"),
 		testutil.NewInputPromptWithDefault("Git repository base path", "The path in the repository where Config As Code settings are stored. Default value is '.octopus/'.", ".octopus/", "./octopus/project"),
 		testutil.NewInputPromptWithDefault("Git branch", "The default branch to use. Default value is 'main'.", "main", "main"),
@@ -19,8 +21,6 @@ func TestPromptForConfigAsCode_UsingCacWithProjectStorage(t *testing.T) {
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "test"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
-		testutil.NewInputPrompt("Git username", "The Git username.", "user1"),
-		testutil.NewPasswordPrompt("Git password", "The Git password.", "password"),
 	}
 
 	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
@@ -45,13 +45,13 @@ func TestPromptForConfigAsCode_UsingCacWithProjectStorage(t *testing.T) {
 func TestPromptForConfigAsCode_UsingCacWithLibraryStorage(t *testing.T) {
 	pa := []*testutil.PA{
 		testutil.NewSelectPrompt("Select where to store the Git credentials", "", []string{"Library", "Project"}, "Library"),
+		testutil.NewSelectPrompt("Select which Git credentials to use", "", []string{"Git Creds 1", "Git Creds 2"}, "Git Creds 2"),
 		testutil.NewInputPrompt("Git URL", "The URL of the Git repository to store configuration.", "https://github.com/blah.git"),
 		testutil.NewInputPromptWithDefault("Git repository base path", "The path in the repository where Config As Code settings are stored. Default value is '.octopus/'.", ".octopus/", "./octopus/project"),
 		testutil.NewInputPromptWithDefault("Git branch", "The default branch to use. Default value is 'main'.", "main", "main"),
 		testutil.NewConfirmPromptWithDefault("Is the 'main' branch protected?", "If the default branch is protected, you may not have permission to push to it.", false, false),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
-		testutil.NewSelectPrompt("Select which Git credentials to use", "", []string{"Git Creds 1", "Git Creds 2"}, "Git Creds 2"),
 	}
 
 	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
@@ -87,6 +87,7 @@ func TestPromptForConfigAsCode_UsingCacWithLibraryStorage(t *testing.T) {
 func TestPromptForConfigAsCode_UsingCacWithBranchProtection(t *testing.T) {
 	pa := []*testutil.PA{
 		testutil.NewSelectPrompt("Select where to store the Git credentials", "", []string{"Library", "Project"}, "Library"),
+		testutil.NewSelectPrompt("Select which Git credentials to use", "", []string{"Git Creds 1", "Git Creds 2"}, "Git Creds 2"),
 		testutil.NewInputPrompt("Git URL", "The URL of the Git repository to store configuration.", "https://github.com/blah.git"),
 		testutil.NewInputPromptWithDefault("Git repository base path", "The path in the repository where Config As Code settings are stored. Default value is '.octopus/'.", ".octopus/", "./octopus/project"),
 		testutil.NewInputPromptWithDefault("Git branch", "The default branch to use. Default value is 'main'.", "main", "main"),
@@ -95,7 +96,6 @@ func TestPromptForConfigAsCode_UsingCacWithBranchProtection(t *testing.T) {
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "test"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
-		testutil.NewSelectPrompt("Select which Git credentials to use", "", []string{"Git Creds 1", "Git Creds 2"}, "Git Creds 2"),
 	}
 
 	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)

--- a/pkg/cmd/project/create/create_opts.go
+++ b/pkg/cmd/project/create/create_opts.go
@@ -96,7 +96,7 @@ func (co *CreateOptions) Commit() error {
 
 func (co *CreateOptions) GenerateAutomationCmd() {
 	if !co.NoPrompt {
-		autoCmd := flag.GenerateAutomationCmd(co.CmdPath, co.Name, co.Description, co.Group, co.Lifecycle, co.ConfigAsCode)
+		autoCmd := flag.GenerateAutomationCmd(co.CmdPath, co.Name, co.Description, co.Group, co.Lifecycle)
 		fmt.Fprintf(co.Out, "%s\n", autoCmd)
 	}
 }


### PR DESCRIPTION
the config-as-code flag on `project create` was not required during automation, missed in https://github.com/OctopusDeploy/cli/pull/166

before:
![image](https://user-images.githubusercontent.com/5336529/208035355-c8bab598-b630-4d2b-8b7f-a0e5005c8379.png)


after:
![image](https://user-images.githubusercontent.com/5336529/208035311-6bd1efb7-329d-4c96-bcfb-b1517b19493d.png)


The git credentials storage question was asked first, then we didn't prompt for the credentials until the end, credentials are now asked second.

result:
![image](https://user-images.githubusercontent.com/5336529/208035378-37888b36-b000-4953-9e3e-f2fecd37de12.png)
