### PR TITLE
Allow CLI invocation if empty or null arguments

### DIFF
--- a/cmd/octopus/main.go
+++ b/cmd/octopus/main.go
@@ -87,5 +87,5 @@ func main() {
 
 func commandDoesNotRequireClient(args []string) bool {
 	cmdToRun := args[0]
-	return cmdToRun == "config" || cmdToRun == "version" || cmdToRun == "help" || cmdToRun == "login" || cmdToRun == "logout" || (cmdToRun == "package" && util.SliceContains(args, "create"))
+	return cmdToRun == "" || cmdToRun == "config" || cmdToRun == "version" || cmdToRun == "help" || cmdToRun == "login" || cmdToRun == "logout" || (cmdToRun == "package" && util.SliceContains(args, "create"))
 }

--- a/cmd/octopus/main.go
+++ b/cmd/octopus/main.go
@@ -86,6 +86,11 @@ func main() {
 }
 
 func commandDoesNotRequireClient(args []string) bool {
+    // if there are no arguments after .\octopus.exe or "octopus", it should default to "octopus" which is a valid command.
+	if len(args) == 0 || args == nil {
+		args = []string{""}
+	}
+	
 	cmdToRun := args[0]
-	return cmdToRun == "" || cmdToRun == "config" || cmdToRun == "version" || cmdToRun == "help" || cmdToRun == "login" || cmdToRun == "logout" || (cmdToRun == "package" && util.SliceContains(args, "create"))
+	return cmdToRun == "config" || cmdToRun == "version" || cmdToRun == "help" || cmdToRun == "login" || cmdToRun == "logout" || (cmdToRun == "package" && util.SliceContains(args, "create")) || (cmdToRun == "octopus" && util.SliceContains(args, ""))
 }


### PR DESCRIPTION
### Why is this change added?
This update lets [octopus](https://octopus.com/docs/octopus-rest-api/cli/octopus) be passed as a command to call `.\octopus.exe`, allowing for empty or null arguments to default to the base `octopus` command

### Before PR
- v2.1.1 installed and added to path:
  <img width="306" alt="image" src="https://github.com/OctopusDeploy/cli/assets/67904550/ca2d7d3b-cab8-4267-90a0-d2d072836f4e">

- going directly to the executable
  <img width="293" alt="image" src="https://github.com/OctopusDeploy/cli/assets/67904550/82b42af7-1af6-4496-a65c-5a7edacfef90">


### After PR
- branch compiled and added to path:
  <img width="455" alt="image" src="https://github.com/OctopusDeploy/cli/assets/67904550/de4489ae-7ab5-4b01-ab71-fb3a524039ec">

- going directly to the executable
  <img width="416" alt="image" src="https://github.com/OctopusDeploy/cli/assets/67904550/3948530a-8484-4d46-9f62-5696da3a94a8">
