### PR TITLE
Update fields included in JSON output for workers list

### DIFF
--- a/pkg/cmd/worker/list/list.go
+++ b/pkg/cmd/worker/list/list.go
@@ -49,10 +49,12 @@ func ListRun(opts *ListOptions) error {
 	}
 
 	type TargetAsJson struct {
-		Id          string         `json:"Id"`
-		Name        string         `json:"Name"`
-		Type        string         `json:"Type"`
-		WorkerPools []model.Entity `json:"WorkerPools"`
+		Id            string         `json:"Id"`
+		Name          string         `json:"Name"`
+		Type          string         `json:"Type"`
+		HealthStatus  string         `json:"HealthStatus"`
+		StatusSummary string         `json:"StatusSummary"`
+		WorkerPools   []model.Entity `json:"WorkerPools"`
 	}
 
 	workerPoolMap, err := GetWorkerPoolMap(opts)
@@ -64,10 +66,12 @@ func ListRun(opts *ListOptions) error {
 		Json: func(item *machines.Worker) any {
 
 			return TargetAsJson{
-				Id:          item.GetID(),
-				Name:        item.Name,
-				Type:        machinescommon.CommunicationStyleToDeploymentTargetTypeMap[item.Endpoint.GetCommunicationStyle()],
-				WorkerPools: resolveEntities(item.WorkerPoolIDs, workerPoolMap),
+				Id:            item.GetID(),
+				Name:          item.Name,
+				Type:          machinescommon.CommunicationStyleToDeploymentTargetTypeMap[item.Endpoint.GetCommunicationStyle()],
+				HealthStatus:  item.HealthStatus,
+				StatusSummary: item.StatusSummary,
+				WorkerPools:   resolveEntities(item.WorkerPoolIDs, workerPoolMap),
 			}
 		},
 		Table: output.TableDefinition[*machines.Worker]{


### PR DESCRIPTION
The fields that are included in the JSON output in `worker list` and `worker view` commands differ. 

This PR updates the `worker list` output to match that of the `worker view` output.

Before

```
octopus worker list --space Default -f json | jq '.[] | select(.Name == "WorkerL0")'
{
  "Id": "Workers-1",
  "Name": "WorkerL0",
  "Type": "TentaclePassive",
  "WorkerPools": [
    {
      "Id": "WorkerPools-1",
      "Name": "Default Worker Pool"
    }
  ]
}
```

After

```
octopus worker list --space Default -f json | jq '.[] | select(.Name == "WorkerL0")'
{
  "Id": "Workers-1",
  "Name": "WorkerL0",
  "Type": "TentaclePassive",
  "HealthStatus": "Healthy",
  "StatusSummary": "Octopus was able to successfully establish a connection with this machine on Tuesday, 31 October 2023 12:06:43 pm +10:00",
  "WorkerPools": [
    {
      "Id": "WorkerPools-1",
      "Name": "Default Worker Pool"
    }
  ]
}
```

[sc-63235]