### PR TITLE
chore: fix null ref in general account create command

### DIFF
--- a/pkg/cmd/account/aws/create/create.go
+++ b/pkg/cmd/account/aws/create/create.go
@@ -2,8 +2,7 @@ package create
 
 import (
 	"fmt"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
-	"io"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"os"
 
 	"github.com/OctopusDeploy/cli/pkg/util"
@@ -15,13 +14,11 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
-	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/surveyext"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/cli/pkg/validation"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -36,13 +33,7 @@ type CreateFlags struct {
 
 type CreateOptions struct {
 	*CreateFlags
-	Writer   io.Writer
-	Octopus  *client.Client
-	Ask      question.Asker
-	Space    string
-	Host     string
-	NoPrompt bool
-	CmdPath  string
+	*cmd.Dependencies
 	selectors.GetAllEnvironmentsCallback
 }
 
@@ -56,11 +47,18 @@ func NewCreateFlags() *CreateFlags {
 	}
 }
 
-func NewCmdCreate(f factory.Factory) *cobra.Command {
-	opts := &CreateOptions{
-		CreateFlags: NewCreateFlags(),
-		Ask:         f.Ask,
+func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  flags,
+		Dependencies: dependencies,
+		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
+			return selectors.GetAllEnvironments(dependencies.Client)
+		},
 	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
 	descriptionFilePath := ""
 
 	cmd := &cobra.Command{
@@ -69,21 +67,10 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 		Long:    "Create an AWS account in Octopus Deploy",
 		Example: heredoc.Docf("$ %s account aws create", constants.ExecutableName),
 		Aliases: []string{"new"},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-			if err != nil {
-				return err
-			}
-			opts.GetAllEnvironmentsCallback = func() ([]*environments.Environment, error) {
-				return selectors.GetAllEnvironments(*client)
-			}
-			opts.CmdPath = cmd.CommandPath()
-			opts.Octopus = client
-			opts.Host = f.GetCurrentHost()
-			opts.Space = f.GetCurrentSpace().GetID()
-			opts.Writer = cmd.OutOrStdout()
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
 			if descriptionFilePath != "" {
-				if err = validation.IsExistingFile(descriptionFilePath); err != nil {
+				if err := validation.IsExistingFile(descriptionFilePath); err != nil {
 					return err
 				}
 				data, err := os.ReadFile(descriptionFilePath)
@@ -92,22 +79,24 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 				}
 				opts.Description.Value = string(data)
 			}
-			opts.NoPrompt = !f.IsPromptEnabled()
 			if opts.Environments.Value != nil {
-				opts.Environments.Value, err = helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Octopus)
+				env, err := helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Client)
 				if err != nil {
 					return err
 				}
+				opts.Environments.Value = env
 			}
 			return CreateRun(opts)
 		},
 	}
-	cmd.Flags().StringVarP(&opts.Name.Value, opts.Name.Name, "n", "", "A short, memorable, unique name for this account.")
-	cmd.Flags().StringVarP(&opts.Description.Value, opts.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
-	cmd.Flags().StringVar(&opts.AccessKey.Value, opts.AccessKey.Name, "", "The AWS access key to use when authenticating against Amazon Web Services.")
-	cmd.Flags().StringVar(&opts.SecretKey.Value, opts.SecretKey.Name, "", "The AWS secret key to use when authenticating against Amazon Web Services.")
-	cmd.Flags().StringArrayVarP(&opts.Environments.Value, opts.Environments.Name, "e", nil, "The environments that are allowed to use this account")
-	cmd.Flags().StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`")
+
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "A short, memorable, unique name for this account.")
+	flags.StringVarP(&createFlags.Description.Value, createFlags.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
+	flags.StringVar(&createFlags.AccessKey.Value, createFlags.AccessKey.Name, "", "The AWS access key to use when authenticating against Amazon Web Services.")
+	flags.StringVar(&createFlags.SecretKey.Value, createFlags.SecretKey.Name, "", "The AWS secret key to use when authenticating against Amazon Web Services.")
+	flags.StringArrayVarP(&createFlags.Environments.Value, createFlags.Environments.Name, "e", nil, "The environments that are allowed to use this account")
+	flags.StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`")
 
 	return cmd
 }
@@ -125,20 +114,20 @@ func CreateRun(opts *CreateOptions) error {
 	awsAccount.Description = opts.Description.Value
 	awsAccount.EnvironmentIDs = opts.Environments.Value
 
-	createdAccount, err := opts.Octopus.Accounts.Add(awsAccount)
+	createdAccount, err := opts.Client.Accounts.Add(awsAccount)
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(opts.Writer, "Successfully created AWS account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
+	_, err = fmt.Fprintf(opts.Out, "Successfully created AWS account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
 	if err != nil {
 		return err
 	}
-	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space, createdAccount.GetID())
-	fmt.Fprintf(opts.Writer, "\nView this account on Octopus Deploy: %s\n", link)
+	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space.GetID(), createdAccount.GetID())
+	fmt.Fprintf(opts.Out, "\nView this account on Octopus Deploy: %s\n", link)
 	if !opts.NoPrompt {
 		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Name, opts.AccessKey, opts.SecretKey, opts.Description, opts.Environments)
-		fmt.Fprintf(opts.Writer, "\nAutomation Command: %s\n", autoCmd)
+		fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
 	}
 
 	return nil

