### PR TITLE
fix: remove project convert support for default protected branch 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.18.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.20.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -50,6 +50,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
+	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.18.1 h1:Bhae8Z8vzvZus2coXQs0EKN+22tonak9nVMI1ArzvEc=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.18.1/go.mod h1:yCrdCpNf9D60Q6zYeG7wt9XHimM0r9z0AY9auR6AjLc=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.20.0 h1:3IpsaL5PJepA/5WEhUBn7GmXS2uT4GZ0n5N/iQV6JhQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.20.0/go.mod h1:++gnwUI5HaG31oDMaUXrNNjsXfmLn/zWyMmy/5GaFSA=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
 github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -282,6 +282,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15 h1:5oN1Pz/eDhCpbMbLstvIPa0b/BEQo6g6nwV3pLjfM6w=
+golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/cmd/project/convert/convert.go
+++ b/pkg/cmd/project/convert/convert.go
@@ -37,9 +37,10 @@ const (
 	FlagInitialCommitBranch     = "git-initial-commit-branch"
 	FlagBranchProtectionPattern = "git-protected-branch-pattern"
 
-	DefaultGitCommitMessage = "Initial commit of deployment process"
-	DefaultBasePath         = ".octopus/"
-	DefaultBranch           = "main"
+	DefaultGitCommitMessage    = "Initial commit of deployment process"
+	DefaultBasePath            = ".octopus/"
+	DefaultBranch              = "main"
+	DefaultInitialCommitBranch = "octopus-vcs-conversion"
 
 	GitStorageProject = "project"
 	GitStorageLibrary = "library"
@@ -125,14 +126,14 @@ func NewCmdConvert(f factory.Factory) *cobra.Command {
 
 func RegisterCacFlags(flags *pflag.FlagSet, convertFlags *ConvertFlags) {
 	flags.StringVar(&convertFlags.GitUrl.Value, convertFlags.GitUrl.Name, "", "Url of the Git repository for storing project configuration")
-	flags.StringVar(&convertFlags.GitBranch.Value, convertFlags.GitBranch.Name, "", fmt.Sprintf("The default branch to use for Config As Code. Default is '%s'.", DefaultBranch))
+	flags.StringVar(&convertFlags.GitBranch.Value, convertFlags.GitBranch.Name, DefaultBranch, fmt.Sprintf("The default branch to use for Config As Code. Default is '%s'.", DefaultBranch))
 	flags.StringVar(&convertFlags.GitCredentials.Value, convertFlags.GitCredentials.Name, "", "The Id or name of the Git credentials stored in Octopus")
 	flags.StringVar(&convertFlags.GitUsername.Value, convertFlags.GitUsername.Name, "", "The username to authenticate with Git")
 	flags.StringVar(&convertFlags.GitPassword.Value, convertFlags.GitPassword.Name, "", "The password to authenticate with Git")
 	flags.StringVar(&convertFlags.GitStorage.Value, convertFlags.GitStorage.Name, "", "The location to store the supplied Git credentials. Options are library or project. Default is library")
-	flags.StringVar(&convertFlags.GitInitialCommitMessage.Value, convertFlags.GitInitialCommitMessage.Name, "", "The initial commit message for configuring Config As Code.")
-	flags.StringVar(&convertFlags.GitBasePath.Value, convertFlags.GitBasePath.Name, "", fmt.Sprintf("The directory where Octopus should store the project files in the repository. Default is '%s'", DefaultBasePath))
-	flags.StringVar(&convertFlags.GitInitialCommitBranch.Value, convertFlags.GitInitialCommitBranch.Name, "", fmt.Sprintf("The branch to initially commit Config As Code settings. Only required if '%s' is listed as a '%s'.", convertFlags.GitBranch.Name, convertFlags.GitProtectedBranchPatterns.Name))
+	flags.StringVar(&convertFlags.GitInitialCommitMessage.Value, convertFlags.GitInitialCommitMessage.Name, DefaultGitCommitMessage, "The initial commit message for configuring Config As Code.")
+	flags.StringVar(&convertFlags.GitBasePath.Value, convertFlags.GitBasePath.Name, DefaultBasePath, fmt.Sprintf("The directory where Octopus should store the project files in the repository. Default is '%s'", DefaultBasePath))
+	flags.StringVar(&convertFlags.GitInitialCommitBranch.Value, convertFlags.GitInitialCommitBranch.Name, DefaultInitialCommitBranch, fmt.Sprintf("The branch to initially commit Config As Code settings. Only required if '%s' is listed as a '%s'. Default value is '%s'.", convertFlags.GitBranch.Name, convertFlags.GitProtectedBranchPatterns.Name, DefaultInitialCommitBranch))
 	flags.StringSliceVar(&convertFlags.GitProtectedBranchPatterns.Value, convertFlags.GitProtectedBranchPatterns.Name, []string{}, "Git branches which are protected from having Config As Code settings committed directly")
 }
 
@@ -286,6 +287,7 @@ func PromptForConfigAsCode(opts *ConvertOptions) (cmd.Dependable, error) {
 		if err := opts.Ask(&survey.Input{
 			Message: "Initial commit branch name",
 			Help:    "The branch where the Config As Code settings will be initially committed",
+			Default: DefaultInitialCommitBranch,
 		}, &opts.GitInitialCommitBranch.Value, survey.WithValidator(survey.ComposeValidators(
 			survey.Required,
 			survey.MaxLength(200),

--- a/pkg/cmd/project/convert/convert_test.go
+++ b/pkg/cmd/project/convert/convert_test.go
@@ -91,7 +91,7 @@ func TestPromptForConfigAsCode_UsingCacWithBranchProtection(t *testing.T) {
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "test"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "main"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
-		testutil.NewInputPrompt("Initial commit branch name", "The branch where the Config As Code settings will be initially committed", "initial-branch"),
+		testutil.NewInputPromptWithDefault("Initial commit branch name", "The branch where the Config As Code settings will be initially committed", "octopus-vcs-conversion", "initial-branch"),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
 	}
 

--- a/pkg/cmd/project/convert/convert_test.go
+++ b/pkg/cmd/project/convert/convert_test.go
@@ -17,7 +17,6 @@ func TestPromptForConfigAsCode_UsingCacWithProjectStorage(t *testing.T) {
 		testutil.NewInputPrompt("Git URL", "The URL of the Git repository to store configuration.", "https://github.com/blah.git"),
 		testutil.NewInputPromptWithDefault("Git repository base path", "The path in the repository where Config As Code settings are stored. Default value is '.octopus/'.", ".octopus/", "./octopus/project"),
 		testutil.NewInputPromptWithDefault("Git branch", "The default branch to use. Default value is 'main'.", "main", "main"),
-		testutil.NewConfirmPromptWithDefault("Is the 'main' branch protected?", "If the default branch is protected, you may not have permission to push to it.", false, false),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "test"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
@@ -35,7 +34,6 @@ func TestPromptForConfigAsCode_UsingCacWithProjectStorage(t *testing.T) {
 	assert.Equal(t, "https://github.com/blah.git", opts.GitUrl.Value)
 	assert.Equal(t, "./octopus/project", opts.GitBasePath.Value)
 	assert.Equal(t, "main", opts.GitBranch.Value)
-	assert.False(t, opts.GitDefaultBranchProtected.Value)
 	assert.Equal(t, "init message", opts.GitInitialCommitMessage.Value)
 	assert.Equal(t, []string{"test"}, opts.GitProtectedBranchPatterns.Value)
 	assert.Equal(t, "user1", opts.GitUsername.Value)
@@ -49,7 +47,6 @@ func TestPromptForConfigAsCode_UsingCacWithLibraryStorage(t *testing.T) {
 		testutil.NewInputPrompt("Git URL", "The URL of the Git repository to store configuration.", "https://github.com/blah.git"),
 		testutil.NewInputPromptWithDefault("Git repository base path", "The path in the repository where Config As Code settings are stored. Default value is '.octopus/'.", ".octopus/", "./octopus/project"),
 		testutil.NewInputPromptWithDefault("Git branch", "The default branch to use. Default value is 'main'.", "main", "main"),
-		testutil.NewConfirmPromptWithDefault("Is the 'main' branch protected?", "If the default branch is protected, you may not have permission to push to it.", false, false),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
 	}
@@ -91,10 +88,10 @@ func TestPromptForConfigAsCode_UsingCacWithBranchProtection(t *testing.T) {
 		testutil.NewInputPrompt("Git URL", "The URL of the Git repository to store configuration.", "https://github.com/blah.git"),
 		testutil.NewInputPromptWithDefault("Git repository base path", "The path in the repository where Config As Code settings are stored. Default value is '.octopus/'.", ".octopus/", "./octopus/project"),
 		testutil.NewInputPromptWithDefault("Git branch", "The default branch to use. Default value is 'main'.", "main", "main"),
-		testutil.NewConfirmPromptWithDefault("Is the 'main' branch protected?", "If the default branch is protected, you may not have permission to push to it.", true, false),
-		testutil.NewInputPrompt("Initial commit branch name", "The branch where the Config As Code settings will be initially committed", "initial-branch"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "test"),
+		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", "main"),
 		testutil.NewInputPrompt("Enter a protected branch pattern (enter blank to end)", "This setting only applies within Octopus and will not affect your protected branches in Git. Use wildcard syntax to specify the range of branches to include. Multiple patterns can be supplied", ""),
+		testutil.NewInputPrompt("Initial commit branch name", "The branch where the Config As Code settings will be initially committed", "initial-branch"),
 		testutil.NewInputPromptWithDefault("Initial Git commit message", "The commit message used in initializing. Default value is 'Initial commit of deployment process'.", "Initial commit of deployment process", "init message"),
 	}
 
@@ -123,7 +120,6 @@ func TestPromptForConfigAsCode_UsingCacWithBranchProtection(t *testing.T) {
 	assert.Equal(t, "main", opts.GitBranch.Value)
 	assert.Equal(t, "init message", opts.GitInitialCommitMessage.Value)
 	assert.Equal(t, "Git Creds 2", opts.GitCredentials.Value)
-	assert.True(t, opts.GitDefaultBranchProtected.Value)
 	assert.Equal(t, "initial-branch", opts.GitInitialCommitBranch.Value)
 
 	assert.True(t, gitCredsCallbackWasCalled)

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1203,7 +1203,6 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 		".octopus",
 		credentials.NewAnonymous(),
 		"main",
-		false,
 		protectedBranchNamePatterns,
 		fakeRepoUrl,
 	)

--- a/test/fixtures/projects.go
+++ b/test/fixtures/projects.go
@@ -84,7 +84,7 @@ func NewVersionControlledProject(spaceID string, projectID string, projectName s
 	protectedBranchNamePatterns := []string{}
 	result := NewProject(spaceID, projectID, projectName, lifecycleID, projectGroupID, deploymentProcessID)
 	result.VersioningStrategy = nil // CaC projects seem to always report nil here via the API
-	result.PersistenceSettings = projects.NewGitPersistenceSettings(".octopus", credentials.NewAnonymous(), "main", false, protectedBranchNamePatterns, repoUrl)
+	result.PersistenceSettings = projects.NewGitPersistenceSettings(".octopus", credentials.NewAnonymous(), "main", protectedBranchNamePatterns, repoUrl)
 
 	// CaC projects have different values in these links
 	result.Links["DeploymentProcess"] = fmt.Sprintf("/api/%s/projects/%s/{gitRef}/deploymentprocesses", spaceID, projectID) // note gitRef is a template param in the middle of the url path


### PR DESCRIPTION
convert a project without supplying values for default branch, initial commit branch, initial commit message

![image](https://user-images.githubusercontent.com/5336529/210304671-350662f3-172e-4382-9054-af67391588cc.png)

![image](https://user-images.githubusercontent.com/5336529/210304898-a45085c0-268f-439a-adf9-e5ffdf3c7bf5.png)

![image](https://user-images.githubusercontent.com/5336529/210305156-8b3b023f-17c3-494e-8985-c1363b866fed.png)


seems like you cannot use the same branch multiple times even if it has been deleted in Github
![image](https://user-images.githubusercontent.com/5336529/210305215-53a72360-26c4-440c-b3f1-a1a74ddd9c6c.png)
