### PR TITLE
fixed factory method parameters

### DIFF
--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/OctopusDeploy/cli/pkg/config"
+	"github.com/spf13/viper"
 	"io"
 	"os"
 	"os/user"
@@ -96,7 +98,9 @@ func run(args []string) error {
 	clientFactory := apiclient.NewStubClientFactory()
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithColor("cyan"))
 	buildVersion := strings.TrimSpace(version.Version)
-	f := factory.New(clientFactory, askProvider, s, buildVersion)
+	viper := viper.GetViper()
+	c := config.New(viper)
+	f := factory.New(clientFactory, askProvider, s, buildVersion, c)
 
 	cmd := root.NewCmdRoot(f, clientFactory, askProvider)
 	cmd.DisableAutoGenTag = true


### PR DESCRIPTION
to fix error in docs-gen

```
# command-line-arguments
Error: cmd/gen-docs/main.go:99:50: not enough arguments in call to factory.New
	have (apiclient.ClientFactory, question.AskProvider, *spinner.Spinner, string)
	want (apiclient.ClientFactory, question.AskProvider, factory.Spinner, string, "github.com/OctopusDeploy/cli/pkg/config".IConfigProvider)
Error: Process completed with exit code 1.
```