### PR TITLE
fix: added support for project slugs to release commands

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -238,7 +238,6 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 			// the Q&A process will have modified options;backfill into flags for generation of the automation cmd
 			resolvedFlags := NewCreateFlags()
 			// deliberately don't include resolvedFlags.PackageVersion in the automation command; it gets converted into PackageVersionSpec
-
 			resolvedFlags.Project.Value = options.ProjectName
 			resolvedFlags.PackageVersionSpec.Value = options.PackageVersionOverrides
 			resolvedFlags.Channel.Value = options.ChannelName

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -238,6 +238,7 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 			// the Q&A process will have modified options;backfill into flags for generation of the automation cmd
 			resolvedFlags := NewCreateFlags()
 			// deliberately don't include resolvedFlags.PackageVersion in the automation command; it gets converted into PackageVersionSpec
+
 			resolvedFlags.Project.Value = options.ProjectName
 			resolvedFlags.PackageVersionSpec.Value = options.PackageVersionOverrides
 			resolvedFlags.Channel.Value = options.ChannelName
@@ -260,6 +261,14 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 				resolvedFlags.Version,
 			)
 			cmd.Printf("\nAutomation Command: %s\n", autoCmd)
+		}
+	} else {
+		if options.ProjectName != "" {
+			project, err := selectors.FindProject(octopus, options.ProjectName)
+			if err != nil {
+				return err
+			}
+			options.ProjectName = project.GetName()
 		}
 	}
 

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1239,6 +1239,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/CaC Project").RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1285,6 +1286,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1331,6 +1333,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			// don't need to validate the json received by the server, we've done that already
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1").RespondWith(&releases.CreateReleaseResponseV1{
@@ -1362,6 +1365,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			// don't need to validate the json received by the server, we've done that already
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1").RespondWith(&releases.CreateReleaseResponseV1{
@@ -1393,6 +1397,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1438,6 +1443,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1513,6 +1519,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1583,6 +1590,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1648,6 +1656,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 
@@ -1716,6 +1725,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+cacProject.GetName()).RespondWith(cacProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/create/v1")
 

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -285,6 +285,15 @@ func deployRun(cmd *cobra.Command, f factory.Factory, flags *DeployFlags) error 
 				cmd.Printf("%s\n", output.Yellow("Warning: Command includes some sensitive variable values which have been replaced with placeholders."))
 			}
 		}
+	} else {
+		if options.ProjectName != "" {
+			project, err := selectors.FindProject(octopus, options.ProjectName)
+			if err != nil {
+				return err
+			}
+			options.ProjectName = project.GetName()
+		}
+
 	}
 
 	// the executor will raise errors if any required options are missing

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -1092,6 +1092,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			_, err := testutil.ReceivePair(cmdReceiver)
 			assert.EqualError(t, err, "release version must be specified")
@@ -1109,6 +1110,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			_, err := testutil.ReceivePair(cmdReceiver)
 			assert.EqualError(t, err, "environment(s) must be specified")
@@ -1126,6 +1128,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			// Note: because we didn't specify --tenant or --tenant-tag, automation-mode code is going to assume untenanted
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/untenanted/v1")
@@ -1175,6 +1178,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			// Note: because we didn't specify --tenant or --tenant-tag, automation-mode code is going to assume untenanted
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/untenanted/v1").RespondWith(&deployments.CreateDeploymentResponseV1{
@@ -1204,6 +1208,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			// Note: because we didn't specify --tenant or --tenant-tag, automation-mode code is going to assume untenanted
 			serverTasks := []*deployments.DeploymentServerTask{
@@ -1234,6 +1239,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/tenanted/v1")
 			requestBody, err := testutil.ReadJson[deployments.CreateDeploymentTenantedCommandV1](req.Request.Body)
@@ -1282,6 +1288,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/tenanted/v1")
 			requestBody, err := testutil.ReadJson[deployments.CreateDeploymentTenantedCommandV1](req.Request.Body)
@@ -1345,6 +1352,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			// Note: because we didn't specify --tenant or --tenant-tag, automation-mode code is going to assume untenanted
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/untenanted/v1")
@@ -1414,6 +1422,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/tenanted/v1")
 			requestBody, err := testutil.ReadJson[deployments.CreateDeploymentTenantedCommandV1](req.Request.Body)


### PR DESCRIPTION
fixes #229 

[sc-48988]

before: 
```
octopus release create -p bulk-project-1 -c default -s "bulk project" --no-prompt
Octopus API error: Project named 'bulk-project-1' was not found. []
```

```
octopus release deploy -s Spaces-123 -p bulk-project-1 --version 0.0.6 -e "test 1" --no-prompt
Octopus API error: Project named 'bulk-project-1' was not found. []
```

after:
```
octopus release create -p bulk-project-1 -c default -s Spaces-123 -v 0.0.7 --no-prompt
Successfully created release version 0.0.7 using channel Default

View this release on Octopus Deploy: http://localhost:8065/app#/Spaces-123/releases/Releases-3522
```

```
octopus release deploy -s Spaces-123 -p bulk-project-1 --version 0.0.6 -e "test 1" --no-prompt
Successfully started 1 deployment(s)
```