### PR TITLE
feat: project variable git support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.28.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.29.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.28.0 h1:7BegZkhNkY6MKgOf0ekNgsRNlvE4lBdzy84zVG+c1+0=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.28.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.29.0 h1:hkFszgjRnXTv54bmgeHLzIoTP1o52QUy57JtHFFfu/Y=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.29.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/project/branch/branch.go
+++ b/pkg/cmd/project/branch/branch.go
@@ -1,0 +1,33 @@
+package branch
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/spf13/cobra"
+
+	cmdCreate "github.com/OctopusDeploy/cli/pkg/cmd/project/branch/create"
+	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/project/branch/list"
+)
+
+func NewCmdBranch(f factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "branch <command>",
+		Aliases: []string{"variable"},
+		Short:   "Manage project branches",
+		Long:    "Manage project branches in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s project branch list "Deploy Web App"
+			$ %[1]s project branch create -p "Deploy Web App" --new-branch-name add-name-variable --base-branch refs/heads/main -
+		`, constants.ExecutableName),
+		Annotations: map[string]string{
+			annotations.IsCore: "true",
+		},
+	}
+
+	cmd.AddCommand(cmdList.NewCmdList(f))
+	cmd.AddCommand(cmdCreate.NewCreateCmd(f))
+
+	return cmd
+}

--- a/pkg/cmd/project/branch/branch.go
+++ b/pkg/cmd/project/branch/branch.go
@@ -27,7 +27,7 @@ func NewCmdBranch(f factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
-	cmd.AddCommand(cmdCreate.NewCreateCmd(f))
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f))
 
 	return cmd
 }

--- a/pkg/cmd/project/branch/create/create.go
+++ b/pkg/cmd/project/branch/create/create.go
@@ -1,0 +1,170 @@
+package create
+
+import (
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	sharedBranches "github.com/OctopusDeploy/cli/pkg/cmd/project/branch/shared"
+	"github.com/OctopusDeploy/cli/pkg/cmd/tenant/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagProject    = "project"
+	FlagName       = "name"
+	FlagBaseBranch = "base-branch"
+)
+
+type CreateFlags struct {
+	Project    *flag.Flag[string]
+	Name       *flag.Flag[string]
+	BaseBranch *flag.Flag[string]
+}
+
+type CreateOptions struct {
+	*CreateFlags
+	*cmd.Dependencies
+	shared.GetProjectCallback
+	shared.GetAllProjectsCallback
+	*sharedBranches.ProjectBranchCallbacks
+}
+
+func NewCreateFlags() *CreateFlags {
+	return &CreateFlags{
+		Project:    flag.New[string](FlagProject, false),
+		Name:       flag.New[string](FlagName, false),
+		BaseBranch: flag.New[string](FlagBaseBranch, false),
+	}
+}
+
+func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  flags,
+		Dependencies: dependencies,
+		GetProjectCallback: func(identifier string) (*projects.Project, error) {
+			return shared.GetProject(dependencies.Client, identifier)
+		},
+		GetAllProjectsCallback: func() ([]*projects.Project, error) { return shared.GetAllProjects(dependencies.Client) },
+		ProjectBranchCallbacks: sharedBranches.NewProjectBranchCallbacks(dependencies),
+	}
+}
+
+func NewCreateCmd(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a Git branch for a project",
+		Long:    "Create a Git branch for a project in Octopus Deploy",
+		Aliases: []string{"add"},
+		Example: heredoc.Docf(`
+			$ %[1]s project branch create
+			$ %[1]s project branch create --project "Deploy Website" --name branch-nane --base-branch refs/heads/main
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
+
+			return CreateRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Project.Value, createFlags.Project.Name, "p", "", "The project")
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "The name of the branch")
+	flags.StringVarP(&createFlags.BaseBranch.Value, createFlags.BaseBranch.Name, "", "", "The git-ref branch to create a new branch from")
+
+	return cmd
+}
+
+func CreateRun(opts *CreateOptions) error {
+	if !opts.NoPrompt {
+		err := PromptMissing(opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	project, err := opts.GetProjectCallback(opts.Project.Value)
+	if err != nil {
+		return err
+	}
+
+	newBranch, err := opts.Client.ProjectBranches.Add(opts.Space.GetID(), project.GetID(), opts.BaseBranch.Value, opts.Name.Value)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(opts.Out, "Successfully created branch '%s' (%s) in project '%s'\n", opts.Name.Value, newBranch.CanonicalName, project.GetName())
+
+	if !opts.NoPrompt {
+		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Project, opts.Name, opts.BaseBranch)
+		fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
+	}
+
+	return nil
+}
+
+func PromptMissing(opts *CreateOptions) error {
+	var project *projects.Project
+	var err error
+	if opts.Project.Value == "" {
+		project, err = projectSelector("You have not specified a Project. Please select one:", opts.GetAllProjectsCallback, opts.Ask)
+		if err != nil {
+			return nil
+		}
+		opts.Project.Value = project.GetName()
+	} else {
+		project, err = opts.GetProjectCallback(opts.Project.Value)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.Name.Value == "" {
+		if err := opts.Ask(&survey.Input{
+			Message: "Name",
+			Help:    fmt.Sprintf("A name for the new branch."),
+		}, &opts.Name.Value, survey.WithValidator(survey.ComposeValidators(
+			survey.MaxLength(200),
+			survey.MinLength(1),
+			survey.Required,
+		))); err != nil {
+			return err
+		}
+	}
+
+	if opts.BaseBranch.Value == "" {
+		branch, err := branchSelector("You have not specified a base branch. Please select one:", project.GetID(), opts)
+		if err != nil {
+			return err
+		}
+		opts.BaseBranch.Value = branch.CanonicalName
+	}
+
+	return nil
+}
+
+func projectSelector(questionText string, getAllProjectsCallback shared.GetAllProjectsCallback, ask question.Asker) (*projects.Project, error) {
+	existingProjects, err := getAllProjectsCallback()
+	if err != nil {
+		return nil, err
+	}
+
+	versionControlledProjects := util.SliceFilter(existingProjects, func(p *projects.Project) bool { return p.IsVersionControlled })
+	return question.SelectMap(ask, questionText, versionControlledProjects, func(p *projects.Project) string { return p.GetName() })
+}
+
+func branchSelector(questionText string, projectId string, opts *CreateOptions) (*projects.GitReference, error) {
+	branches, err := opts.GetAllBranchesCallback(projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	return question.SelectMap(opts.Ask, questionText, branches, func(b *projects.GitReference) string { return b.CanonicalName })
+}

--- a/pkg/cmd/project/branch/create/create.go
+++ b/pkg/cmd/project/branch/create/create.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/cmd"
@@ -56,7 +57,7 @@ func NewCreateOptions(flags *CreateFlags, dependencies *cmd.Dependencies) *Creat
 	}
 }
 
-func NewCreateCmd(f factory.Factory) *cobra.Command {
+func NewCmdCreate(f factory.Factory) *cobra.Command {
 	createFlags := NewCreateFlags()
 	cmd := &cobra.Command{
 		Use:     "create",

--- a/pkg/cmd/project/branch/create/create_test.go
+++ b/pkg/cmd/project/branch/create/create_test.go
@@ -1,0 +1,59 @@
+package create_test
+
+import (
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/project/branch/create"
+	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPromptMissing_AllFlagsSupplied(t *testing.T) {
+	pa := []*testutil.PA{}
+
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
+	flags := create.NewCreateFlags()
+	flags.Project.Value = "Project"
+	flags.BaseBranch.Value = "refs/heads/main"
+	flags.Name.Value = "newvar"
+	opts := create.NewCreateOptions(flags, &cmd.Dependencies{Ask: asker})
+	opts.GetProjectCallback = func(identifier string) (*projects.Project, error) {
+		return projects.NewProject("Project", "Lifecycles-1", "ProjectGroups-1"), nil
+	}
+
+	err := create.PromptMissing(opts)
+	checkRemainingPrompts()
+	assert.NoError(t, err)
+}
+
+func TestPromptMissing_NoFlagsSupplied(t *testing.T) {
+	project1 := projects.NewProject("Project", "Lifecycles-1", "ProjectGroups-1")
+	project1.IsVersionControlled = true
+	project2 := projects.NewProject("Project 2", "Lifecycles-1", "ProjectGroups-1")
+	project2.IsVersionControlled = true
+
+	pa := []*testutil.PA{
+		testutil.NewSelectPrompt("You have not specified a Project. Please select one:", "", []string{project1.Name, project2.Name}, project1.Name),
+		testutil.NewInputPrompt("Name", "A name for the new branch.", "newbranch"),
+		testutil.NewSelectPrompt("You have not specified a base branch. Please select one:", "", []string{"refs/heads/main", "refs/heads/second-branch"}, "refs/heads/main"),
+	}
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
+	flags := create.NewCreateFlags()
+	opts := create.NewCreateOptions(flags, &cmd.Dependencies{Ask: asker})
+	opts.GetAllProjectsCallback = func() ([]*projects.Project, error) {
+		return []*projects.Project{project1, project2}, nil
+	}
+	opts.GetAllBranchesCallback = func(projectId string) ([]*projects.GitReference, error) {
+		return []*projects.GitReference{
+			projects.NewGitBranchReference("main", "refs/heads/main"),
+			projects.NewGitBranchReference("second-branch", "refs/heads/second-branch"),
+		}, nil
+	}
+
+	err := create.PromptMissing(opts)
+	checkRemainingPrompts()
+	assert.NoError(t, err)
+	assert.Equal(t, "newbranch", opts.Name.Value)
+	assert.Equal(t, "refs/heads/main", opts.BaseBranch.Value)
+}

--- a/pkg/cmd/project/branch/list/list.go
+++ b/pkg/cmd/project/branch/list/list.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	FlagProject = "project"
-	FlagGitRef  = "gitref"
+	FlagGitRef  = "git-ref"
 )
 
 type ListFlags struct {

--- a/pkg/cmd/project/branch/list/list.go
+++ b/pkg/cmd/project/branch/list/list.go
@@ -1,0 +1,118 @@
+package list
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/tenant/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	sharedVariable "github.com/OctopusDeploy/cli/pkg/question/shared/variables"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectbranches"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/spf13/cobra"
+	"strconv"
+)
+
+const (
+	FlagProject = "project"
+	FlagGitRef  = "git-ref"
+)
+
+type ListFlags struct {
+	GitRef  *flag.Flag[string]
+	Project *flag.Flag[string]
+}
+
+func NewListFlags() *ListFlags {
+	return &ListFlags{
+		GitRef:  flag.New[string](FlagGitRef, false),
+		Project: flag.New[string](FlagProject, false),
+	}
+}
+
+type ListOptions struct {
+	*ListFlags
+	Command            *cobra.Command
+	GetProjectCallback shared.GetProjectCallback
+	*sharedVariable.VariableCallbacks
+	*cmd.Dependencies
+}
+
+func NewListOptions(flags *ListFlags, dependencies *cmd.Dependencies, cmd *cobra.Command) *ListOptions {
+	return &ListOptions{
+		ListFlags:    flags,
+		Command:      cmd,
+		Dependencies: dependencies,
+		GetProjectCallback: func(identifier string) (*projects.Project, error) {
+			return shared.GetProject(dependencies.Client, identifier)
+		},
+	}
+}
+
+type BranchesAsJson struct {
+	*projects.GitReference
+}
+
+func NewCmdList(f factory.Factory) *cobra.Command {
+	listFlags := NewListFlags()
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List project branches",
+		Long:  "List project branches in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s project branch list "Deploy Website"
+			$ %[1]s project variable ls
+		`, constants.ExecutableName),
+		Aliases: []string{"ls"},
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := NewListOptions(listFlags, cmd.NewDependencies(f, c), c)
+
+			if opts.Project.Value == "" {
+				opts.Project.Value = args[0]
+			}
+
+			if opts.Project.Value == "" {
+				return fmt.Errorf("must supply project identifier")
+			}
+			return listRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&listFlags.GitRef.Value, listFlags.GitRef.Name, "", "", "The git-ref for the Config-As-Code branch")
+	flags.StringVarP(&listFlags.Project.Value, listFlags.Project.Name, "p", "", "The project")
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	project, err := opts.GetProjectCallback(opts.Project.Value)
+	if err != nil {
+		return err
+	}
+
+	branches, err := opts.Client.ProjectBranches.Get(opts.Space.GetID(), project.GetID(), projectbranches.ProjectBranchQuery{Skip: 0, Take: 1000})
+	if err != nil {
+		return err
+	}
+
+	return output.PrintArray(branches.Items, opts.Command, output.Mappers[*projects.GitReference]{
+		Json: func(b *projects.GitReference) any {
+			return BranchesAsJson{
+				GitReference: b,
+			}
+		},
+		Table: output.TableDefinition[*projects.GitReference]{
+			Header: []string{"NAME", "CANONICAL NAME", "IS PROTECTED"},
+			Row: func(b *projects.GitReference) []string {
+				return []string{output.Bold(b.Name), b.CanonicalName, strconv.FormatBool(b.IsProtected)}
+			},
+		},
+		Basic: func(b *projects.GitReference) string {
+			return b.Name
+		},
+	})
+}

--- a/pkg/cmd/project/branch/shared/shared.go
+++ b/pkg/cmd/project/branch/shared/shared.go
@@ -1,0 +1,30 @@
+package shared
+
+import (
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectbranches"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+)
+
+type GetAllBranchesCallback func(projectId string) ([]*projects.GitReference, error)
+
+type ProjectBranchCallbacks struct {
+	GetAllBranchesCallback GetAllBranchesCallback
+}
+
+func NewProjectBranchCallbacks(dependencies *cmd.Dependencies) *ProjectBranchCallbacks {
+	return &ProjectBranchCallbacks{
+		GetAllBranchesCallback: func(projectId string) ([]*projects.GitReference, error) {
+			return getAllBranches(dependencies.Client, dependencies.Space.GetID(), projectId)
+		},
+	}
+}
+
+func getAllBranches(client *client.Client, spaceId string, projectId string) ([]*projects.GitReference, error) {
+	branches, err := client.ProjectBranches.Get(spaceId, projectId, projectbranches.ProjectBranchQuery{Skip: 0, Take: 9999})
+	if err != nil {
+		return nil, err
+	}
+	return branches.Items, nil
+}

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	cmdBranch "github.com/OctopusDeploy/cli/pkg/cmd/project/branch"
 	cmdClone "github.com/OctopusDeploy/cli/pkg/cmd/project/clone"
 	cmdConnect "github.com/OctopusDeploy/cli/pkg/cmd/project/connect"
 	cmdConvert "github.com/OctopusDeploy/cli/pkg/cmd/project/convert"
@@ -41,6 +42,7 @@ func NewCmdProject(f factory.Factory) *cobra.Command {
 	cmd.AddCommand(cmdConvert.NewCmdConvert(f))
 	cmd.AddCommand(cmdVariables.NewCmdVariables(f))
 	cmd.AddCommand(cmdClone.NewCmdClone(f))
+	cmd.AddCommand(cmdBranch.NewCmdBranch(f))
 
 	return cmd
 }

--- a/pkg/cmd/project/variables/create/create.go
+++ b/pkg/cmd/project/variables/create/create.go
@@ -26,7 +26,7 @@ const (
 	FlagValue       = "value"
 	FlagType        = "type"
 	FlagDescription = "description"
-	FlagGitRef      = "gitref"
+	FlagGitRef      = "git-ref"
 
 	FlagPrompt              = "prompted"
 	FlagPromptLabel         = "prompt-label"
@@ -117,7 +117,7 @@ func NewCreateCmd(f factory.Factory) *cobra.Command {
 			$ %[1]s project variable create --project "Deploy Website" --name varname --value "abc"
 			$ %[1]s project variable create --name varname --value "passwordABC" --type sensitive
 			$ %[1]s project variable create --name varname --value "abc" --scope environment='test'
-			$ %[1]s project variable create --name varname --value "abc" --scope environment='test' --gitref refs/heads/main
+			$ %[1]s project variable create --name varname --value "abc" --scope environment='test' --git-ref refs/heads/main
 		`, constants.ExecutableName),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
@@ -134,7 +134,7 @@ func NewCreateCmd(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "The name of the variable")
 	flags.StringVarP(&createFlags.Type.Value, createFlags.Type.Name, "t", "", fmt.Sprintf("The type of variable. Valid values are %s. Default is %s", strings.Join([]string{TypeText, TypeSensitive, TypeWorkerPool, TypeAwsAccount, TypeAzureAccount, TypeGoogleAccount, TypeCertificate}, ", "), TypeText))
 	flags.StringVar(&createFlags.Value.Value, createFlags.Value.Name, "", "The value to set on the variable")
-	flags.StringVarP(&createFlags.GitRef.Value, createFlags.GitRef.Name, "", "", "The git-ref for the Config-As-Code branch")
+	flags.StringVarP(&createFlags.GitRef.Value, createFlags.GitRef.Name, "", "", "The GitRef for the Config-As-Code branch")
 
 	sharedProjectVariable.RegisterScopeFlags(cmd, createFlags.ScopeFlags)
 	flags.BoolVar(&createFlags.IsPrompted.Value, createFlags.IsPrompted.Name, false, "Make a prompted variable")

--- a/pkg/cmd/project/variables/create/create_test.go
+++ b/pkg/cmd/project/variables/create/create_test.go
@@ -175,3 +175,33 @@ func TestPromptMissing_PromptedVariableForSelectOptions(t *testing.T) {
 	checkRemainingPrompts()
 	assert.Equal(t, []string{"value1|display 1", "value2|display 2"}, opts.PromptSelectOptions.Value)
 }
+
+func TestPromptVersionControl_NoFlagsSupplied_ExistingBranch(t *testing.T) {
+	pa := []*testutil.PA{
+		testutil.NewInputPrompt("GitRef", "The GitRef where the variable is stored", "refs/heads/main"),
+	}
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
+	flags := create.NewCreateFlags()
+	opts := create.NewCreateOptions(flags, &cmd.Dependencies{Ask: asker})
+	project := projects.NewProject("Project", "Lifecycles-1", "ProjectGroups-1")
+	project.IsVersionControlled = true
+
+	err := create.PromptVersionControl(opts, project)
+	checkRemainingPrompts()
+	assert.NoError(t, err)
+	assert.Equal(t, "refs/heads/main", opts.GitRef.Value)
+}
+
+func TestPromptVersionControl_ProjectNotVersionControlled(t *testing.T) {
+	pa := []*testutil.PA{}
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
+	flags := create.NewCreateFlags()
+	opts := create.NewCreateOptions(flags, &cmd.Dependencies{Ask: asker})
+	project := projects.NewProject("Project", "Lifecycles-1", "ProjectGroups-1")
+	project.IsVersionControlled = false
+
+	err := create.PromptVersionControl(opts, project)
+	checkRemainingPrompts()
+	assert.NoError(t, err)
+	assert.Equal(t, "", opts.GitRef.Value)
+}

--- a/pkg/cmd/project/variables/list/list.go
+++ b/pkg/cmd/project/variables/list/list.go
@@ -2,6 +2,9 @@ package list
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/cmd"
 	variableShared "github.com/OctopusDeploy/cli/pkg/cmd/project/variables/shared"
@@ -14,8 +17,6 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/spf13/cobra"
-	"sort"
-	"strconv"
 )
 
 const (
@@ -98,8 +99,6 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return err
 	}
-
-	//var vars *variables.VariableSet
 
 	var allVariables []*variables.Variable
 	vars, err := opts.GetProjectVariables(project.GetID())

--- a/pkg/cmd/project/variables/list/list.go
+++ b/pkg/cmd/project/variables/list/list.go
@@ -63,7 +63,7 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		Long:  "List project variables in Octopus Deploy",
 		Example: heredoc.Docf(`
 			$ %[1]s project variable list "Deploy Website"
-			$ %[1]s project variable list -p "Deploy Website" --git-ref refs/head/main
+			$ %[1]s project variable list -p "Deploy Website" --git-ref refs/heads/main
 			$ %[1]s project variable ls
 		`, constants.ExecutableName),
 		Aliases: []string{"ls"},
@@ -82,7 +82,7 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&listFlags.GitRef.Value, listFlags.GitRef.Name, "", "", "The git-ref for the Config-As-Code branch")
+	flags.StringVarP(&listFlags.GitRef.Value, listFlags.GitRef.Name, "", "", "The GitRef for the Config-As-Code branch")
 	flags.StringVarP(&listFlags.Project.Value, listFlags.Project.Name, "p", "", "The project")
 
 	return cmd

--- a/pkg/cmd/project/variables/update/update.go
+++ b/pkg/cmd/project/variables/update/update.go
@@ -27,7 +27,7 @@ const (
 	FlagName     = "name"
 	FlagValue    = "value"
 	FlagUnscoped = "unscoped"
-	FlagGitRef   = "gitref"
+	FlagGitRef   = "git-ref"
 )
 
 type UpdateFlags struct {
@@ -85,7 +85,7 @@ func NewUpdateCmd(f factory.Factory) *cobra.Command {
 			$ %[1]s project variable update --name varname --value "password"
 			$ %[1]s project variable update --name varname --unscoped
 			$ %[1]s project variable update --name varname --environment-scope test
-			$ %[1]s project variable update -p "Deploy Website" --name varname --value "updated" --gitref refs/head/main
+			$ %[1]s project variable update -p "Deploy Website" --name varname --value "updated" --git-ref refs/heads/main
 		`, constants.ExecutableName),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := NewUpdateOptions(updateFlags, cmd.NewDependencies(f, c))

--- a/pkg/cmd/project/variables/update/update.go
+++ b/pkg/cmd/project/variables/update/update.go
@@ -168,7 +168,7 @@ func updateRun(opts *UpdateOptions) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(opts.Out, "Successfully updated variable '%s' in project '%s'\n", opts.Name.Value, project.GetName())
+	_, err = fmt.Fprintf(opts.Out, "Successfully updated variable '%s' in project '%s'\n", variable.Name, project.GetName())
 
 	if !opts.NoPrompt {
 		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Id, opts.Name, opts.Value, opts.Project, opts.EnvironmentsScopes, opts.ChannelScopes, opts.StepScopes, opts.TargetScopes, opts.TagScopes, opts.RoleScopes, opts.ProcessScopes, opts.Unscoped, opts.GitRef)

--- a/pkg/cmd/project/variables/update/update.go
+++ b/pkg/cmd/project/variables/update/update.go
@@ -27,6 +27,7 @@ const (
 	FlagName     = "name"
 	FlagValue    = "value"
 	FlagUnscoped = "unscoped"
+	FlagGitRef   = "gitref"
 )
 
 type UpdateFlags struct {
@@ -35,6 +36,7 @@ type UpdateFlags struct {
 	Name     *flag.Flag[string]
 	Value    *flag.Flag[string]
 	Unscoped *flag.Flag[bool]
+	GitRef   *flag.Flag[string]
 
 	*sharedProjectVariable.ScopeFlags
 }
@@ -54,6 +56,7 @@ func NewUpdateFlags() *UpdateFlags {
 		Name:       flag.New[string](FlagName, false),
 		Value:      flag.New[string](FlagValue, false),
 		Unscoped:   flag.New[bool](FlagUnscoped, false),
+		GitRef:     flag.New[string](FlagGitRef, false),
 		ScopeFlags: sharedProjectVariable.NewScopeFlags(),
 	}
 }
@@ -82,6 +85,7 @@ func NewUpdateCmd(f factory.Factory) *cobra.Command {
 			$ %[1]s project variable update --name varname --value "password"
 			$ %[1]s project variable update --name varname --unscoped
 			$ %[1]s project variable update --name varname --environment-scope test
+			$ %[1]s project variable update -p "Deploy Website" --name varname --value "updated" --gitref refs/head/main
 		`, constants.ExecutableName),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := NewUpdateOptions(updateFlags, cmd.NewDependencies(f, c))
@@ -96,6 +100,7 @@ func NewUpdateCmd(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&updateFlags.Name.Value, updateFlags.Name.Name, "n", "", "The name of the variable")
 	flags.StringVar(&updateFlags.Value.Value, updateFlags.Value.Name, "", "The value to set on the variable")
 	flags.BoolVar(&updateFlags.Unscoped.Value, updateFlags.Unscoped.Name, false, "Remove all shared from the variable, cannot be used with shared")
+	flags.StringVarP(&updateFlags.GitRef.Value, updateFlags.GitRef.Name, "", "", "The GitRef for the Config-As-Code branch")
 	sharedProjectVariable.RegisterScopeFlags(cmd, updateFlags.ScopeFlags)
 
 	return cmd
@@ -118,7 +123,12 @@ func updateRun(opts *UpdateOptions) error {
 		return err
 	}
 
-	projectVariables, err := opts.GetProjectVariables(project.GetID())
+	var projectVariables *variables.VariableSet
+	if project.IsVersionControlled && opts.GitRef.Value != "" {
+		projectVariables, err = opts.GetProjectVariablesByGitRef(opts.Space.GetID(), project.GetID(), opts.GitRef.Value)
+	} else {
+		projectVariables, err = opts.GetProjectVariables(project.GetID())
+	}
 	if err != nil {
 		return err
 	}
@@ -149,14 +159,19 @@ func updateRun(opts *UpdateOptions) error {
 		}
 	}
 
-	_, err = opts.Client.Variables.UpdateSingle(project.GetID(), variable)
+	if opts.GitRef.Value != "" {
+		_, err = opts.Client.ProjectVariables.UpdateByGitRef(opts.Space.GetID(), project.GetID(), opts.GitRef.Value, projectVariables)
+	} else {
+		_, err = opts.Client.Variables.UpdateSingle(project.GetID(), variable)
+	}
+
 	if err != nil {
 		return err
 	}
 	_, err = fmt.Fprintf(opts.Out, "Successfully updated variable '%s' in project '%s'\n", opts.Name.Value, project.GetName())
 
 	if !opts.NoPrompt {
-		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Id, opts.Name, opts.Value, opts.Project, opts.EnvironmentsScopes, opts.ChannelScopes, opts.StepScopes, opts.TargetScopes, opts.TagScopes, opts.RoleScopes, opts.ProcessScopes, opts.Unscoped)
+		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Id, opts.Name, opts.Value, opts.Project, opts.EnvironmentsScopes, opts.ChannelScopes, opts.StepScopes, opts.TargetScopes, opts.TagScopes, opts.RoleScopes, opts.ProcessScopes, opts.Unscoped, opts.GitRef)
 		fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
 	}
 
