### PR TITLE
feat: Adds support for authenticating with access token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.31.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.32.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.29.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.31.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.29.0 h1:hkFszgjRnXTv54bmgeHLzIoTP1o52QUy57JtHFFfu/Y=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.29.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.31.0 h1:zHxbQ6TAO4+2hInP3v80X8pkf7CG/araghc9xpxIg2w=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.31.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.31.0 h1:zHxbQ6TAO4+2hInP3v80X8pkf7CG/araghc9xpxIg2w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.31.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.32.0 h1:UWNSsntIp4J+F7JOw4k6Df4gAOg8fBwCyoeBizy1ff4=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.32.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -1,13 +1,14 @@
 package apiclient_test
 
 import (
+	"testing"
+
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
 	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/test/testutil"
 	octopusApiClient "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const serverUrl = "http://server"
@@ -20,7 +21,7 @@ func TestClient_GetSystemClient(t *testing.T) {
 	api := testutil.NewMockHttpServer()
 
 	t.Run("GetSystemClient returns the client", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -40,7 +41,7 @@ func TestClient_GetSystemClient(t *testing.T) {
 	})
 
 	t.Run("GetSystemClient called twice returns the same client instance", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "", qa)
 		testutil.RequireSuccess(t, err)
 		clientReceiver := testutil.GoBegin2(
 			func() (*octopusApiClient.Client, error) {
@@ -80,7 +81,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 		// that in no-prompt mode because otherwise people could write a CI script that worked due to
 		// auto-selection of the first space, which would then unexpectedly break later if someone added a
 		// second space to the octopus server
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -97,7 +98,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient returns an error when a space with the wrong name is specified", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "Integrations", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Integrations", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -115,7 +116,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space ID is directly specified", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "Spaces-7", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Spaces-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -139,7 +140,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space ID is directly specified (case insensitive)", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "spaCeS-7", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "spaCeS-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -163,7 +164,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space Name is directly specified", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "Integrations", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Integrations", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -187,7 +188,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space Name is directly specified (case insensitive)", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "iNtegrationS", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "iNtegrationS", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -217,7 +218,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 		spaces7space := spaces.NewSpace("Spaces-7") // nobody would do this in reality, but our software must still work properly
 		spaces7space.ID = "Spaces-209"
 
-		factory2, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "Spaces-7", qa)
+		factory2, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Spaces-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -243,7 +244,7 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient called twice returns the same client instance without additional requests", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "Integrations", qa)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Integrations", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(

--- a/pkg/apiclient/apiclient_test.go
+++ b/pkg/apiclient/apiclient_test.go
@@ -21,7 +21,8 @@ func TestClient_GetSystemClient(t *testing.T) {
 	api := testutil.NewMockHttpServer()
 
 	t.Run("GetSystemClient returns the client", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -41,7 +42,8 @@ func TestClient_GetSystemClient(t *testing.T) {
 	})
 
 	t.Run("GetSystemClient called twice returns the same client instance", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "", qa)
 		testutil.RequireSuccess(t, err)
 		clientReceiver := testutil.GoBegin2(
 			func() (*octopusApiClient.Client, error) {
@@ -65,7 +67,8 @@ func TestClient_GetSystemClient(t *testing.T) {
 	})
 
 	t.Run("GetSystemClient contains the access token in the right header if supplied", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, "", "token", "", qa)
+		accessTokenCredential, _ := octopusApiClient.NewAccessToken("token")
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, accessTokenCredential, "", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -100,7 +103,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 		// that in no-prompt mode because otherwise people could write a CI script that worked due to
 		// auto-selection of the first space, which would then unexpectedly break later if someone added a
 		// second space to the octopus server
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -117,7 +121,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient returns an error when a space with the wrong name is specified", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Integrations", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "Integrations", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -135,7 +140,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space ID is directly specified", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Spaces-7", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "Spaces-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -159,7 +165,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space ID is directly specified (case insensitive)", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "spaCeS-7", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "spaCeS-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -183,7 +190,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space Name is directly specified", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Integrations", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "Integrations", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -207,7 +215,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient works when the Space Name is directly specified (case insensitive)", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "iNtegrationS", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "iNtegrationS", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -237,7 +246,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 		spaces7space := spaces.NewSpace("Spaces-7") // nobody would do this in reality, but our software must still work properly
 		spaces7space.ID = "Spaces-209"
 
-		factory2, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Spaces-7", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory2, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "Spaces-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -263,7 +273,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient called twice returns the same client instance without additional requests", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "", "Integrations", qa)
+		apiKeyCredential, _ := octopusApiClient.NewApiKey(placeholderApiKey)
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, apiKeyCredential, "Integrations", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(
@@ -294,7 +305,8 @@ func TestClient_GetSpacedClient_NoPrompt(t *testing.T) {
 	})
 
 	t.Run("GetSpacedClient contains the access token in the right header if supplied", func(t *testing.T) {
-		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, "", "token", "Spaces-7", qa)
+		accessTokenCredential, _ := octopusApiClient.NewAccessToken("token")
+		factory, err := apiclient.NewClientFactory(testutil.NewMockHttpClientWithTransport(api), serverUrl, accessTokenCredential, "Spaces-7", qa)
 		testutil.RequireSuccess(t, err)
 
 		clientReceiver := testutil.GoBegin2(

--- a/pkg/apiclient/client_factory_test.go
+++ b/pkg/apiclient/client_factory_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
 	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,28 +38,32 @@ func TestValidateMandatoryEnvironment_WhenHostAndAccessTokenAreSupplied_DoesNotR
 }
 
 func TestNewClientFactory_WhenHostIsNotSupplied_ReturnsError(t *testing.T) {
-	_, err := apiclient.NewClientFactory(nil, "", apiKey, "", "", qa)
+	apiKeyCredential, _ := client.NewApiKey(apiKey)
+	_, err := apiclient.NewClientFactory(nil, "", apiKeyCredential, "", qa)
 	assert.Error(t, err)
 }
 
 func TestNewClientFactory_WhenHostIsNotAValidUrl_ReturnsError(t *testing.T) {
-	_, err := apiclient.NewClientFactory(nil, "http_foo:bar/this-is-invalid", apiKey, "", "", qa)
+	apiKeyCredential, _ := client.NewApiKey(apiKey)
+	_, err := apiclient.NewClientFactory(nil, "http_foo:bar/this-is-invalid", apiKeyCredential, "", qa)
 	assert.Error(t, err)
 }
 
 func TestNewClientFactory_WhenApiKeyAndAccessTokenAreNotSupplied_ReturnsError(t *testing.T) {
-	_, err := apiclient.NewClientFactory(nil, hostUrl, "", "", "", qa)
+	_, err := apiclient.NewClientFactory(nil, hostUrl, nil, "", qa)
 	assert.Error(t, err)
 }
 
 func TestNewClientFactory_WhenHostAndApiKeyAreSupplied_ReturnsClientFactory(t *testing.T) {
-	factory, err := apiclient.NewClientFactory(nil, hostUrl, apiKey, "", "", qa)
+	apiKeyCredential, _ := client.NewApiKey(apiKey)
+	factory, err := apiclient.NewClientFactory(nil, hostUrl, apiKeyCredential, "", qa)
 	testutil.RequireSuccess(t, err)
 	assert.NotNil(t, factory)
 }
 
 func TestNewClientFactory_WhenHostAndAccessTokenAreSupplied_ReturnsClientFactory(t *testing.T) {
-	factory, err := apiclient.NewClientFactory(nil, hostUrl, "", accessToken, "", qa)
+	accessTokenCredential, _ := client.NewAccessToken(accessToken)
+	factory, err := apiclient.NewClientFactory(nil, hostUrl, accessTokenCredential, "", qa)
 	testutil.RequireSuccess(t, err)
 	assert.NotNil(t, factory)
 }

--- a/pkg/apiclient/client_factory_test.go
+++ b/pkg/apiclient/client_factory_test.go
@@ -1,0 +1,64 @@
+package apiclient_test
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+const hostUrl = "http://octopus.com"
+const apiKey = "API-APIKEY01"
+const accessToken = "token"
+
+func TestValidateMandatoryEnvironment_WhenHostIsNotSupplied_ReturnsError(t *testing.T) {
+	err := apiclient.ValidateMandatoryEnvironment("", apiKey, accessToken)
+
+	assert.Error(t, err)
+}
+
+func TestValidateMandatoryEnvironment_WhenApiKeyAndAccessTokenAreNotSupplied_ReturnsError(t *testing.T) {
+	err := apiclient.ValidateMandatoryEnvironment(hostUrl, "", "")
+
+	assert.Error(t, err)
+}
+
+func TestValidateMandatoryEnvironment_WhenHostAndApiKeyAreSupplied_DoesNotReturnError(t *testing.T) {
+	err := apiclient.ValidateMandatoryEnvironment(hostUrl, apiKey, "")
+
+	assert.Nil(t, err)
+}
+
+func TestValidateMandatoryEnvironment_WhenHostAndAccessTokenAreSupplied_DoesNotReturnError(t *testing.T) {
+	err := apiclient.ValidateMandatoryEnvironment(hostUrl, "", accessToken)
+
+	assert.Nil(t, err)
+}
+
+func TestNewClientFactory_WhenHostIsNotSupplied_ReturnsError(t *testing.T) {
+	_, err := apiclient.NewClientFactory(nil, "", apiKey, "", "", qa)
+	assert.Error(t, err)
+}
+
+func TestNewClientFactory_WhenHostIsNotAValidUrl_ReturnsError(t *testing.T) {
+	_, err := apiclient.NewClientFactory(nil, "http_foo:bar/this-is-invalid", apiKey, "", "", qa)
+	assert.Error(t, err)
+}
+
+func TestNewClientFactory_WhenApiKeyAndAccessTokenAreNotSupplied_ReturnsError(t *testing.T) {
+	_, err := apiclient.NewClientFactory(nil, hostUrl, "", "", "", qa)
+	assert.Error(t, err)
+}
+
+func TestNewClientFactory_WhenHostAndApiKeyAreSupplied_ReturnsClientFactory(t *testing.T) {
+	factory, err := apiclient.NewClientFactory(nil, hostUrl, apiKey, "", "", qa)
+	testutil.RequireSuccess(t, err)
+	assert.NotNil(t, factory)
+}
+
+func TestNewClientFactory_WhenHostAndAccessTokenAreSupplied_ReturnsClientFactory(t *testing.T) {
+	factory, err := apiclient.NewClientFactory(nil, hostUrl, "", accessToken, "", qa)
+	testutil.RequireSuccess(t, err)
+	assert.NotNil(t, factory)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,13 +2,14 @@ package config
 
 import (
 	"fmt"
-	"github.com/OctopusDeploy/cli/pkg/constants"
-	"github.com/OctopusDeploy/cli/pkg/util"
-	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/spf13/viper"
 )
 
 const configName = "cli_config"
@@ -39,6 +40,9 @@ func setDefaults(v *viper.Viper) {
 
 func bindEnvironment(v *viper.Viper) error {
 	if err := v.BindEnv(constants.ConfigApiKey, constants.EnvOctopusApiKey); err != nil {
+		return err
+	}
+	if err := v.BindEnv(constants.ConfigAccessToken, constants.EnvOctopusAccessToken); err != nil {
 		return err
 	}
 	if err := v.BindEnv(constants.ConfigUrl, constants.EnvOctopusUrl); err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,10 +28,11 @@ const (
 
 // keys for key/value store config file
 const (
-	ConfigUrl      = "Url"
-	ConfigApiKey   = "ApiKey"
-	ConfigSpace    = "Space"
-	ConfigNoPrompt = "NoPrompt"
+	ConfigUrl         = "Url"
+	ConfigApiKey      = "ApiKey"
+	ConfigAccessToken = "AccessToken"
+	ConfigSpace       = "Space"
+	ConfigNoPrompt    = "NoPrompt"
 	// ConfigProxyUrl     = "ProxyUrl"
 	ConfigEditor       = "Editor"
 	ConfigShowOctopus  = "ShowOctopus"
@@ -39,12 +40,13 @@ const (
 )
 
 const (
-	EnvOctopusUrl    = "OCTOPUS_URL"
-	EnvOctopusApiKey = "OCTOPUS_API_KEY"
-	EnvOctopusSpace  = "OCTOPUS_SPACE"
-	EnvEditor        = "EDITOR"
-	EnvVisual        = "VISUAL"
-	EnvCI            = "CI"
+	EnvOctopusUrl         = "OCTOPUS_URL"
+	EnvOctopusApiKey      = "OCTOPUS_API_KEY"
+	EnvOctopusAccessToken = "OCTOPUS_ACCESS_TOKEN"
+	EnvOctopusSpace       = "OCTOPUS_SPACE"
+	EnvEditor             = "EDITOR"
+	EnvVisual             = "VISUAL"
+	EnvCI                 = "CI"
 )
 
 const (

--- a/test/testutil/fakeoctopusserver.go
+++ b/test/testutil/fakeoctopusserver.go
@@ -159,8 +159,16 @@ type RequestWrapper struct {
 	Server  *MockHttpServer
 }
 
-func (r *RequestWrapper) RespondWith(responseObject any) {
+func (r *RequestWrapper) RespondWith(responseObject any) *RequestWrapper {
 	r.RespondWithStatus(http.StatusOK, "200 OK", responseObject)
+	return r
+}
+
+func (r *RequestWrapper) ExpectHeader(t *testing.T, name string, value string) *RequestWrapper {
+	assert.Contains(t, r.Request.Header, name)
+	headerValues := r.Request.Header[name]
+	assert.Contains(t, headerValues, value)
+	return r
 }
 
 func (r *RequestWrapper) RespondWithStatus(statusCode int, statusString string, responseObject any) {


### PR DESCRIPTION
This PR adds support for authenticating using an access token as a bearer token in the `Authorization` header. Access tokens are obtained using OpenID Connect and by nature are short-lived. As such, storing access tokens in the cli configuration (`octopus config set`) is not supported, and are only read from the `OCTOPUS_ACCESS_TOKEN` environment variable. This environment variable will be set automatically when using the `OctopusDeploy/login` action which is currently only released internally.

Note: This PR requires https://github.com/OctopusDeploy/go-octopusdeploy/pull/201 to be completed and a new version of the `go-octopusdeploy` client to be released before it will build. Update: This PR is merged now.

Note: The OpenID Connect feature is currently under development and may not be available on all Octopus instances at the moment, so this PR doesn't make any changes to the readme for the CLI. Once the feature is released then a follow up PR will add documentation around this.