### PR TITLE
Fix tenant flags for tenant variables list and tenant view

### DIFF
--- a/pkg/cmd/tenant/variables/list/list.go
+++ b/pkg/cmd/tenant/variables/list/list.go
@@ -22,18 +22,15 @@ const (
 	LibraryVariableSetType = "Library"
 	ProjectType            = "Project"
 	FlagTenant             = "tenant"
-	FlagName               = "name"
 )
 
 type ListFlags struct {
 	Tenant *flag.Flag[string]
-	Name   *flag.Flag[string]
 }
 
 func NewListFlags() *ListFlags {
 	return &ListFlags{
 		Tenant: flag.New[string](FlagTenant, false),
-		Name:   flag.New[string](FlagName, false),
 	}
 }
 
@@ -106,7 +103,6 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringVarP(&listFlags.Tenant.Value, listFlags.Tenant.Name, "t", "", "Name or ID of the tenant to list variables for")
-	flags.StringVarP(&listFlags.Name.Value, listFlags.Name.Name, "n", "", "filter variables to match only ones with a name containing the given string")
 	return cmd
 }
 


### PR DESCRIPTION
Partial fix for https://github.com/OctopusDeploy/cli/issues/297

Adds the --tenant flag as shown in the documentation for 
```
octopus tenant variables list --tenant "example tenant"
```

Adds the --tenant flag as shown in the documentation for
```
octopus tenant view --tenant "example tenant"
```