### PR TITLE
fixed go-releaser due to deprecated feature

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,12 +23,15 @@ builds:
     binary: "{{ .ProjectName }}"
 
 archives:
-  - replacements:
-      darwin: macOS
-    format_overrides:
+  - format_overrides:
       - goos: windows
         format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- if eq .Os "darwin}}macOS
+      {{- else }}{{ .Os }}_
+      {{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}
 
 nfpms:
   - license: Apache 2.0


### PR DESCRIPTION
archives replacements has been deprecated - https://goreleaser.com/deprecations/#archivesreplacements