--- a/pkg/cmd/account/aws/create/create_test.go
+++ b/pkg/cmd/account/aws/create/create_test.go
@@ -2,6 +2,7 @@ package create_test
 
 import (
 	"bytes"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"net/url"
 	"testing"
 
@@ -28,13 +29,14 @@ var rootResource = testutil.NewRootResource()
 func TestAWSAccountCreatePromptMissing(t *testing.T) {
 	const spaceID = "Space-1"
 	const envID = "Env-1"
-	_ = fixtures.NewSpace(spaceID, "testspace")
+	space := fixtures.NewSpace(spaceID, "testspace")
 	env := fixtures.NewEnvironment(spaceID, envID, "testenv")
 	api, qa := testutil.NewMockServerAndAsker()
 	out := &bytes.Buffer{}
 
 	opts := &create.CreateOptions{
-		CreateFlags: create.NewCreateFlags(),
+		CreateFlags:  create.NewCreateFlags(),
+		Dependencies: &cmd.Dependencies{Space: space},
 		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
 			return []*environments.Environment{env}, nil
 		},
@@ -44,8 +46,8 @@ func TestAWSAccountCreatePromptMissing(t *testing.T) {
 		defer testutil.Close(api, qa)
 		octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 		opts.Ask = qa.AsAsker()
-		opts.Octopus = octopus
-		opts.Writer = out
+		opts.Client = octopus
+		opts.Out = out
 		return create.PromptMissing(opts)
 	})
 
@@ -93,15 +95,15 @@ func TestAWSAccountCreatePromptMissing(t *testing.T) {
 func TestAWSAccountCreateNoPrompt(t *testing.T) {
 	const spaceID = "Space-1"
 	const envID = "Env-1"
-	_ = fixtures.NewSpace(spaceID, "testspace")
+	space := fixtures.NewSpace(spaceID, "testspace")
 	_ = fixtures.NewEnvironment(spaceID, envID, "testenv")
 	api, qa := testutil.NewMockServerAndAsker()
 	out := &bytes.Buffer{}
 
 	opts := &create.CreateOptions{
-		CreateFlags: create.NewCreateFlags(),
+		CreateFlags:  create.NewCreateFlags(),
+		Dependencies: &cmd.Dependencies{Space: space},
 	}
-	opts.Space = spaceID
 	opts.Name.Value = "testaccount"
 	opts.AccessKey.Value = "testaccesskey123"
 	opts.SecretKey.Value = "testsecretkey123"
@@ -110,8 +112,8 @@ func TestAWSAccountCreateNoPrompt(t *testing.T) {
 		defer testutil.Close(api, qa)
 		octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 		opts.Ask = qa.AsAsker()
-		opts.Octopus = octopus
-		opts.Writer = out
+		opts.Client = octopus
+		opts.Out = out
 		opts.NoPrompt = true
 		return create.CreateRun(opts)
 	})
@@ -139,6 +141,6 @@ func TestAWSAccountCreateNoPrompt(t *testing.T) {
 	`,
 		testAccount.Name,
 		output.Dimf("(%s)", testAccount.Slug),
-		output.Bluef("%s/app#/%s/infrastructure/accounts/%s", "", opts.Space, testAccount.ID),
+		output.Bluef("%s/app#/%s/infrastructure/accounts/%s", "", opts.Space.GetID(), testAccount.ID),
 	), res)
 }

--- a/pkg/cmd/account/create/create.go
+++ b/pkg/cmd/account/create/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	awsCreate "github.com/OctopusDeploy/cli/pkg/cmd/account/aws/create"
 	azureCreate "github.com/OctopusDeploy/cli/pkg/cmd/account/azure/create"
 	gcpCreate "github.com/OctopusDeploy/cli/pkg/cmd/account/gcp/create"
@@ -14,6 +14,15 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/spf13/cobra"
+)
+
+const (
+	AwsAccount              = "AWS Account"
+	AzureAccount            = "Azure Account"
+	GcpAccount              = "Google Cloud Account"
+	SshAccount              = "SSH Key Pair"
+	UsernamePasswordAccount = "Username/Password"
+	TokenAccount            = "Token"
 )
 
 func NewCmdCreate(f factory.Factory) *cobra.Command {
@@ -31,24 +40,20 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 	return cmd
 }
 
-func createRun(f factory.Factory, cmd *cobra.Command) error {
-	client, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-	w := cmd.OutOrStderr()
-	if err != nil {
-		return err
-	}
+func createRun(f factory.Factory, c *cobra.Command) error {
+	dependencies := cmd.NewDependencies(f, c)
 
 	accountTypes := []string{
-		"AWS Account",
-		"Azure Account",
-		"Google Cloud Account",
-		"SSH Key Pair",
-		"Username/Password",
-		"Token",
+		AwsAccount,
+		AzureAccount,
+		GcpAccount,
+		SshAccount,
+		UsernamePasswordAccount,
+		TokenAccount,
 	}
 
 	var accountType string
-	err = f.Ask(&survey.Select{
+	err := f.Ask(&survey.Select{
 		Help:    "The type of account being created.",
 		Message: "Account Type",
 		Options: accountTypes,
@@ -58,81 +63,33 @@ func createRun(f factory.Factory, cmd *cobra.Command) error {
 	}
 
 	switch accountType {
-	case "AWS Account":
-		opts := &awsCreate.CreateOptions{
-			Writer:      w,
-			Octopus:     client,
-			Ask:         f.Ask,
-			Space:       f.GetCurrentSpace().GetID(),
-			CreateFlags: awsCreate.NewCreateFlags(),
-			CmdPath:     fmt.Sprintf("%s account aws create", constants.ExecutableName),
-			Host:        f.GetCurrentHost(),
-		}
+	case AwsAccount:
+		opts := awsCreate.NewCreateOptions(awsCreate.NewCreateFlags(), cmd.NewDependenciesFromExisting(dependencies, fmt.Sprintf("%s account aws create", constants.ExecutableName)))
 		if err := awsCreate.CreateRun(opts); err != nil {
 			return err
 		}
-	case "Azure Account":
-		opts := &azureCreate.CreateOptions{
-			Writer:      w,
-			Octopus:     client,
-			Ask:         f.Ask,
-			Space:       f.GetCurrentSpace().GetID(),
-			CreateFlags: azureCreate.NewCreateFlags(),
-			CmdPath:     fmt.Sprintf("%s account azure create", constants.ExecutableName),
-			Host:        f.GetCurrentHost(),
-		}
+	case AzureAccount:
+		opts := azureCreate.NewCreateOptions(azureCreate.NewCreateFlags(), cmd.NewDependenciesFromExisting(dependencies, fmt.Sprintf("%s account azure create", constants.ExecutableName)))
 		if err := azureCreate.CreateRun(opts); err != nil {
 			return err
 		}
-	case "Google Cloud Account":
-		opts := &gcpCreate.CreateOptions{
-			Writer:      w,
-			Octopus:     client,
-			Ask:         f.Ask,
-			Space:       f.GetCurrentSpace().GetID(),
-			CreateFlags: gcpCreate.NewCreateFlags(),
-			CmdPath:     fmt.Sprintf("%s account gcp create", constants.ExecutableName),
-			Host:        f.GetCurrentHost(),
-		}
+	case GcpAccount:
+		opts := gcpCreate.NewCreateOptions(gcpCreate.NewCreateFlags(), cmd.NewDependenciesFromExisting(dependencies, fmt.Sprintf("%s account gcp create", constants.ExecutableName)))
 		if err := gcpCreate.CreateRun(opts); err != nil {
 			return err
 		}
-	case "SSH Key Pair":
-		opts := &sshCreate.CreateOptions{
-			Writer:      w,
-			Octopus:     client,
-			Ask:         f.Ask,
-			Space:       f.GetCurrentSpace().GetID(),
-			CreateFlags: sshCreate.NewCreateFlags(),
-			CmdPath:     fmt.Sprintf("%s account ssh create", constants.ExecutableName),
-			Host:        f.GetCurrentHost(),
-		}
+	case SshAccount:
+		opts := sshCreate.NewCreateOptions(sshCreate.NewCreateFlags(), cmd.NewDependenciesFromExisting(dependencies, fmt.Sprintf("%s account ssh create", constants.ExecutableName)))
 		if err := sshCreate.CreateRun(opts); err != nil {
 			return err
 		}
-	case "Token":
-		opts := &tokenCreate.CreateOptions{
-			Writer:      w,
-			Octopus:     client,
-			Ask:         f.Ask,
-			Space:       f.GetCurrentSpace().GetID(),
-			CreateFlags: tokenCreate.NewCreateFlags(),
-			CmdPath:     fmt.Sprintf("%s account token create", constants.ExecutableName),
-			Host:        f.GetCurrentHost(),
-		}
+	case TokenAccount:
+		opts := tokenCreate.NewCreateOptions(tokenCreate.NewCreateFlags(), cmd.NewDependenciesFromExisting(dependencies, fmt.Sprintf("%s account token create", constants.ExecutableName)))
 		if err := tokenCreate.CreateRun(opts); err != nil {
 			return err
 		}
-	case "Username/Password":
-		opts := &usernameCreate.CreateOptions{
-			Writer:      w,
-			Octopus:     client,
-			Ask:         f.Ask,
-			Space:       f.GetCurrentSpace().GetID(),
-			CreateFlags: usernameCreate.NewCreateFlags(),
-			CmdPath:     fmt.Sprintf("%s account username create", constants.ExecutableName),
-			Host:        f.GetCurrentHost(),
-		}
+	case UsernamePasswordAccount:
+		opts := usernameCreate.NewCreateOptions(usernameCreate.NewCreateFlags(), cmd.NewDependenciesFromExisting(dependencies, fmt.Sprintf("%s account username create", constants.ExecutableName)))
 		if err := usernameCreate.CreateRun(opts); err != nil {
 			return err
 		}

--- a/pkg/cmd/account/gcp/create/create.go
+++ b/pkg/cmd/account/gcp/create/create.go
@@ -3,8 +3,7 @@ package create
 import (
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
-	"io"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"os"
 
 	"github.com/OctopusDeploy/cli/pkg/util"
@@ -16,13 +15,11 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
-	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/surveyext"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/cli/pkg/validation"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -36,16 +33,9 @@ type CreateFlags struct {
 
 type CreateOptions struct {
 	*CreateFlags
-	Writer  io.Writer
-	Octopus *client.Client
-	Ask     question.Asker
-	Space   string
-	Host    string
-	CmdPath string
+	*cmd.Dependencies
 
 	KeyFileData []byte
-
-	NoPrompt bool
 	selectors.GetAllEnvironmentsCallback
 }
 
@@ -58,11 +48,18 @@ func NewCreateFlags() *CreateFlags {
 	}
 }
 
-func NewCmdCreate(f factory.Factory) *cobra.Command {
-	opts := &CreateOptions{
-		Ask:         f.Ask,
-		CreateFlags: NewCreateFlags(),
+func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  flags,
+		Dependencies: dependencies,
+		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
+			return selectors.GetAllEnvironments(dependencies.Client)
+		},
 	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
 	descriptionFilePath := ""
 
 	cmd := &cobra.Command{
@@ -71,19 +68,8 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 		Long:    "Create a Google Cloud account in Octopus Deploy",
 		Example: heredoc.Docf("$ %s account gcp create", constants.ExecutableName),
 		Aliases: []string{"new"},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-			if err != nil {
-				return err
-			}
-			opts.GetAllEnvironmentsCallback = func() ([]*environments.Environment, error) {
-				return selectors.GetAllEnvironments(*client)
-			}
-			opts.CmdPath = cmd.CommandPath()
-			opts.Octopus = client
-			opts.Space = f.GetCurrentSpace().GetID()
-			opts.Host = f.GetCurrentHost()
-			opts.Writer = cmd.OutOrStdout()
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
 			if descriptionFilePath != "" {
 				if err := validation.IsExistingFile(descriptionFilePath); err != nil {
 					return err
@@ -104,22 +90,23 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 				}
 				opts.KeyFileData = data
 			}
-			opts.NoPrompt = !f.IsPromptEnabled()
 			if opts.Environments.Value != nil {
-				opts.Environments.Value, err = helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Octopus)
+				env, err := helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Client)
 				if err != nil {
 					return err
 				}
+				opts.Environments.Value = env
 			}
 			return CreateRun(opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Name.Value, opts.Name.Name, "n", "", "A short, memorable, unique name for this account.")
-	cmd.Flags().StringVarP(&opts.Description.Value, opts.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
-	cmd.Flags().StringVarP(&opts.KeyFilePath.Value, opts.KeyFilePath.Name, "K", "", "The json key file to use when authenticating against Google Cloud.")
-	cmd.Flags().StringArrayVarP(&opts.Environments.Value, opts.Environments.Name, "e", nil, "The environments that are allowed to use this account")
-	cmd.Flags().StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`")
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "A short, memorable, unique name for this account.")
+	flags.StringVarP(&createFlags.Description.Value, createFlags.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
+	flags.StringVarP(&createFlags.KeyFilePath.Value, createFlags.KeyFilePath.Name, "K", "", "The json key file to use when authenticating against Google Cloud.")
+	flags.StringArrayVarP(&createFlags.Environments.Value, createFlags.Environments.Name, "e", nil, "The environments that are allowed to use this account")
+	flags.StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`")
 
 	return cmd
 }
@@ -140,20 +127,20 @@ func CreateRun(opts *CreateOptions) error {
 	gcpAccount.Description = opts.Description.Value
 	gcpAccount.EnvironmentIDs = opts.Environments.Value
 
-	createdAccount, err := opts.Octopus.Accounts.Add(gcpAccount)
+	createdAccount, err := opts.Client.Accounts.Add(gcpAccount)
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(opts.Writer, "Successfully created GCP account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
+	_, err = fmt.Fprintf(opts.Out, "Successfully created GCP account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
 	if err != nil {
 		return err
 	}
-	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space, createdAccount.GetID())
-	_, _ = fmt.Fprintf(opts.Writer, "\nView this account on Octopus Deploy: %s\n", link)
+	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space.GetID(), createdAccount.GetID())
+	_, _ = fmt.Fprintf(opts.Out, "\nView this account on Octopus Deploy: %s\n", link)
 	if !opts.NoPrompt {
 		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Name, opts.KeyFilePath, opts.Description, opts.Environments)
-		_, _ = fmt.Fprintf(opts.Writer, "\nAutomation Command: %s\n", autoCmd)
+		_, _ = fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
 	}
 	return nil
 }

--- a/pkg/cmd/account/gcp/create/create_test.go
+++ b/pkg/cmd/account/gcp/create/create_test.go
@@ -3,6 +3,7 @@ package create_test
 import (
 	"bytes"
 	"encoding/base64"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"net/url"
 	"testing"
 
@@ -29,13 +30,14 @@ var rootResource = testutil.NewRootResource()
 func TestGCPAccountCreatePromptMissing(t *testing.T) {
 	const spaceID = "Space-1"
 	const envID = "Env-1"
-	_ = fixtures.NewSpace(spaceID, "testspace")
+	space := fixtures.NewSpace(spaceID, "testspace")
 	env := fixtures.NewEnvironment(spaceID, envID, "testenv")
 	api, qa := testutil.NewMockServerAndAsker()
 	out := &bytes.Buffer{}
 
 	opts := &create.CreateOptions{
-		CreateFlags: create.NewCreateFlags(),
+		CreateFlags:  create.NewCreateFlags(),
+		Dependencies: &cmd.Dependencies{Space: space},
 		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
 			return []*environments.Environment{env}, nil
 		},
@@ -47,8 +49,8 @@ func TestGCPAccountCreatePromptMissing(t *testing.T) {
 		defer testutil.Close(api, qa)
 		octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 		opts.Ask = qa.AsAsker()
-		opts.Octopus = octopus
-		opts.Writer = out
+		opts.Client = octopus
+		opts.Out = out
 		return create.PromptMissing(opts)
 	})
 
@@ -84,15 +86,15 @@ func TestGCPAccountCreatePromptMissing(t *testing.T) {
 func TestGCPAccountCreateNoPrompt(t *testing.T) {
 	const spaceID = "Space-1"
 	const envID = "Env-1"
-	_ = fixtures.NewSpace(spaceID, "testspace")
+	space := fixtures.NewSpace(spaceID, "testspace")
 	_ = fixtures.NewEnvironment(spaceID, envID, "testenv")
 	api, qa := testutil.NewMockServerAndAsker()
 	out := &bytes.Buffer{}
 
 	opts := &create.CreateOptions{
-		CreateFlags: create.NewCreateFlags(),
+		CreateFlags:  create.NewCreateFlags(),
+		Dependencies: &cmd.Dependencies{Space: space},
 	}
-	opts.Space = spaceID
 	opts.Name.Value = "testaccount"
 	opts.KeyFileData = []byte{1, 1}
 
@@ -100,8 +102,8 @@ func TestGCPAccountCreateNoPrompt(t *testing.T) {
 		defer testutil.Close(api, qa)
 		octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 		opts.Ask = qa.AsAsker()
-		opts.Octopus = octopus
-		opts.Writer = out
+		opts.Client = octopus
+		opts.Out = out
 		opts.NoPrompt = true
 		return create.CreateRun(opts)
 	})
@@ -128,6 +130,6 @@ func TestGCPAccountCreateNoPrompt(t *testing.T) {
 	`,
 		testAccount.Name,
 		output.Dimf("(%s)", testAccount.Slug),
-		output.Bluef("%s/app#/%s/infrastructure/accounts/%s", "", opts.Space, testAccount.ID),
+		output.Bluef("%s/app#/%s/infrastructure/accounts/%s", "", opts.Space.GetID(), testAccount.ID),
 	), res)
 }

