### PR TITLE
Update go-releaser.yml

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -275,6 +275,7 @@ jobs:
           run: |
             git config user.email 'bob@octopus.com'
             git config user.name octobob
+            git fetch
             git checkout main
             git checkout -b $BRANCH_NAME
 


### PR DESCRIPTION
The original change configures the git context assuming the GH action is running against main. the go-releaser action runs against a tagged version i.e. v1.2.1.

Resolved by adding a git fetch call prior to checking out main.

GH action with reproduced error - https://github.com/OctopusDeploy/Isaac-Actions-Test/actions/runs/4956303398
Resolved after adding a git fetch - https://github.com/OctopusDeploy/Isaac-Actions-Test/actions/runs/4956303398