### PR TITLE
Use Integrations Token over GHA Token for PR permissions

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -258,7 +258,7 @@ jobs:
     needs: [goreleaser, msi, generate-packages-and-publish]
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INTEGRATIONS_TOKEN: ${{ secrets.INTEGRATIONS_FNM_BOT_TOKEN }}
 
     steps:
         - name: Calculate branch name
@@ -294,11 +294,11 @@ jobs:
             add: releases.json
             push: false
 
-        - run: git push --repo https:/octobob:$GITHUB_TOKEN@github.com/OctopusDeploy/cli.git --set-upstream origin $BRANCH_NAME
+        - run: git push --repo https:/octobob:$INTEGRATIONS_TOKEN@github.com/OctopusDeploy/cli.git --set-upstream origin $BRANCH_NAME
           working-directory: cli
 
         - name: Create PR
           run: |
-            curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" \
+            curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $INTEGRATIONS_TOKEN" \
             https://api.github.com/repos/OctopusDeploy/cli/pulls \
             -d '{"title":"update cli releases.json","body":"An automated update of the releases.json for octopus CLI\nCreated by GitHub Actions [go-releaser](https://github.com/OctopusDeploy/cli/actions/workflows/go-releaser.yml)","head":"'$BRANCH_NAME'","base":"main"}'


### PR DESCRIPTION
GH action update-releases.json is failing when creating a PR due to GITHUB_TOKEN permissions. INTEGRATIONS_TOKEN has these permissions and is being used instead. See Create_PR - https://github.com/OctopusDeploy/cli/actions/runs/5040370886/jobs/9039191314

I've attempted to confirm this will not hit other organisation restrictions over in [my test project ](https://github.com/OctopusDeploy/Isaac-Actions-Test/pulls), however am waiting on approval for my OctopusDeploy organisation scoped token.