### PR TITLE
Only prompt for variables within scope by fetching from deployments p…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/OctopusDeploy/cli
 
 go 1.21
 
+replace github.com/OctopusDeploy/go-octopusdeploy/v2 => ..\go-octopusdeploy
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.34.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.36.3
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,10 @@ module github.com/OctopusDeploy/cli
 
 go 1.21
 
-replace github.com/OctopusDeploy/go-octopusdeploy/v2 => ..\go-octopusdeploy
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.36.3
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.37.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0
@@ -34,7 +32,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.11.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.37.0 h1:mWTTDaQtMzwM/7eL4PgQaQ/H9QHTKrHbEOc7R/xNux8=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.37.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
@@ -89,8 +91,6 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.11.2 h1:q3SHpufmypg+erIExEKUmsgmhDTyhcJ38oeKGACXohU=
 github.com/go-playground/validator/v10 v10.11.2/go.mod h1:NieE624vt4SCTJtD87arVLvdmjPAeV8BQlHtMnw9D7s=
-github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
-github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.34.0 h1:S8h21VdVSHC8yfAk0Te8eHU/gkJ+3w2pv7Q/0kooK8I=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.34.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/project/variables/create/create.go
+++ b/pkg/cmd/project/variables/create/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/spf13/cobra"
 	"strings"
@@ -196,7 +197,7 @@ func CreateRun(opts *CreateOptions) error {
 		}
 
 		selectOptions := parseSelectOptions(opts, promptControlType)