--- a/pkg/cmd/account/ssh/create/create.go
+++ b/pkg/cmd/account/ssh/create/create.go
@@ -3,8 +3,7 @@ package create
 import (
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
-	"io"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"os"
 
 	"github.com/OctopusDeploy/cli/pkg/util"
@@ -16,13 +15,11 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
-	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/surveyext"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/cli/pkg/validation"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -38,16 +35,8 @@ type CreateFlags struct {
 
 type CreateOptions struct {
 	*CreateFlags
-	Writer  io.Writer
-	Octopus *client.Client
-	Ask     question.Asker
-	Space   string
-	Host    string
-	CmdPath string
-
+	*cmd.Dependencies
 	KeyFileData []byte
-
-	NoPrompt bool
 	selectors.GetAllEnvironmentsCallback
 }
 
@@ -62,11 +51,18 @@ func NewCreateFlags() *CreateFlags {
 	}
 }
 
-func NewCmdCreate(f factory.Factory) *cobra.Command {
-	opts := &CreateOptions{
-		Ask:         f.Ask,
-		CreateFlags: NewCreateFlags(),
+func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  flags,
+		Dependencies: dependencies,
+		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
+			return selectors.GetAllEnvironments(dependencies.Client)
+		},
 	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
 	descriptionFilePath := ""
 
 	cmd := &cobra.Command{
@@ -75,19 +71,8 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 		Long:    "Create a SSH Key Pair account in Octopus Deploy",
 		Example: heredoc.Docf("$ %s account ssh create", constants.ExecutableName),
 		Aliases: []string{"new"},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-			if err != nil {
-				return err
-			}
-			opts.GetAllEnvironmentsCallback = func() ([]*environments.Environment, error) {
-				return selectors.GetAllEnvironments(*octopus)
-			}
-			opts.CmdPath = cmd.CommandPath()
-			opts.Octopus = octopus
-			opts.Space = f.GetCurrentSpace().GetID()
-			opts.Host = f.GetCurrentHost()
-			opts.Writer = cmd.OutOrStdout()
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
 			if descriptionFilePath != "" {
 				if err := validation.IsExistingFile(descriptionFilePath); err != nil {
 					return err
@@ -108,24 +93,25 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 				}
 				opts.KeyFileData = data
 			}
-			opts.NoPrompt = !f.IsPromptEnabled()
 			if opts.Environments.Value != nil {
-				opts.Environments.Value, err = helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Octopus)
+				env, err := helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Client)
 				if err != nil {
 					return err
 				}
+				opts.Environments.Value = env
 			}
 			return CreateRun(opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Name.Value, opts.Name.Name, "n", "", "A short, memorable, unique name for this account.")
-	cmd.Flags().StringVarP(&opts.Description.Value, opts.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
-	cmd.Flags().StringVarP(&opts.KeyFilePath.Value, opts.KeyFilePath.Name, "K", "", "Path to the private key file portion of the key pair.")
-	cmd.Flags().StringVarP(&opts.Username.Value, opts.Username.Name, "u", "", "The username to use when authenticating against the remote host.")
-	cmd.Flags().StringVarP(&opts.Passphrase.Value, opts.Passphrase.Name, "p", "", "The passphrase for the private key, if required.")
-	cmd.Flags().StringArrayVarP(&opts.Environments.Value, opts.Environments.Name, "e", nil, "The environments that are allowed to use this account.")
-	cmd.Flags().StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`.")
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "A short, memorable, unique name for this account.")
+	flags.StringVarP(&createFlags.Description.Value, createFlags.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
+	flags.StringVarP(&createFlags.KeyFilePath.Value, createFlags.KeyFilePath.Name, "K", "", "Path to the private key file portion of the key pair.")
+	flags.StringVarP(&createFlags.Username.Value, createFlags.Username.Name, "u", "", "The username to use when authenticating against the remote host.")
+	flags.StringVarP(&createFlags.Passphrase.Value, createFlags.Passphrase.Name, "p", "", "The passphrase for the private key, if required.")
+	flags.StringArrayVarP(&createFlags.Environments.Value, createFlags.Environments.Name, "e", nil, "The environments that are allowed to use this account.")
+	flags.StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`.")
 
 	return cmd
 }
@@ -150,20 +136,20 @@ func CreateRun(opts *CreateOptions) error {
 		sshAccount.PrivateKeyPassphrase = core.NewSensitiveValue(opts.Passphrase.Value)
 	}
 
-	createdAccount, err := opts.Octopus.Accounts.Add(sshAccount)
+	createdAccount, err := opts.Client.Accounts.Add(sshAccount)
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(opts.Writer, "Successfully created SSH account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
+	_, err = fmt.Fprintf(opts.Out, "Successfully created SSH account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
 	if err != nil {
 		return err
 	}
-	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space, createdAccount.GetID())
-	_, _ = fmt.Fprintf(opts.Writer, "\nView this account on Octopus Deploy: %s\n", link)
+	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space.GetID(), createdAccount.GetID())
+	_, _ = fmt.Fprintf(opts.Out, "\nView this account on Octopus Deploy: %s\n", link)
 	if !opts.NoPrompt {
 		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Name, opts.KeyFilePath, opts.Passphrase, opts.Description, opts.Environments)
-		_, _ = fmt.Fprintf(opts.Writer, "\nAutomation Command: %s\n", autoCmd)
+		_, _ = fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
 	}
 	return nil
 }

