### PR TITLE
Updating Ubuntu/Debian Install Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ The Homebrew package has native support for macOS Intel and Apple Silicon
 #### Linux (debian/ubuntu based distributions)
 
 ```shell
-apt-get update && apt-get install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
-  install -m 0755 -d /etc/apt/keyrings && \
+sudo apt update && sudo apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+sudo install -m 0755 -d /etc/apt/keyrings && \
 curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg && \
-chmod a+r /etc/apt/keyrings/octopus.gpg && \
+sudo chmod a+r /etc/apt/keyrings/octopus.gpg && \
 echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
   stable main" | \
-  tee /etc/apt/sources.list.d/octopus.list > /dev/null && \
-sudo apt-get update && sudo apt-get install octopus-cli
+  sudo tee /etc/apt/sources.list.d/octopus.list > /dev/null && \
+sudo apt update && sudo apt install octopus-cli
 
 # for legacy Ubuntu/Debian (< 18.04) use
 # sudo apt update && sudo apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ sudo install -m 0755 -d /etc/apt/keyrings && \
 curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg && \
 sudo chmod a+r /etc/apt/keyrings/octopus.gpg && \
 echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ stable main" | \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
+  stable main" | \
   sudo tee /etc/apt/sources.list.d/octopus.list > /dev/null && \
 sudo apt update && sudo apt install octopus-cli
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ The Homebrew package has native support for macOS Intel and Apple Silicon
 #### Linux (debian/ubuntu based distributions)
 
 ```shell
+apt-get update && apt-get install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+  install -m 0755 -d /etc/apt/keyrings && \
+curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg && \
+chmod a+r /etc/apt/keyrings/octopus.gpg && \
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
+  stable main" | \
+  tee /etc/apt/sources.list.d/octopus.list > /dev/null && \
+sudo apt-get update && sudo apt-get install octopus-cli
+
+# for legacy Ubuntu/Debian (< 18.04) use
 sudo apt update && sudo apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
 curl -sSfL https://apt.octopus.com/public.key | sudo apt-key add - && \
 sudo sh -c "echo deb https://apt.octopus.com/ stable main > /etc/apt/sources.list.d/octopus.com.list" && \

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ sudo install -m 0755 -d /etc/apt/keyrings && \
 curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg && \
 sudo chmod a+r /etc/apt/keyrings/octopus.gpg && \
 echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
-  stable main" | \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ stable main" | \
   sudo tee /etc/apt/sources.list.d/octopus.list > /dev/null && \
 sudo apt update && sudo apt install octopus-cli
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ echo \
 sudo apt-get update && sudo apt-get install octopus-cli
 
 # for legacy Ubuntu/Debian (< 18.04) use
-sudo apt update && sudo apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
-curl -sSfL https://apt.octopus.com/public.key | sudo apt-key add - && \
-sudo sh -c "echo deb https://apt.octopus.com/ stable main > /etc/apt/sources.list.d/octopus.com.list" && \
-sudo apt update && sudo apt install octopus-cli
+# sudo apt update && sudo apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+# curl -sSfL https://apt.octopus.com/public.key | sudo apt-key add - && \
+# sudo sh -c "echo deb https://apt.octopus.com/ stable main > /etc/apt/sources.list.d/octopus.com.list" && \
+# sudo apt update && sudo apt install octopus-cli
 ```
 
 #### Linux (redhat/fedora based distributions)


### PR DESCRIPTION
Removing the use of deprecated apt-key command in our default install instructions