@@ -167,25 +182,28 @@ func getVariable(opts *UpdateOptions, project *projects.Project, projectVariable
 	var variable *variables.Variable
 	var err error
 	if opts.Id.Value != "" {
-		variable, err = opts.GetVariableById(project.GetID(), opts.Id.Value)
-		if err != nil {
-			return nil, err
-		}
+		possibleVariables := util.SliceFilter(projectVariables.Variables, func(v *variables.Variable) bool {
+			return strings.EqualFold(v.ID, opts.Id.Value)
+		})
 
-		if variable == nil {
+		if len(possibleVariables) == 0 {
 			return nil, fmt.Errorf("cannot find variable with id '%s'", opts.Id.Value)
+		} else if len(possibleVariables) > 1 {
+			return nil, fmt.Errorf("'%s' has matched multiple variables", opts.Id.Value)
+		} else {
+			variable = possibleVariables[0]
 		}
 	} else {
-		variables := util.SliceFilter(projectVariables.Variables, func(v *variables.Variable) bool {
+		possibleVariables := util.SliceFilter(projectVariables.Variables, func(v *variables.Variable) bool {
 			return strings.EqualFold(v.Name, opts.Name.Value)
 		})
 
-		if len(variables) == 0 {
+		if len(possibleVariables) == 0 {
 			return nil, fmt.Errorf("cannot find variable with name '%s'", opts.Name.Value)
-		} else if len(variables) > 1 {
-			return nil, fmt.Errorf("'%s' has multiple values, supply '%s' flag", variables[0].Name, FlagId)
+		} else if len(possibleVariables) > 1 {
+			return nil, fmt.Errorf("'%s' has multiple values, supply '%s' flag", possibleVariables[0].Name, FlagId)
 		} else {
-			variable = variables[0]
+			variable = possibleVariables[0]
 		}
 	}
 
@@ -208,7 +226,25 @@ func PromptMissing(opts *UpdateOptions) error {
 		}
 	}
 
-	projectVariables, err := opts.GetProjectVariables(project.GetID())
+	if project.IsVersionControlled && opts.GitRef.Value == "" {
+		if err := opts.Ask(&survey.Input{
+			Message: "GitRef",
+			Help:    fmt.Sprintf("The GitRef where the variable is stored"),
+		}, &opts.GitRef.Value, survey.WithValidator(survey.ComposeValidators(
+			survey.MaxLength(200),
+			survey.MinLength(1),
+			survey.Required,
+		))); err != nil {
+			return err
+		}
+	}
+
+	var projectVariables *variables.VariableSet
+	if opts.GitRef.Value != "" {
+		projectVariables, err = opts.GetProjectVariablesByGitRef(opts.Space.GetID(), project.GetID(), opts.GitRef.Value)
+	} else {
+		projectVariables, err = opts.GetProjectVariables(project.GetID())
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/question/shared/variables/variables.go
+++ b/pkg/question/shared/variables/variables.go
@@ -35,17 +35,19 @@ type GetAccountsByTypeCallback func(accountType accounts.AccountType) ([]account
 type GetAllWorkerPoolsCallback func() ([]*workerpools.WorkerPoolListResult, error)
 type GetAllCertificatesCallback func() ([]*certificates.CertificateResource, error)
 type GetProjectVariablesCallback func(projectId string) (*variables.VariableSet, error)
+type GetProjectVariablesByGitRefCallback func(spaceId string, projectId string, gitRef string) (*variables.VariableSet, error)
 type GetTenantVariablesCallback func(tenant *tenants.Tenant) (*variables.TenantVariables, error)
 type GetVariableByIdCallback func(ownerId, variableId string) (*variables.Variable, error)
 type GetAllLibraryVariableSetsCallback func() ([]*variables.LibraryVariableSet, error)
 
 type VariableCallbacks struct {
-	GetAccountsByType   GetAccountsByTypeCallback
-	GetAllWorkerPools   GetAllWorkerPoolsCallback
-	GetAllCertificates  GetAllCertificatesCallback
-	GetProjectVariables GetProjectVariablesCallback
-	GetVariableById     GetVariableByIdCallback
-	GetTenantVariables  GetTenantVariablesCallback
+	GetAccountsByType           GetAccountsByTypeCallback
+	GetAllWorkerPools           GetAllWorkerPoolsCallback
+	GetAllCertificates          GetAllCertificatesCallback
+	GetProjectVariables         GetProjectVariablesCallback
+	GetProjectVariablesByGitRef GetProjectVariablesByGitRefCallback
+	GetVariableById             GetVariableByIdCallback
+	GetTenantVariables          GetTenantVariablesCallback
 }
 
 func NewVariableCallbacks(dependencies *cmd.Dependencies) *VariableCallbacks {
@@ -61,6 +63,9 @@ func NewVariableCallbacks(dependencies *cmd.Dependencies) *VariableCallbacks {
 		},
 		GetProjectVariables: func(projectId string) (*variables.VariableSet, error) {
 			return getProjectVariables(dependencies.Client, projectId)
+		},
+		GetProjectVariablesByGitRef: func(spaceId string, projectId string, gitRef string) (*variables.VariableSet, error) {
+			return getProjectVariablesByGitRef(dependencies.Client, spaceId, projectId, gitRef)
 		},
 		GetTenantVariables: func(tenant *tenants.Tenant) (*variables.TenantVariables, error) {
 			return getTenantVariables(dependencies.Client, tenant)
@@ -197,6 +202,11 @@ func getAllWorkerPools(client *client.Client) ([]*workerpools.WorkerPoolListResu
 func getProjectVariables(client *client.Client, id string) (*variables.VariableSet, error) {
 	variableSet, err := client.Variables.GetAll(id)
 	return &variableSet, err
+}
+
+func getProjectVariablesByGitRef(client *client.Client, spaceId string, projectId string, gitRef string) (*variables.VariableSet, error) {
+	variableSet, err := client.ProjectVariables.GetAllByGitRef(spaceId, projectId, gitRef)
+	return variableSet, err
 }
 
 func getTenantVariables(client *client.Client, tenant *tenants.Tenant) (*variables.TenantVariables, error) {


### PR DESCRIPTION
Depends upon https://github.com/OctopusDeploy/go-octopusdeploy/pull/198

Fixes: #252 

Branches:

Create new branch for project:
```
❯ octopus project branch create -p "cac project" --base-branch refs/heads/main --name second-branch

Successfully created branch 'second-branch' (refs/heads/second-branch) in project 'Cac project'

Automation Command: octopus project branch create --project 'cac project' --name 'second-branch' --base-branch 'refs/heads/main' --no-prompt
```

List branches for project:
```
❯ octopus project branch list -p "cac project"
NAME           CANONICAL NAME            IS PROTECTED
main           refs/heads/main           false
second-branch  refs/heads/second-branch  false
```

Create variable on CaC branch:
```
❯ octopus project variable create -p "cac project" --git-ref refs/heads/main -n variable --value "variable value" --no-prompt
Successfully created variable 'variable' in project 'Cac project'
```

```
❯ octopus project variable create -p "cac project" --git-ref refs/heads/second-branch -n branch-variable --value "variable value on branch" --no-prompt
Successfully created variable 'branch-variable' in project 'Cac project'
```

List variable for specific branch, this lists variables from the git db storage as sensitive variables are only allowed in db storage:
```
❯ octopus project variable list "cac project" --git-ref refs/heads/main
NAME             DESCRIPTION  VALUE           IS PROMPTED  ID
sensitive                     ***             false        aa978b91-5846-afe6-c464-0801b59e9961
sensitive var                 ***             false        6b8766ca-74af-4fbd-bbed-7494fbafb1e4
sensitive var 2               ***             false        e8f65787-8ea2-460e-94e9-417179a3f368
sensitive var 3               ***             false        5cba1afd-34e1-4fd6-837a-4ecb29adbd53
variable                      variable value  false        variable-1
```

```
❯ octopus project variable list -p "cac project" --git-ref refs/heads/second-branch
NAME             DESCRIPTION  VALUE                     IS PROMPTED  ID
branch-variable               variable value on branch  false        branch-variable-1
variable                      variable value            false        variable-1
```

Update variable on branch:
```
❯ octopus project variable update --project "cac project" --git-ref refs/heads/second-branch --id branch-variable-1 --value "updated on branch" --no-prompt
Successfully updated variable 'branch-variable' in project 'Cac project'
```

```
❯ octopus project variable list -p "cac project" --git-ref refs/heads/second-branch
NAME             DESCRIPTION  VALUE              IS PROMPTED  ID
branch-variable               updated on branch  false        branch-variable-1
variable                      variable value     false        variable-1
```

Update sensitive variable and specify a git ref:
```
❯ octopus project variable create --project "cac project" --value "sensitive value" --name "sensitive var 3"  --git-ref refs/heads/main --type sensitive --no-prompt
octopus deploy api returned an error on endpoint /api/Spaces-1/projects/Projects-441/refs%2Fheads%2Fmain/variables - [Sensitive variables can not be saved in Git. Use the non-Git route for sensitive variables.]
```
