### PR TITLE
Fixed the OCTOPUS_URL environment variable name

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OCTOPUS_API_KEY: ${{ secrets.OCTOPUS_API_KEY }}
-      OCTOPUS_HOST: ${{ secrets.OCTOPUS_URL }}  
+      OCTOPUS_URL: ${{ secrets.OCTOPUS_URL }}  
       OCTOPUS_SPACE: Integrations
 
     steps:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ This is currently managed using environment variables which you must set before 
 **macOS/Linux:**
 
 ```shell
-export OCTOPUS_HOST="http://localhost:8050" # replace with your octopus URL
+export OCTOPUS_URL="http://localhost:8050" # replace with your octopus URL
 export OCTOPUS_API_KEY="API-XXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # replace with your API key
 ./octopus space list # should list all the spaces
 ```
@@ -178,7 +178,7 @@ export OCTOPUS_API_KEY="API-XXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # replace with your A
 **Windows (powershell):**
 
 ```shell
-$env:OCTOPUS_HOST="http://localhost:8050" # replace with your octopus URL
+$env:OCTOPUS_URL="http://localhost:8050" # replace with your octopus URL
 $env:OCTOPUS_API_KEY="API-XXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # replace with your API key
 ./octopus.exe space list # should list all the spaces
 ```
@@ -186,7 +186,7 @@ $env:OCTOPUS_API_KEY="API-XXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # replace with your API
 **Windows (cmd):**
 
 ```shell
-set OCTOPUS_HOST="http://localhost:8050" # replace with your octopus URL
+set OCTOPUS_URL="http://localhost:8050" # replace with your octopus URL
 set OCTOPUS_API_KEY="API-XXXXXXXXXXXXXXXXXXXXXXXXXXXXX" # replace with your API key
 octopus.exe space list # should list all the spaces
 ```