--- a/pkg/cmd/account/token/create/create.go
+++ b/pkg/cmd/account/token/create/create.go
@@ -2,8 +2,7 @@ package create
 
 import (
 	"fmt"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
-	"io"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"os"
 
 	"github.com/OctopusDeploy/cli/pkg/util"
@@ -15,13 +14,11 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
-	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/surveyext"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/cli/pkg/validation"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -35,13 +32,7 @@ type CreateFlags struct {
 
 type CreateOptions struct {
 	*CreateFlags
-	Writer   io.Writer
-	Octopus  *client.Client
-	Ask      question.Asker
-	Space    string
-	NoPrompt bool
-	CmdPath  string
-	Host     string
+	*cmd.Dependencies
 	selectors.GetAllEnvironmentsCallback
 }
 
@@ -54,11 +45,18 @@ func NewCreateFlags() *CreateFlags {
 	}
 }
 
-func NewCmdCreate(f factory.Factory) *cobra.Command {
-	opts := &CreateOptions{
-		Ask:         f.Ask,
-		CreateFlags: NewCreateFlags(),
+func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  flags,
+		Dependencies: dependencies,
+		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
+			return selectors.GetAllEnvironments(dependencies.Client)
+		},
 	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
 	descriptionFilePath := ""
 
 	cmd := &cobra.Command{
@@ -67,19 +65,8 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 		Long:    "Create a Token account in Octopus Deploy",
 		Example: heredoc.Docf("$ %s account token create", constants.ExecutableName),
 		Aliases: []string{"new"},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-			if err != nil {
-				return err
-			}
-			opts.GetAllEnvironmentsCallback = func() ([]*environments.Environment, error) {
-				return selectors.GetAllEnvironments(*octopus)
-			}
-			opts.CmdPath = cmd.CommandPath()
-			opts.Octopus = octopus
-			opts.Host = f.GetCurrentHost()
-			opts.Space = f.GetCurrentSpace().GetID()
-			opts.Writer = cmd.OutOrStdout()
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
 			if descriptionFilePath != "" {
 				if err := validation.IsExistingFile(descriptionFilePath); err != nil {
 					return err
@@ -90,22 +77,23 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 				}
 				opts.Description.Value = string(data)
 			}
-			opts.NoPrompt = !f.IsPromptEnabled()
 			if opts.Environments.Value != nil {
-				opts.Environments.Value, err = helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Octopus)
+				env, err := helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Client)
 				if err != nil {
 					return err
 				}
+				opts.Environments.Value = env
 			}
 			return CreateRun(opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Name.Value, opts.Name.Name, "n", "", "A short, memorable, unique name for this account.")
-	cmd.Flags().StringVarP(&opts.Description.Value, opts.Description.Value, "d", "", "A summary explaining the use of the account to other users.")
-	cmd.Flags().StringVarP(&opts.Token.Value, opts.Token.Name, "t", "", "The password to use to when authenticating against the remote host.")
-	cmd.Flags().StringArrayVarP(&opts.Environments.Value, opts.Environments.Name, "e", nil, "The environments that are allowed to use this account.")
-	cmd.Flags().StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`.")
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "A short, memorable, unique name for this account.")
+	flags.StringVarP(&createFlags.Description.Value, createFlags.Description.Value, "d", "", "A summary explaining the use of the account to other users.")
+	flags.StringVarP(&createFlags.Token.Value, createFlags.Token.Name, "t", "", "The password to use to when authenticating against the remote host.")
+	flags.StringArrayVarP(&createFlags.Environments.Value, createFlags.Environments.Name, "e", nil, "The environments that are allowed to use this account.")
+	flags.StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`.")
 
 	return cmd
 }
