### PR TITLE
Update releases.json on new release created/published. 

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -278,11 +278,6 @@ jobs:
             git checkout main
             git checkout -b $BRANCH_NAME
 
-        - name: Set up Go
-          uses: actions/setup-go@v3
-          with:
-            go-version: 1.19
-
         - name: Generate cli docs
           working-directory: cli
           run: curl -s https://api.github.com/repos/OctopusDeploy/cli/releases > releases.json

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -252,3 +252,57 @@ jobs:
         release_notes_file: ${{ steps.fetch-release-notes.outputs.release-note-file || ''}}
         git_ref: ${{ github.event.repository.default_branch }}
         git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}
+
+
+  update-releases-json:
+    needs: [goreleaser, msi, generate-packages-and-publish]
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+        - name: Calculate branch name
+          id: branch-name
+          run: echo "BRANCH_NAME=releases-json-update-$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
+
+        - name: Checkout CLI
+          uses: actions/checkout@v3
+          with:
+            path: cli
+
+        - name: Setup cli repo
+          working-directory: cli
+          run: |
+            git config user.email 'bob@octopus.com'
+            git config user.name octobob
+            git checkout main
+            git checkout -b $BRANCH_NAME
+
+        - name: Set up Go
+          uses: actions/setup-go@v3
+          with:
+            go-version: 1.19
+
+        - name: Generate cli docs
+          working-directory: cli
+          run: curl -s https://api.github.com/repos/OctopusDeploy/cli/releases > releases.json
+
+        - name: Commit
+          uses: EndBug/add-and-commit@v9
+          with:
+            message: 'Update cli releases.json'
+            author_name: Bob
+            author_email: bob@octopus.com
+            committer_name: bob
+            cwd: cli
+            add: releases.json
+            push: false
+
+        - run: git push --repo https:/octobob:$GITHUB_TOKEN@github.com/OctopusDeploy/cli.git --set-upstream origin $BRANCH_NAME
+          working-directory: cli
+
+        - name: Create PR
+          run: |
+            curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/OctopusDeploy/cli/pulls \
+            -d '{"title":"update cli releases.json","body":"An automated update of the releases.json for octopus CLI\nCreated by GitHub Actions [go-releaser](https://github.com/OctopusDeploy/cli/actions/workflows/go-releaser.yml)","head":"'$BRANCH_NAME'","base":"main"}'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,6 +8,7 @@ on:
   push:
     paths-ignore:
       - "**.md"
+      - "releases.json"
 env:
   SA_PASSWORD: ${{ secrets.DB_IMAGE_SA_PASSWORD }}
   ADMIN_API_KEY: ${{ secrets.OD_IMAGE_ADMIN_API_KEY }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '**.md'
+      - "releases.json"
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[sc-41298]

This change creates a PR with the latest releases as releases.json in the repository. This is to avoid rate limiting on the install-octopus-cli steps for both GH actions and ADO. Tokens can be used to avoid rate limiting. However, this isn't viable as GH branch protections prevent generic public tokens from accessing our releases. These tokens are also not generated automatically in ADO so instead this approach allows us to use `https://raw.githubusercontent.com/OctopusDeploy/cli/releases.json` which is not rate limited.

Functionality and generated PR tested on https://github.com/OctopusDeploy/Isaac-Actions-Test/pull/19. I didn't have access to gpg keys etc [to test e2e](https://github.com/OctopusDeploy/Isaac-Actions-Test/actions/runs/4911571245/jobs/8769726720), however am confident that the PR creation functionality is working as expected when ran individually. 