### PR TITLE
Add link to Octopus docs in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,13 @@ This project aims to create a new CLI (written in Go) for communicating with the
 It does **not** seek to be a drop-in replacement for the existing CLI which is written in C# using .NET.
 https://github.com/OctopusDeploy/OctopusCLI
 
-### Differences from the .NET CLI
-
-The new CLI will not initially contain all the features of the existing .NET CLI.
-Over time we plan to add features and may eventually reach parity, but our intent is that both the
-.NET and Go CLI's will co-exist for a significant period of time.
+### Differences from the .NET CLI (octo)
 
 The new CLI restructures the command line to be more consistent, and fit with convention
 across other popular CLI apps. It is built on the popular and widely-used [Cobra](https://github.com/spf13/cobra)
 command line processing library.
+
+The new CLI does not intend to replace all features that were supported by the .NET CLI.
 
 #### Examples:
 
@@ -129,7 +127,7 @@ parameters are not fully specified on the command line.
 
 ## Documentation
 
-End-user documentation will be provided via the octopus documentation site at a future date.
+- [cli](https://octopus.com/docs/octopus-rest-api/cli)
 
 ## 🤝 Contributions
 


### PR DESCRIPTION
It's been quite some time since this readme was written and a large number of features that the .NET CLI has have now been implemented and we also have documentation hosted in on our website.