@@ -126,20 +114,20 @@ func CreateRun(opts *CreateOptions) error {
 	tokenAccount.Description = opts.Description.Value
 	tokenAccount.EnvironmentIDs = opts.Environments.Value
 
-	createdAccount, err := opts.Octopus.Accounts.Add(tokenAccount)
+	createdAccount, err := opts.Client.Accounts.Add(tokenAccount)
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(opts.Writer, "Successfully created Token account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
+	_, err = fmt.Fprintf(opts.Out, "Successfully created Token account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
 	if err != nil {
 		return err
 	}
-	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space, createdAccount.GetID())
-	_, _ = fmt.Fprintf(opts.Writer, "\nView this account on Octopus Deploy: %s\n", link)
+	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space.GetID(), createdAccount.GetID())
+	_, _ = fmt.Fprintf(opts.Out, "\nView this account on Octopus Deploy: %s\n", link)
 	if !opts.NoPrompt {
 		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Name, opts.Token, opts.Description, opts.Environments)
-		_, _ = fmt.Fprintf(opts.Writer, "\nAutomation Command: %s\n", autoCmd)
+		_, _ = fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
 	}
 	return nil
 }

--- a/pkg/cmd/account/username/create/create.go
+++ b/pkg/cmd/account/username/create/create.go
@@ -2,8 +2,7 @@ package create
 
 import (
 	"fmt"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
-	"io"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"os"
 
 	"github.com/OctopusDeploy/cli/pkg/util"
@@ -15,13 +14,11 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
-	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/surveyext"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/cli/pkg/validation"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -36,13 +33,7 @@ type CreateFlags struct {
 
 type CreateOptions struct {
 	*CreateFlags
-	Writer   io.Writer
-	Octopus  *client.Client
-	Ask      question.Asker
-	Space    string
-	NoPrompt bool
-	CmdPath  string
-	Host     string
+	*cmd.Dependencies
 	selectors.GetAllEnvironmentsCallback
 }
 
@@ -56,11 +47,18 @@ func NewCreateFlags() *CreateFlags {
 	}
 }
 
-func NewCmdCreate(f factory.Factory) *cobra.Command {
-	opts := &CreateOptions{
-		Ask:         f.Ask,
-		CreateFlags: NewCreateFlags(),
+func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  flags,
+		Dependencies: dependencies,
+		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
+			return selectors.GetAllEnvironments(dependencies.Client)
+		},
 	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
 	descriptionFilePath := ""
 
 	cmd := &cobra.Command{
@@ -70,19 +68,8 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 		Example: heredoc.Docf(`
 			$ %s account username create"
 		`, constants.ExecutableName),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-			if err != nil {
-				return err
-			}
-			opts.GetAllEnvironmentsCallback = func() ([]*environments.Environment, error) {
-				return selectors.GetAllEnvironments(*octopus)
-			}
-			opts.CmdPath = cmd.CommandPath()
-			opts.Octopus = octopus
-			opts.Host = f.GetCurrentHost()
-			opts.Space = f.GetCurrentSpace().GetID()
-			opts.Writer = cmd.OutOrStdout()
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
 			if descriptionFilePath != "" {
 				if err := validation.IsExistingFile(descriptionFilePath); err != nil {
 					return err
@@ -93,23 +80,24 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 				}
 				opts.Description.Value = string(data)
 			}
-			opts.NoPrompt = !f.IsPromptEnabled()
 			if opts.Environments.Value != nil {
-				opts.Environments.Value, err = helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Octopus)
+				env, err := helper.ResolveEnvironmentNames(opts.Environments.Value, opts.Client)
 				if err != nil {
 					return err
 				}
+				opts.Environments.Value = env
 			}
 			return CreateRun(opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Name.Value, opts.Name.Name, "n", "", "A short, memorable, unique name for this account.")
-	cmd.Flags().StringVarP(&opts.Description.Value, opts.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
-	cmd.Flags().StringVarP(&opts.Username.Value, opts.Username.Name, "u", "", "The username to use when authenticating against the remote host.")
-	cmd.Flags().StringVarP(&opts.Password.Value, opts.Password.Name, "p", "", "The password to use to when authenticating against the remote host.")
-	cmd.Flags().StringArrayVarP(&opts.Environments.Value, opts.Environments.Name, "e", nil, "The environments that are allowed to use this account.")
-	cmd.Flags().StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`.")
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "A short, memorable, unique name for this account.")
+	flags.StringVarP(&createFlags.Description.Value, createFlags.Description.Name, "d", "", "A summary explaining the use of the account to other users.")
+	flags.StringVarP(&createFlags.Username.Value, createFlags.Username.Name, "u", "", "The username to use when authenticating against the remote host.")
+	flags.StringVarP(&createFlags.Password.Value, createFlags.Password.Name, "p", "", "The password to use to when authenticating against the remote host.")
+	flags.StringArrayVarP(&createFlags.Environments.Value, createFlags.Environments.Name, "e", nil, "The environments that are allowed to use this account.")
+	flags.StringVarP(&descriptionFilePath, "description-file", "D", "", "Read the description from `file`.")
 
 	return cmd
 }
@@ -131,20 +119,20 @@ func CreateRun(opts *CreateOptions) error {
 	usernameAccount.Description = opts.Description.Value
 	usernameAccount.EnvironmentIDs = opts.Environments.Value
 
-	createdAccount, err := opts.Octopus.Accounts.Add(usernameAccount)
+	createdAccount, err := opts.Client.Accounts.Add(usernameAccount)
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(opts.Writer, "Successfully created Username account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
+	_, err = fmt.Fprintf(opts.Out, "Successfully created Username account %s %s.\n", createdAccount.GetName(), output.Dimf("(%s)", createdAccount.GetSlug()))
 	if err != nil {
 		return err
 	}
-	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space, createdAccount.GetID())
-	_, _ = fmt.Fprintf(opts.Writer, "\nView this account on Octopus Deploy: %s\n", link)
+	link := output.Bluef("%s/app#/%s/infrastructure/accounts/%s", opts.Host, opts.Space.GetID(), createdAccount.GetID())
+	_, _ = fmt.Fprintf(opts.Out, "\nView this account on Octopus Deploy: %s\n", link)
 	if !opts.NoPrompt {
 		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Name, opts.Username, opts.Password, opts.Description, opts.Environments)
-		_, _ = fmt.Fprintf(opts.Writer, "\nAutomation Command: %s\n", autoCmd)
+		_, _ = fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
 	}
 	return nil
 }

--- a/pkg/cmd/account/username/create/create_test.go
+++ b/pkg/cmd/account/username/create/create_test.go
@@ -2,6 +2,7 @@ package create_test
 
 import (
 	"bytes"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"net/url"
 	"testing"
 
@@ -28,13 +29,14 @@ var rootResource = testutil.NewRootResource()
 func TestUsernameAccountCreatePromptMissing(t *testing.T) {
 	const spaceID = "Space-1"
 	const envID = "Env-1"
-	_ = fixtures.NewSpace(spaceID, "testspace")
+	space := fixtures.NewSpace(spaceID, "testspace")
 	env := fixtures.NewEnvironment(spaceID, envID, "testenv")
 	api, qa := testutil.NewMockServerAndAsker()
 	out := &bytes.Buffer{}
 
 	opts := &create.CreateOptions{
-		CreateFlags: create.NewCreateFlags(),
+		CreateFlags:  create.NewCreateFlags(),
+		Dependencies: &cmd.Dependencies{Space: space},
 		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
 			return []*environments.Environment{env}, nil
 		},
@@ -44,8 +46,8 @@ func TestUsernameAccountCreatePromptMissing(t *testing.T) {
 		defer testutil.Close(api, qa)
 		octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 		opts.Ask = qa.AsAsker()
-		opts.Octopus = octopus
-		opts.Writer = out
+		opts.Client = octopus
+		opts.Out = out
 		return create.PromptMissing(opts)
 	})
 
@@ -93,23 +95,23 @@ func TestUsernameAccountCreatePromptMissing(t *testing.T) {
 func TestUsernameAccountCreateNoPrompt(t *testing.T) {
 	const spaceID = "Space-1"
 	const envID = "Env-1"
-	_ = fixtures.NewSpace(spaceID, "testspace")
+	space := fixtures.NewSpace(spaceID, "testspace")
 	_ = fixtures.NewEnvironment(spaceID, envID, "testenv")
 	api, qa := testutil.NewMockServerAndAsker()
 	out := &bytes.Buffer{}
 
 	opts := &create.CreateOptions{
-		CreateFlags: create.NewCreateFlags(),
+		CreateFlags:  create.NewCreateFlags(),
+		Dependencies: &cmd.Dependencies{Space: space},
 	}
-	opts.Space = spaceID
 	opts.Name.Value = "testaccount"
 
 	errReceiver := testutil.GoBegin(func() error {
 		defer testutil.Close(api, qa)
 		octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 		opts.Ask = qa.AsAsker()
-		opts.Octopus = octopus
-		opts.Writer = out
+		opts.Client = octopus
+		opts.Out = out
 		opts.NoPrompt = true
 		return create.CreateRun(opts)
 	})
@@ -137,6 +139,6 @@ func TestUsernameAccountCreateNoPrompt(t *testing.T) {
 	`,
 		testAccount.Name,
 		output.Dimf("(%s)", testAccount.Slug),
-		output.Bluef("%s/app#/%s/infrastructure/accounts/%s", "", opts.Space, testAccount.ID),
+		output.Bluef("%s/app#/%s/infrastructure/accounts/%s", "", opts.Space.GetID(), testAccount.ID),
 	), res)
 }

--- a/pkg/cmd/target/shared/environment.go
+++ b/pkg/cmd/target/shared/environment.go
@@ -26,7 +26,7 @@ func NewCreateTargetEnvironmentOptions(dependencies *cmd.Dependencies) *CreateTa
 	return &CreateTargetEnvironmentOptions{
 		Dependencies: dependencies,
 		GetAllEnvironmentsCallback: func() ([]*environments.Environment, error) {
-			return selectors.GetAllEnvironments(*dependencies.Client)
+			return selectors.GetAllEnvironments(dependencies.Client)
 		},
 	}
 }

--- a/pkg/question/selectors/environments.go
+++ b/pkg/question/selectors/environments.go
@@ -10,7 +10,7 @@ import (
 
 type GetAllEnvironmentsCallback func() ([]*environments.Environment, error)
 
-func GetAllEnvironments(client client.Client) ([]*environments.Environment, error) {
+func GetAllEnvironments(client *client.Client) ([]*environments.Environment, error) {
 	envResources, err := client.Environments.Get(environments.EnvironmentsQuery{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/cli/issues/205

This PR also consolidates a lot of repeated code for create new options structs plus cleans up repeated properties to use shared structs for dependencies on a command