--- a/pkg/apiclient/client_factory.go
+++ b/pkg/apiclient/client_factory.go
@@ -55,7 +55,7 @@ type Client struct {
 	// Octopus API Client scoped to the current space. nullable, lazily created by Get()
 	SpaceScopedClient *octopusApiClient.Client
 
-	// the Server URL, obtained from OCTOPUS_HOST
+	// the Server URL, obtained from OCTOPUS_URL
 	ApiUrl *url.URL
 	// the Octopus API Key, obtained from OCTOPUS_API_KEY
 	ApiKey string
@@ -104,7 +104,7 @@ func NewClientFactory(httpClient *http.Client, host string, apiKey string, space
 // NewClientFactoryFromConfig Creates a new Client wrapper structure by reading the viper config.
 // specifies nil for the HTTP Client, so this is not for unit tests; use NewClientFactory(... instead)
 func NewClientFactoryFromConfig(ask question.AskProvider) (ClientFactory, error) {
-	host := viper.GetString(constants.ConfigHost)
+	host := viper.GetString(constants.ConfigUrl)
 	apiKey := viper.GetString(constants.ConfigApiKey)
 	spaceNameOrID := viper.GetString(constants.ConfigSpace)
 
@@ -132,7 +132,7 @@ func ValidateMandatoryEnvironment(host string, apiKey string) error {
           Alternatively you can run:
             octopus config set %s
             octopus config set %s
-    `, constants.EnvOctopusHost, constants.EnvOctopusApiKey, constants.ConfigHost, constants.ConfigApiKey)
+    `, constants.EnvOctopusUrl, constants.EnvOctopusApiKey, constants.ConfigUrl, constants.ConfigApiKey)
 		return fmt.Errorf(err)
 	}
 

--- a/pkg/cmd/config/get/get.go
+++ b/pkg/cmd/config/get/get.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/OctopusDeploy/cli/pkg/config"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -60,7 +59,7 @@ func promptMissing(ask question.Asker) (string, error) {
 		constants.ConfigApiKey,
 		constants.ConfigSpace,
 		constants.ConfigNoPrompt,
-		constants.ConfigHost,
+		constants.ConfigUrl,
 		constants.ConfigOutputFormat,
 		constants.ConfigShowOctopus,
 		constants.ConfigEditor,

--- a/pkg/cmd/config/get/get.go
+++ b/pkg/cmd/config/get/get.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/OctopusDeploy/cli/pkg/config"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -62,7 +62,7 @@ func listRun(cmd *cobra.Command) error {
 				configData.ApiKey = configFile.GetString(key)
 			case strings.ToLower(constants.ConfigEditor):
 				configData.Editor = configFile.GetString(key)
-			case strings.ToLower(constants.ConfigHost):
+			case strings.ToLower(constants.ConfigUrl):
 				configData.Host = configFile.GetString(key)
 			case strings.ToLower(constants.ConfigNoPrompt):
 				configData.NoPrompt = configFile.GetString(key)

--- a/pkg/cmd/config/set/set.go
+++ b/pkg/cmd/config/set/set.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/OctopusDeploy/cli/pkg/config"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"

--- a/pkg/cmd/config/set/set.go
+++ b/pkg/cmd/config/set/set.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/OctopusDeploy/cli/pkg/config"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -86,7 +85,7 @@ func promptMissing(ask question.Asker, key string) (string, string, error) {
 		constants.ConfigApiKey,
 		constants.ConfigSpace,
 		constants.ConfigNoPrompt,
-		constants.ConfigHost,
+		constants.ConfigUrl,
 		constants.ConfigOutputFormat,
 		constants.ConfigShowOctopus,
 		constants.ConfigEditor,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ func SetupConfigFile(v *viper.Viper, configPath string) {
 }
 
 func setDefaults(v *viper.Viper) {
-	v.SetDefault(constants.ConfigHost, "")
+	v.SetDefault(constants.ConfigUrl, "")
 	v.SetDefault(constants.ConfigApiKey, "")
 	v.SetDefault(constants.ConfigSpace, "")
 	v.SetDefault(constants.ConfigNoPrompt, false)
@@ -41,7 +41,7 @@ func bindEnvironment(v *viper.Viper) error {
 	if err := v.BindEnv(constants.ConfigApiKey, constants.EnvOctopusApiKey); err != nil {
 		return err
 	}
-	if err := v.BindEnv(constants.ConfigHost, constants.EnvOctopusHost); err != nil {
+	if err := v.BindEnv(constants.ConfigUrl, constants.EnvOctopusUrl); err != nil {
 		return err
 	}
 	if err := v.BindEnv(constants.ConfigSpace, constants.EnvOctopusSpace); err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,7 +28,7 @@ const (
 
 // keys for key/value store config file
 const (
-	ConfigHost     = "Host"
+	ConfigUrl      = "Url"
 	ConfigApiKey   = "ApiKey"
 	ConfigSpace    = "Space"
 	ConfigNoPrompt = "NoPrompt"
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	EnvOctopusHost   = "OCTOPUS_HOST"
+	EnvOctopusUrl    = "OCTOPUS_URL"
 	EnvOctopusApiKey = "OCTOPUS_API_KEY"
 	EnvOctopusSpace  = "OCTOPUS_SPACE"
 	EnvEditor        = "EDITOR"
@@ -72,7 +72,6 @@ const OctopusLogo = `            &#BGGGGGGB#&
 const (
 	PromptCreateNew = "<Create New>"
 )
-
 
 // IsProgrammaticOutputFormat tells you if it is acceptable for your command to
 // print miscellaneous output to stdout, such as progress messages.

--- a/test/integration/integrationtestutil.go
+++ b/test/integration/integrationtestutil.go
@@ -153,7 +153,7 @@ func EnsureCli() (cliPath string, cliDir string, err error) {
 func createEnvForCli(space string) []string {
 	return []string{
 		"CI=1", // disable prompting
-		fmt.Sprintf("OCTOPUS_HOST=%s", os.Getenv("OCTOPUS_TEST_URL")),
+		fmt.Sprintf("OCTOPUS_URL=%s", os.Getenv("OCTOPUS_TEST_URL")),
 		fmt.Sprintf("OCTOPUS_API_KEY=%s", os.Getenv("OCTOPUS_TEST_APIKEY")),
 		fmt.Sprintf("OCTOPUS_SPACE=%s", space),
 	}


### PR DESCRIPTION
All of our GitHubAction tooling etc uses `OCTOPUS_URL` for the environment variable name that gives us the base url for the Octopus API.

This PR brings the Go CLI into line with that naming.