### PR TITLE
Add additional fields to json output when listing workers

### DIFF
--- a/pkg/cmd/worker/ssh/view/view.go
+++ b/pkg/cmd/worker/ssh/view/view.go
@@ -44,7 +44,7 @@ func contributeEndpoint(opts *shared.ViewOptions, workerEndpoint machines.IEndpo
 	endpoint := workerEndpoint.(*machines.SSHEndpoint)
 
 	data = append(data, output.NewDataRow("URI", endpoint.URI.String()))
-	data = append(data, output.NewDataRow("Runtime architecture", getRuntimeArchitecture(endpoint)))
+	data = append(data, output.NewDataRow("Runtime architecture", GetRuntimeArchitecture(endpoint)))
 	accountRows, err := shared.ContributeAccount(opts, endpoint.AccountID)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func contributeEndpoint(opts *shared.ViewOptions, workerEndpoint machines.IEndpo
 	return data, nil
 }
 
-func getRuntimeArchitecture(endpoint *machines.SSHEndpoint) string {
+func GetRuntimeArchitecture(endpoint *machines.SSHEndpoint) string {
 	if endpoint.DotNetCorePlatform == "" {
 		return "Mono"
 	}


### PR DESCRIPTION
I missed adding URI, Tentacle version, SSH runtime architecture, Account and Proxy details to the JSON output when listing workers in #284.

This PR adds these additional fields.

### Listening Worker
```
octopus worker list --space Default --output-format json | jq '.[] | select(.Name == "WorkerL0")'
{
  "Id": "Workers-1",
  "Name": "WorkerL0",
  "Type": "TentaclePassive",
  "HealthStatus": "Healthy",
  "StatusSummary": "Octopus was able to successfully establish a connection with this machine on Tuesday, 31 October 2023 12:06:43 pm +10:00",
  "WorkerPools": [
    {
      "Id": "WorkerPools-1",
      "Name": "Default Worker Pool"
    }
  ],
  "URI": "https://localhost:10000/",
  "Version": "0.0.0-local",
  "Proxy": "None"
}
```
### SSH Worker
```
octopus worker list --space Default --output-format json | jq '.[] | select(.Name == "SshWorker")'
{
  "Id": "Workers-21",
  "Name": "SshWorker",
  "Type": "Ssh",
  "HealthStatus": "Healthy",
  "StatusSummary": "Octopus was able to successfully establish a connection with this machine on Tuesday, 31 October 2023 3:33:06 pm +10:00",
  "WorkerPools": [
    {
      "Id": "WorkerPools-1",
      "Name": "Default Worker Pool"
    }
  ],
  "URI": "ssh://localhost:22/",
  "Runtime": "linux-x64",
  "Account": {
    "Id": "Accounts-101",
    "Name": "Local Worker"
  },
  "Proxy": "None"
```

**When running `octopus worker view` we include a web URL for the worker, I have not included that as part of JSON output.**

[sc-63235]