### PR TITLE
fix: prompt checks for git credentials storage was case-sensitive

### DIFF
--- a/pkg/cmd/project/convert/convert.go
+++ b/pkg/cmd/project/convert/convert.go
@@ -235,7 +235,7 @@ func PromptForConfigAsCode(opts *ConvertOptions) (cmd.Dependable, error) {
 		opts.GitStorage.Value = selectedOption.Value
 	}
 
-	if opts.GitStorage.Value == GitStorageLibrary {
+	if strings.EqualFold(opts.GitStorage.Value, GitStorageLibrary) {
 		err := promptLibraryGitCredentials(opts, opts.GetAllGitCredentialsCallback)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
fixes #222 

before: 
```
❯ octopus project create --process-vcs -n ${PWD##*/} -l "Default Lifecycle"  -g "Default Project Group" --git-url $(git config --get remote.origin.url) --git-credentials git-creds --git-credential-store "Library" -s Default
? Git username [? for help]
interrupt
```

after:
```
❯ octopus project create --process-vcs -n ${PWD##*/} -l "Default Lifecycle"  -g "Default Project Group" --git-url $(git config --get remote.origin.url) --git-credentials git-creds --git-credential-store "Library" -s Default
? Git repository base path .octopus/octopus
? Git branch main
? Enter a protected branch pattern (enter blank to end)
? Initial Git commit message Initial commit of deployment process

Successfully created project 'octopus' (octopus), with lifecycle 'Default Lifecycle' in project group 'Default Project Group'.
View this project on Octopus Deploy: http://localhost:8065/app#/Spaces-1/projects/Projects-3802
Successfully configured Config as Code on 'octopus'
```