### PR TITLE
chore: updated action workflow file

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -48,7 +48,7 @@ jobs:
           author_email: bob@octopus.com
           committer_name: bob
           cwd: docs
-          add: docs/octopus-rest-api/cli
+          add: src/pages/docs/octopus-rest-api/cli
           push: false
 
       - run: git push --repo https://octobob:$DOCS_TOKEN@github.com/OctopusDeploy/docs.git --set-upstream origin $BRANCH_NAME


### PR DESCRIPTION
Another broken path in the `generate docs` workflow
Ran against this branch and it produced this docs pr https://github.com/OctopusDeploy/docs/pull/1908/files