-		newVariable.Prompt.DisplaySettings = variables.NewDisplaySettings(promptControlType, selectOptions)
+		newVariable.Prompt.DisplaySettings = resources.NewDisplaySettings(promptControlType, selectOptions)
 	}
 
 	if opts.GitRef.Value != "" {
@@ -412,15 +413,15 @@ func projectSelector(questionText string, getAllProjectsCallback shared.GetAllPr
 	return question.SelectMap(ask, questionText, existingProjects, func(p *projects.Project) string { return p.GetName() })
 }
 
-func parseSelectOptions(opts *CreateOptions, controlType variables.ControlType) []*variables.SelectOption {
-	options := []*variables.SelectOption{}
-	if controlType != variables.ControlTypeSelect {
+func parseSelectOptions(opts *CreateOptions, controlType resources.ControlType) []*resources.SelectOption {
+	options := []*resources.SelectOption{}
+	if controlType != resources.ControlTypeSelect {
 		return options
 	}
 
 	for _, selectOption := range opts.PromptSelectOptions.Value {
 		o := strings.Split(selectOption, "|")
-		options = append(options, &variables.SelectOption{
+		options = append(options, &resources.SelectOption{
 			Value:       o[0],
 			DisplayName: o[1],
 		})
@@ -454,16 +455,16 @@ func mapVariableType(varType string) (string, error) {
 	}
 }
 
-func mapControlType(promptType string) (variables.ControlType, error) {
+func mapControlType(promptType string) (resources.ControlType, error) {
 	switch promptType {
 	case PromptTypeText:
-		return variables.ControlTypeSingleLineText, nil
+		return resources.ControlTypeSingleLineText, nil
 	case PromptTypeMultiText:
-		return variables.ControlTypeMultiLineText, nil
+		return resources.ControlTypeMultiLineText, nil
 	case PromptTypeCheckbox:
-		return variables.ControlTypeCheckbox, nil
+		return resources.ControlTypeCheckbox, nil
 	case PromptTypeDropdown:
-		return variables.ControlTypeSelect, nil
+		return resources.ControlTypeSelect, nil
 	default:
 		return "", fmt.Errorf("unknown prompt type '%s', valid values are '%s','%s','%s', '%s'", promptType, PromptTypeText, PromptTypeMultiText, PromptTypeCheckbox, PromptTypeDropdown)
 	}

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -225,7 +225,7 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			assert.Equal(t, &executor.TaskOptionsDeployRelease{
 				ProjectName:       "Fire Project",
 				ReleaseVersion:    "1.9",
-				Environments:      []string{"dev"}test,
+				Environments:      []string{"dev"},
 				GuidedFailureMode: "",
 				Variables:         make(map[string]string, 0),
 				ReleaseID:         release19.ID,

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -382,7 +382,7 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			}, options)
 		}},
 
-		{"multiple prompted variables", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, stdout *bytes.Buffer) {
+		{"only prompt required variables", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, stdout *bytes.Buffer) {
 			// we don't need to fully test prompted variables; AskPromptedVariables already has all its own tests, we just
 			// need to very it's wired up properly
 			options := &executor.TaskOptionsDeployRelease{
@@ -417,14 +417,6 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 
 			deploymentPreviews := fixtures.NewDeploymentPreviews()
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/"+release20.ID+"/deployments/previews").RespondWith(&deploymentPreviews)
-
-			promptQuestionOne := qa.ExpectQuestion(t, &survey.Input{
-				Message: "Prompt Required",
-				Default: "Prompt value required",
-				Help:    "",
-			})
-			assert.Regexp(t, "", stdout.String()) // actual options tested in PrintAdvancedSummary
-			_ = promptQuestionOne.AnswerWith("Some Value")
 
 			promptQuestionTwo := qa.ExpectQuestion(t, &survey.Password{
 				Message: "Scoped Sensitive",

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -418,12 +418,12 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			deploymentPreviews := fixtures.NewDeploymentPreviews()
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/"+release20.ID+"/deployments/previews").RespondWith(&deploymentPreviews)
 
-			promptQuestionTwo := qa.ExpectQuestion(t, &survey.Password{
+			promptQuestion := qa.ExpectQuestion(t, &survey.Password{
 				Message: "Scoped Sensitive",
 				Help:    "",
 			})
 			assert.Regexp(t, "", stdout.String()) // actual options tested in PrintAdvancedSummary
-			_ = promptQuestionTwo.AnswerWith("Secret Value")
+			_ = promptQuestion.AnswerWith("Secret Value")
 
 			assert.Equal(t, heredoc.Doc(`
 				Project Fire Project

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -449,7 +449,6 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 				Environments:      []string{"dev"},
 				GuidedFailureMode: "",
 				Variables: map[string]string{
-					"Prompt Required":  "Some Value",
 					"Scoped Sensitive": "Secret Value",
 				},
 				ReleaseID: release20.ID,

--- a/pkg/cmd/tenant/variables/update/update.go
+++ b/pkg/cmd/tenant/variables/update/update.go
@@ -17,6 +17,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/workerpools"
@@ -292,32 +293,32 @@ func PromptForVariable(opts *UpdateOptions, tenantVariables *variables.TenantVar
 	return selectedVariable, nil
 }
 
-func mapVariableControlTypeToVariableType(controlType variables.ControlType) (sharedVariable.VariableType, error) {
+func mapVariableControlTypeToVariableType(controlType resources.ControlType) (sharedVariable.VariableType, error) {
 	switch controlType {
-	case variables.ControlTypeSingleLineText, variables.ControlTypeMultiLineText:
+	case resources.ControlTypeSingleLineText, resources.ControlTypeMultiLineText:
 		return sharedVariable.VariableTypeString, nil
-	case variables.ControlTypeSensitive:
+	case resources.ControlTypeSensitive:
 		return sharedVariable.VariableTypeSensitive, nil
-	case variables.ControlTypeCheckbox:
+	case resources.ControlTypeCheckbox:
 		return sharedVariable.VariableTypeBoolean, nil
-	case variables.ControlTypeCertificate:
+	case resources.ControlTypeCertificate:
 		return sharedVariable.VariableTypeCertificate, nil
-	case variables.ControlTypeWorkerPool:
+	case resources.ControlTypeWorkerPool:
 		return sharedVariable.VariableTypeWorkerPool, nil
-	case variables.ControlTypeGoogleCloudAccount:
+	case resources.ControlTypeGoogleCloudAccount:
 		return sharedVariable.VariableTypeGoogleCloudAccount, nil
-	case variables.ControlTypeAwsAccount:
+	case resources.ControlTypeAwsAccount:
 		return sharedVariable.VariableTypeAwsAccount, nil
-	case variables.ControlTypeAzureAccount:
+	case resources.ControlTypeAzureAccount:
 		return sharedVariable.VariableTypeAzureAccount, nil
-	case variables.ControlTypeSelect:
+	case resources.ControlTypeSelect:
 		return sharedVariable.VariableTypeSelect, nil
 	}
 
 	return "", fmt.Errorf("cannot map control type '%s' to variable type", controlType)
 }
 
-func getVariableType(opts *UpdateOptions, tenantVariables *variables.TenantVariables) (variables.ControlType, error) {
+func getVariableType(opts *UpdateOptions, tenantVariables *variables.TenantVariables) (resources.ControlType, error) {
 	if opts.LibraryVariableSet.Value != "" {
 		for _, v := range tenantVariables.LibraryVariables {
 			if strings.EqualFold(v.LibraryVariableSetName, opts.LibraryVariableSet.Value) {
@@ -325,7 +326,7 @@ func getVariableType(opts *UpdateOptions, tenantVariables *variables.TenantVaria
 				if err != nil {
 					return "", err
 				}
-				return variables.ControlType(template.DisplaySettings["Octopus.ControlType"]), nil
+				return resources.ControlType(template.DisplaySettings["Octopus.ControlType"]), nil
 			}
 		}
 	} else if opts.Project.Value != "" {
@@ -335,7 +336,7 @@ func getVariableType(opts *UpdateOptions, tenantVariables *variables.TenantVaria
 				if err != nil {
 					return "", err
 				}
-				return variables.ControlType(template.DisplaySettings["Octopus.ControlType"]), nil
+				return resources.ControlType(template.DisplaySettings["Octopus.ControlType"]), nil
 			}
 		}
 	}
@@ -457,17 +458,17 @@ func updateCommonVariableValue(opts *UpdateOptions, vars *variables.TenantVariab
 }
 
 func convertValue(opts *UpdateOptions, t *actiontemplates.ActionTemplateParameter) (*core.PropertyValue, error) {
-	variableType := variables.ControlType(t.DisplaySettings["Octopus.ControlType"])
+	variableType := resources.ControlType(t.DisplaySettings["Octopus.ControlType"])
 	value := opts.Value.Value
 	var err error
 	switch variableType {
-	case variables.ControlTypeAwsAccount:
+	case resources.ControlTypeAwsAccount:
 		value, err = findAccount(opts, accounts.AccountTypeAmazonWebServicesAccount)
-	case variables.ControlTypeGoogleCloudAccount:
+	case resources.ControlTypeGoogleCloudAccount:
 		value, err = findAccount(opts, accounts.AccountTypeGoogleCloudPlatformAccount)
-	case variables.ControlTypeAzureAccount:
+	case resources.ControlTypeAzureAccount:
 		value, err = findAccount(opts, accounts.AccountTypeAzureServicePrincipal)
-	case variables.ControlTypeWorkerPool:
+	case resources.ControlTypeWorkerPool:
 		allWorkerPools, err := opts.GetAllWorkerPools()
 		if err != nil {
 			return nil, err
@@ -483,7 +484,7 @@ func convertValue(opts *UpdateOptions, t *actiontemplates.ActionTemplateParamete
 		}
 
 		value, err = matchedWorkerPools[0].ID, nil
-	case variables.ControlTypeCertificate:
+	case resources.ControlTypeCertificate:
 		allCertificates, err := opts.GetAllCertificates()
 		if err != nil {
 			return nil, err
@@ -499,7 +500,7 @@ func convertValue(opts *UpdateOptions, t *actiontemplates.ActionTemplateParamete
 		}
 
 		value, err = matchedCertificate[0].ID, nil
-	case variables.ControlTypeSelect:
+	case resources.ControlTypeSelect:
 		selectionOptions := sharedVariable.GetSelectOptions(t)
 		for _, o := range selectionOptions {
 			if strings.EqualFold(o.Display, opts.Value.Value) || strings.EqualFold(o.Value, opts.Value.Value) {
@@ -511,7 +512,7 @@ func convertValue(opts *UpdateOptions, t *actiontemplates.ActionTemplateParamete
 		if value == "" {
 			err = fmt.Errorf("cannot match selection value  '%s'", opts.Value.Value)
 		}
-	case variables.ControlTypeSensitive:
+	case resources.ControlTypeSensitive:
 		propertyValue := core.NewPropertyValue(value, true)
 		return &propertyValue, nil
 	}

--- a/pkg/cmd/tenant/variables/update/update_test.go
+++ b/pkg/cmd/tenant/variables/update/update_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,7 @@ func TestPromptMissing_ProjectVariable_AllFlagsProvided(t *testing.T) {
 			ProjectID:   "Projects-1",
 			ProjectName: flags.Project.Value,
 		}
-		projectTemplate := createTemplate("var name", variables.ControlTypeSingleLineText, "templateId-1")
+		projectTemplate := createTemplate("var name", resources.ControlTypeSingleLineText, "templateId-1")
 		projectVars.Templates = append(projectVars.Templates, projectTemplate)
 		vars := variables.NewTenantVariables("Tenants-1")
 		vars.SpaceID = "Spaces-1"
@@ -67,7 +68,7 @@ func TestPromptMissing_LibraryVariable_AllFlagsProvided(t *testing.T) {
 		libraryVariables := variables.NewLibraryVariable()
 		libraryVariables.LibraryVariableSetID = "LibraryVariableSets-1"
 		libraryVariables.LibraryVariableSetName = "lvs"
-		libraryVariables.Templates = append(libraryVariables.Templates, createTemplate("var name", variables.ControlTypeSingleLineText, "templateId-1"))
+		libraryVariables.Templates = append(libraryVariables.Templates, createTemplate("var name", resources.ControlTypeSingleLineText, "templateId-1"))
 		vars := variables.NewTenantVariables("Tenants-1")
 		vars.SpaceID = "Spaces-1"
 		vars.TenantName = "tenant name"
@@ -103,8 +104,8 @@ func TestPromptMissing_LibraryVariable_NoFlagsProvided(t *testing.T) {
 		libraryVariables := variables.NewLibraryVariable()
 		libraryVariables.LibraryVariableSetID = "LibraryVariableSets-1"
 		libraryVariables.LibraryVariableSetName = "lvs"
-		libraryVariables.Templates = append(libraryVariables.Templates, createTemplate("var name", variables.ControlTypeSingleLineText, "templateId-1"))
-		libraryVariables.Templates = append(libraryVariables.Templates, createTemplate("var name 2", variables.ControlTypeSingleLineText, "templateId-2"))
+		libraryVariables.Templates = append(libraryVariables.Templates, createTemplate("var name", resources.ControlTypeSingleLineText, "templateId-1"))
+		libraryVariables.Templates = append(libraryVariables.Templates, createTemplate("var name 2", resources.ControlTypeSingleLineText, "templateId-2"))
 		vars := variables.NewTenantVariables("Tenants-1")
 		vars.SpaceID = "Spaces-1"
 		vars.TenantName = "tenant name"
@@ -152,7 +153,7 @@ func TestPromptMissing_ProjectVariable_NoFlagsProvided(t *testing.T) {
 			ProjectName: "Project 1",
 			Variables:   make(map[string]map[string]core.PropertyValue),
 		}
-		project1Vars.Templates = append(project1Vars.Templates, createTemplate("project 1 var", variables.ControlTypeSingleLineText, "templateId-1"))
+		project1Vars.Templates = append(project1Vars.Templates, createTemplate("project 1 var", resources.ControlTypeSingleLineText, "templateId-1"))
 		project1Vars.Variables["Environments-1"] = make(map[string]core.PropertyValue)
 		project1Vars.Variables["Environments-1"]["templateId-1"] = core.NewPropertyValue("", false)
 		project1Vars.Variables["Environments-2"] = make(map[string]core.PropertyValue)
@@ -162,7 +163,7 @@ func TestPromptMissing_ProjectVariable_NoFlagsProvided(t *testing.T) {
 			ProjectName: "Project 2",
 			Variables:   make(map[string]map[string]core.PropertyValue),
 		}
-		project2Vars.Templates = append(project2Vars.Templates, createTemplate("project 2 var", variables.ControlTypeSingleLineText, "templateId-2"))
+		project2Vars.Templates = append(project2Vars.Templates, createTemplate("project 2 var", resources.ControlTypeSingleLineText, "templateId-2"))
 		project2Vars.Variables["Environments-1"] = make(map[string]core.PropertyValue)
 		project2Vars.Variables["Environments-1"]["templateId-2"] = core.NewPropertyValue("", false)
 		project2Vars.Variables["Environments-2"] = make(map[string]core.PropertyValue)
@@ -205,7 +206,7 @@ func TestPromptMissing_ProjectVariable_NoFlagsProvided(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func createTemplate(name string, controlType variables.ControlType, templateId string) *actiontemplates.ActionTemplateParameter {
+func createTemplate(name string, controlType resources.ControlType, templateId string) *actiontemplates.ActionTemplateParameter {
 	template := actiontemplates.NewActionTemplateParameter()
 	template.Name = name
 	template.DisplaySettings = make(map[string]string)

--- a/pkg/executionscommon/executionscommon_test.go
+++ b/pkg/executionscommon/executionscommon_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/executionscommon"
 	"github.com/OctopusDeploy/cli/test/fixtures"
 	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -96,7 +97,7 @@ func TestAskVariables(t *testing.T) {
 			v1 := variables.NewVariable("ReqText")
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description:     "Enter required text",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeSingleLineText, nil),
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeSingleLineText, nil),
 				IsRequired:      true,
 			}
 
@@ -140,7 +141,7 @@ func TestAskVariables(t *testing.T) {
 			v1 := variables.NewVariable("SomeText")
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description:     "Enter secret text",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeSensitive, nil),
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeSensitive, nil),
 			}
 
 			vars := makeVariables(v1)
@@ -188,14 +189,14 @@ func TestAskVariables(t *testing.T) {
 			v1.Type = "Certificate"
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description:     "Codesigning certificate?",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeCertificate, nil),
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeCertificate, nil),
 			}
 
 			v2 := variables.NewVariable("AWS Account")
 			v2.Type = "AzureAccount"
 			v2.Prompt = &variables.VariablePromptOptions{
 				Description:     "AZ Account?",
-				DisplaySettings: &variables.DisplaySettings{},
+				DisplaySettings: &resources.DisplaySettings{},
 			}
 			vars := makeVariables(v1, v2)
 
@@ -211,7 +212,7 @@ func TestAskVariables(t *testing.T) {
 			v1.Type = "String"
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description: "Which part of the company do you work in?",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeSelect, []*variables.SelectOption{
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeSelect, []*resources.SelectOption{
 					{Value: "rnd", DisplayName: "R&D"},
 					{Value: "finance", DisplayName: "Finance"},
 					{Value: "hr", DisplayName: "Human Resources"},
@@ -241,7 +242,7 @@ func TestAskVariables(t *testing.T) {
 			v1.Value = "rnd" // looks this up!
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description: "Which part of the company do you work in?",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeSelect, []*variables.SelectOption{
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeSelect, []*resources.SelectOption{
 					{Value: "rnd", DisplayName: "R&D"},
 					{Value: "finance", DisplayName: "Finance"},
 					{Value: "hr", DisplayName: "Human Resources"},
@@ -269,7 +270,7 @@ func TestAskVariables(t *testing.T) {
 			v1 := variables.NewVariable("IsApproved")
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description:     "Is this approved?",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeCheckbox, nil),
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeCheckbox, nil),
 				IsRequired:      false,
 			}
 
@@ -294,7 +295,7 @@ func TestAskVariables(t *testing.T) {
 			v1.Value = "True"
 			v1.Prompt = &variables.VariablePromptOptions{
 				Description:     "Is this approved?",
-				DisplaySettings: variables.NewDisplaySettings(variables.ControlTypeCheckbox, nil),
+				DisplaySettings: resources.NewDisplaySettings(resources.ControlTypeCheckbox, nil),
 				IsRequired:      false,
 			}
 

--- a/test/fixtures/projects.go
+++ b/test/fixtures/projects.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
@@ -160,4 +161,84 @@ func NewRunbookProcessForRunbook(spaceID string, projectID string, runbookID str
 	result.ProjectID = projectID
 	result.ID = "RunbookProcess-" + runbookID
 	return result
+}
+
+func EmptyDeploymentPreviews() []*deployments.DeploymentPreview {
+	// Define the Form instance
+	formValues := map[string]string{}
+	formElements := []*deployments.Element{}
+	form := deployments.NewFormWithValuesAndElements(formValues, formElements)
+
+	deploymentPreview := &deployments.DeploymentPreview{
+		Form:                          form,
+		StepsToExecute:                []*deployments.DeploymentTemplateStep{},
+		UseGuidedFailureModeByDefault: false,
+	}
+
+	// Serialize the DeploymentPreview instances to JSON
+	deploymentPreviews := []*deployments.DeploymentPreview{deploymentPreview}
+
+	return deploymentPreviews
+}
+
+func NewDeploymentPreviews() []*deployments.DeploymentPreview {
+	newDisplaySettings := &resources.DisplaySettings{}
+	controlPromptNotRequired := deployments.NewControl("VariableValue", "Prompt not required", "Prompt not required", "", false, newDisplaySettings)
+	controlPromptRequired := deployments.NewControl("VariableValue", "Prompt Required", "Test Env scoped", "", true, newDisplaySettings)
+	controlScopedSensitive := deployments.NewControl("VariableValue", "Scoped Sensitive", "Scoped Sensitive", "", true, resources.NewDisplaySettings(resources.ControlTypeSensitive, nil))
+
+	elementPromptNotRequired := deployments.NewElement("5103b61d-9142-c146-d2c9-11b0e63aa438", controlPromptNotRequired, false)
+	elementTestEnvScoped := deployments.NewElement("1953afe6-f094-1287-2d8a-04846dc0f9b1", controlPromptRequired, true)
+	elementScopedSensitive := deployments.NewElement("41824a1b-64ad-430f-862b-39d8cfeeb13a", controlScopedSensitive, true)
+
+	// Define the Form instance
+	formValues := map[string]string{
+		"5103b61d-9142-c146-d2c9-11b0e63aa438": "Prompt value not required",
+		"1953afe6-f094-1287-2d8a-04846dc0f9b1": "Prompt value required",
+		"41824a1b-64ad-430f-862b-39d8cfeeb13a": "Prompt secret value",
+	}
+	formElements := []*deployments.Element{elementPromptNotRequired, elementTestEnvScoped, elementScopedSensitive}
+	form := deployments.NewFormWithValuesAndElements(formValues, formElements)
+
+	deploymentPreview1 := &deployments.DeploymentPreview{
+		Form:                          form,
+		StepsToExecute:                []*deployments.DeploymentTemplateStep{},
+		UseGuidedFailureModeByDefault: false,
+	}
+
+	deploymentPreview2 := &deployments.DeploymentPreview{
+		Form:                          form,
+		StepsToExecute:                []*deployments.DeploymentTemplateStep{},
+		UseGuidedFailureModeByDefault: false,
+	}
+
+	// Serialize the DeploymentPreview instances to JSON
+	deploymentPreviews := []*deployments.DeploymentPreview{deploymentPreview1, deploymentPreview2}
+
+	return deploymentPreviews
+}
+
+func NewDeploymentPreviewsWithApproval() []*deployments.DeploymentPreview {
+	newDisplaySettings := &resources.DisplaySettings{}
+
+	approvalPromptRequired := deployments.NewControl("VariableValue", "Approver", "Who approved this deployment?", "Who approved this deployment?", true, newDisplaySettings)
+	approvalPromptRequiredElement := deployments.NewElement("1953afe6-f094-1287-2d8a-04846dc0f9b1", approvalPromptRequired, true)
+
+	// Define the Form instance
+	formValues := map[string]string{
+		"1953afe6-f094-1287-2d8a-04846dc0f9b1": "",
+	}
+	formElements := []*deployments.Element{approvalPromptRequiredElement}
+	form := deployments.NewFormWithValuesAndElements(formValues, formElements)
+
+	deploymentPreview1 := &deployments.DeploymentPreview{
+		Form:                          form,
+		StepsToExecute:                []*deployments.DeploymentTemplateStep{},
+		UseGuidedFailureModeByDefault: false,
+	}
+
+	// Serialize the DeploymentPreview instances to JSON
+	deploymentPreviews := []*deployments.DeploymentPreview{deploymentPreview1}
+
+	return deploymentPreviews
 }

--- a/test/fixtures/projects.go
+++ b/test/fixtures/projects.go
@@ -184,20 +184,17 @@ func EmptyDeploymentPreviews() []*deployments.DeploymentPreview {
 func NewDeploymentPreviews() []*deployments.DeploymentPreview {
 	newDisplaySettings := &resources.DisplaySettings{}
 	controlPromptNotRequired := deployments.NewControl("VariableValue", "Prompt not required", "Prompt not required", "", false, newDisplaySettings)
-	controlPromptRequired := deployments.NewControl("VariableValue", "Prompt Required", "Test Env scoped", "", true, newDisplaySettings)
 	controlScopedSensitive := deployments.NewControl("VariableValue", "Scoped Sensitive", "Scoped Sensitive", "", true, resources.NewDisplaySettings(resources.ControlTypeSensitive, nil))
 
 	elementPromptNotRequired := deployments.NewElement("5103b61d-9142-c146-d2c9-11b0e63aa438", controlPromptNotRequired, false)
-	elementTestEnvScoped := deployments.NewElement("1953afe6-f094-1287-2d8a-04846dc0f9b1", controlPromptRequired, true)
 	elementScopedSensitive := deployments.NewElement("41824a1b-64ad-430f-862b-39d8cfeeb13a", controlScopedSensitive, true)
 
 	// Define the Form instance
 	formValues := map[string]string{
 		"5103b61d-9142-c146-d2c9-11b0e63aa438": "Prompt value not required",
-		"1953afe6-f094-1287-2d8a-04846dc0f9b1": "Prompt value required",
 		"41824a1b-64ad-430f-862b-39d8cfeeb13a": "Prompt secret value",
 	}
-	formElements := []*deployments.Element{elementPromptNotRequired, elementTestEnvScoped, elementScopedSensitive}
+	formElements := []*deployments.Element{elementPromptNotRequired, elementScopedSensitive}
 	form := deployments.NewFormWithValuesAndElements(formValues, formElements)
 
 	deploymentPreview1 := &deployments.DeploymentPreview{

--- a/test/testutil/fakesurvey.go
+++ b/test/testutil/fakesurvey.go
@@ -285,6 +285,7 @@ func (m *AskMocker) sendAnswer(answer any, err error) {
 	}
 
 	m.Answer <- answerOrError{answer: answer, error: err}
+
 }
 
 // ReceiveQuestion gets the next question and options from the channel and returns them in a wrapper struct.

--- a/test/testutil/fakesurvey.go
+++ b/test/testutil/fakesurvey.go
@@ -285,7 +285,6 @@ func (m *AskMocker) sendAnswer(answer any, err error) {
 	}
 
 	m.Answer <- answerOrError{answer: answer, error: err}
-
 }
 
 // ReceiveQuestion gets the next question and options from the channel and returns them in a wrapper struct.


### PR DESCRIPTION
This adds support for only prompting on variables within the deployment scope using the deployments previews endpoint instead of the project variable set.

Currently fetch the variable set and prompt for all variables, regardless of the scope. The change to the CLI will only prompt for variables in that specific set of releases. This is handled by flattening the deployment previews, so if multiple environments contain differently scoped variables, they will all be prompted for and contributed. While they are all contributed due to variable scoping at deployment time the out of scope variables are not included in the manifest and therefore deployment. 

![image](https://github.com/OctopusDeploy/go-octopusdeploy/assets/101079287/08962ee2-623d-479b-9497-ccfd1ec110b3)

For this use case (showing prompted variables) tenant scoping is not allowed
![image](https://github.com/OctopusDeploy/go-octopusdeploy/assets/101079287/fe816b1b-4325-4838-8e6f-e6257a71f213)

When requesting a deployment previews for a tenant with environments out of scope those prompted variables are still returned. Tenant variables are also not able to be prompted. In the CLI consuming code this means specifying the tenant is redundant in our use case.
![image](https://github.com/OctopusDeploy/go-octopusdeploy/assets/101079287/aa4b3b96-f303-4212-b63d-0d6e7ca46eec)

fixes #316 
Fixes https://github.com/OctopusDeploy/Issues/issues/8559
