### PR TITLE
Tenant view command support for output formatting

### DIFF
--- a/pkg/cmd/tenant/list/list.go
+++ b/pkg/cmd/tenant/list/list.go
@@ -3,26 +3,13 @@ package list
 import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/cmd/tenant/shared"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
-	"github.com/OctopusDeploy/cli/pkg/util"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/spf13/cobra"
 )
-
-type ProjectEnvironment struct {
-	Project      output.IdAndName   `json:"Project"`
-	Environments []output.IdAndName `json:"Environments"`
-}
-
-type TenantAsJson struct {
-	*tenants.Tenant
-	ProjectEnvironments []ProjectEnvironment
-}
 
 func NewCmdList(f factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -53,12 +40,12 @@ func listRun(cmd *cobra.Command, f factory.Factory) error {
 		return err
 	}
 
-	environmentMap, err := getEnvironmentMap(client, allTenants)
+	environmentMap, err := shared.GetEnvironmentMap(client, allTenants)
 	if err != nil {
 		return err
 	}
 
-	projectMap, err := getProjectMap(client, allTenants)
+	projectMap, err := shared.GetProjectMap(client, allTenants)
 	if err != nil {
 		return err
 	}
@@ -66,19 +53,19 @@ func listRun(cmd *cobra.Command, f factory.Factory) error {
 	return output.PrintArray(allTenants, cmd, output.Mappers[*tenants.Tenant]{
 		Json: func(t *tenants.Tenant) any {
 
-			projectEnvironments := []ProjectEnvironment{}
+			projectEnvironments := []shared.ProjectEnvironment{}
 
 			for p := range t.ProjectEnvironments {
 				projectEntity := output.IdAndName{Id: p, Name: projectMap[p]}
-				environments, err := resolveEntities(t.ProjectEnvironments[p], environmentMap)
+				environments, err := shared.ResolveEntities(t.ProjectEnvironments[p], environmentMap)
 				if err != nil {
 					return err
 				}
-				projectEnvironments = append(projectEnvironments, ProjectEnvironment{Project: projectEntity, Environments: environments})
+				projectEnvironments = append(projectEnvironments, shared.ProjectEnvironment{Project: projectEntity, Environments: environments})
 			}
 
 			t.Links = nil // ensure the links collection is not serialised
-			return TenantAsJson{
+			return shared.TenantAsJson{
 				Tenant:              t,
 				ProjectEnvironments: projectEnvironments,
 			}
@@ -93,63 +80,4 @@ func listRun(cmd *cobra.Command, f factory.Factory) error {
 			return t.Name
 		},
 	})
-}
-
-func resolveEntities(keys []string, lookup map[string]string) ([]output.IdAndName, error) {
-	var entities []output.IdAndName
-	for _, k := range keys {
-		entities = append(entities, output.IdAndName{Id: k, Name: lookup[k]})
-	}
-
-	return entities, nil
-}
-
-func getEnvironmentMap(client *client.Client, tenants []*tenants.Tenant) (map[string]string, error) {
-	var environmentIds []string
-	for _, t := range tenants {
-		for p := range t.ProjectEnvironments {
-			environmentIds = append(environmentIds, t.ProjectEnvironments[p]...)
-		}
-	}
-
-	environmentIds = util.SliceDistinct(environmentIds)
-
-	environmentMap := make(map[string]string)
-	queryResult, err := client.Environments.Get(environments.EnvironmentsQuery{IDs: environmentIds})
-	if err != nil {
-		return nil, err
-	}
-	allEnvs, err := queryResult.GetAllPages(client.Environments.GetClient())
-	if err != nil {
-		return nil, err
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	for _, e := range allEnvs {
-		environmentMap[e.GetID()] = e.GetName()
-	}
-	return environmentMap, nil
-}
-
-func getProjectMap(client *client.Client, tenants []*tenants.Tenant) (map[string]string, error) {
-	var projectIds []string
-	for _, t := range tenants {
-		for p := range t.ProjectEnvironments {
-			projectIds = append(projectIds, p)
-		}
-	}
-	projectIds = util.SliceDistinct(projectIds)
-
-	projectMap := make(map[string]string)
-	queryResult, err := client.Projects.Get(projects.ProjectsQuery{IDs: projectIds})
-	allProjects, err := queryResult.GetAllPages(client.Projects.GetClient())
-	if err != nil {
-		return nil, err
-	}
-	for _, e := range allProjects {
-		projectMap[e.GetID()] = e.GetName()
-	}
-	return projectMap, nil
 }

--- a/pkg/cmd/tenant/shared/shared.go
+++ b/pkg/cmd/tenant/shared/shared.go
@@ -1,8 +1,10 @@
 package shared
 
 import (
+	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/teams"
@@ -10,6 +12,16 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/users"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 )
+
+type ProjectEnvironment struct {
+	Project      output.IdAndName   `json:"Project"`
+	Environments []output.IdAndName `json:"Environments"`
+}
+
+type TenantAsJson struct {
+	*tenants.Tenant
+	ProjectEnvironments []ProjectEnvironment
+}
 
 type GetAllSpacesCallback func() ([]*spaces.Space, error)
 type GetAllTeamsCallback func() ([]*teams.Team, error)
@@ -20,6 +32,65 @@ type GetAllProjectsCallback func() ([]*projects.Project, error)
 type GetProjectCallback func(identifier string) (*projects.Project, error)
 type GetProjectProgression func(project *projects.Project) (*projects.Progression, error)
 type GetAllLibraryVariableSetsCallback func() ([]*variables.LibraryVariableSet, error)
+
+func ResolveEntities(keys []string, lookup map[string]string) ([]output.IdAndName, error) {
+	var entities []output.IdAndName
+	for _, k := range keys {
+		entities = append(entities, output.IdAndName{Id: k, Name: lookup[k]})
+	}
+
+	return entities, nil
+}
+
+func GetEnvironmentMap(client *client.Client, tenants []*tenants.Tenant) (map[string]string, error) {
+	var environmentIds []string
+	for _, t := range tenants {
+		for p := range t.ProjectEnvironments {
+			environmentIds = append(environmentIds, t.ProjectEnvironments[p]...)
+		}
+	}
+
+	environmentIds = util.SliceDistinct(environmentIds)
+
+	environmentMap := make(map[string]string)
+	queryResult, err := client.Environments.Get(environments.EnvironmentsQuery{IDs: environmentIds})
+	if err != nil {
+		return nil, err
+	}
+	allEnvs, err := queryResult.GetAllPages(client.Environments.GetClient())
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range allEnvs {
+		environmentMap[e.GetID()] = e.GetName()
+	}
+	return environmentMap, nil
+}
+
+func GetProjectMap(client *client.Client, tenants []*tenants.Tenant) (map[string]string, error) {
+	var projectIds []string
+	for _, t := range tenants {
+		for p := range t.ProjectEnvironments {
+			projectIds = append(projectIds, p)
+		}
+	}
+	projectIds = util.SliceDistinct(projectIds)
+
+	projectMap := make(map[string]string)
+	queryResult, err := client.Projects.Get(projects.ProjectsQuery{IDs: projectIds})
+	allProjects, err := queryResult.GetAllPages(client.Projects.GetClient())
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range allProjects {
+		projectMap[e.GetID()] = e.GetName()
+	}
+	return projectMap, nil
+}
 
 func GetAllTeams(client client.Client) ([]*teams.Team, error) {
 	res, err := client.Teams.Get(teams.TeamsQuery{IncludeSystem: true})

--- a/pkg/cmd/tenant/view/view.go
+++ b/pkg/cmd/tenant/view/view.go
@@ -147,29 +147,6 @@ func viewRun(opts *ViewOptions, cmd *cobra.Command) error {
 			}
 
 			return s.String()
-
-			// fmt.Fprintf(opts.out, "%s %s\n", output.Bold(tenant.Name), output.Dimf("(%s)", tenant.ID))
-
-			// if len(tenant.TenantTags) > 0 {
-			// 	fmt.Fprintf(opts.out, "Tags: %s", output.FormatAsList(tenant.TenantTags))
-			// 	fmt.Fprintf(opts.out, "\n")
-			// }
-
-			// if tenant.Description == "" {
-			// 	fmt.Fprintln(opts.out, output.Dim(constants.NoDescription))
-			// } else {
-			// 	fmt.Fprintln(opts.out, output.Dim(tenant.Description))
-			// }
-
-			// link := fmt.Sprintf("%s/app#/%s/tenants/%s/overview", opts.Host, tenant.SpaceID, tenant.ID)
-
-			// // footer
-			// fmt.Fprintf(opts.out, "View this tenant in Octopus Deploy: %s\n", output.Blue(link))
-
-			// if opts.flags.Web.Value {
-			// 	browser.OpenURL(link)
-			// }
-			// return ""
 		},
 	})
 }

--- a/pkg/cmd/tenant/view/view.go
+++ b/pkg/cmd/tenant/view/view.go
@@ -139,8 +139,6 @@ func viewRun(opts *ViewOptions, cmd *cobra.Command) error {
 			}
 
 			link := fmt.Sprintf("%s/app#/%s/tenants/%s/overview", opts.Host, tenant.SpaceID, tenant.ID)
-			s.WriteString(fmt.Sprintf("%s\n", link))
-
 			// footer
 			s.WriteString(fmt.Sprintf("View this tenant in Octopus Deploy: %s\n", output.Blue(link)))
 

--- a/pkg/output/print_resource.go
+++ b/pkg/output/print_resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func PrintArray[T any](items []T, cmd *cobra.Command, mappers Mappers[T]) error {
+func PrintResource[T any](item T, cmd *cobra.Command, mappers Mappers[T]) error {
 	outputFormat, _ := cmd.Flags().GetString(constants.FlagOutputFormat)
 	if outputFormat == "" {
 		outputFormat = viper.GetString(constants.ConfigOutputFormat)
@@ -26,10 +26,8 @@ func PrintArray[T any](items []T, cmd *cobra.Command, mappers Mappers[T]) error 
 		if jsonMapper == nil {
 			return errors.New("command does not support output in JSON format")
 		}
-		var outputJson []any
-		for _, e := range items {
-			outputJson = append(outputJson, jsonMapper(e))
-		}
+		var outputJson any
+		outputJson = jsonMapper(item)
 
 		data, _ := json.MarshalIndent(outputJson, "", "  ")
 		cmd.Println(string(data))
@@ -39,9 +37,7 @@ func PrintArray[T any](items []T, cmd *cobra.Command, mappers Mappers[T]) error 
 		if textMapper == nil {
 			return errors.New("command does not support output in plain text")
 		}
-		for _, e := range items {
-			cmd.Println(textMapper(e))
-		}
+		cmd.Println(textMapper(item))
 
 	case constants.OutputFormatTable, "": // table is the default of unspecified
 		tableMapper := mappers.Table
@@ -57,9 +53,7 @@ func PrintArray[T any](items []T, cmd *cobra.Command, mappers Mappers[T]) error 
 			t.AddRow(tableMapper.Header...)
 		}
 
-		for _, item := range items {
-			t.AddRow(tableMapper.Row(item)...)
-		}
+		t.AddRow(tableMapper.Row(item)...)
 
 		return t.Print()
 

--- a/pkg/output/shared.go
+++ b/pkg/output/shared.go
@@ -1,0 +1,35 @@
+package output
+
+// Common struct used for rendering JSON summaries of things that just have an ID and a Name
+type IdAndName struct {
+	Id   string `json:"Id"`
+	Name string `json:"Name"`
+}
+
+type TableDefinition[T any] struct {
+	Header []string
+	Row    func(item T) []string
+}
+
+// carries conversion functions used by PrintArray and potentially other output code in future
+type Mappers[T any] struct {
+	// A function which will convert T into an output structure suitable for json.Marshal (e.g. IdAndName).
+	// If you leave this as nil, then the command will simply not support output as JSON and will
+	// fail if someone asks for it
+	Json func(item T) any
+
+	// A function which will convert T into ?? suitable for table printing
+	// If you leave this as nil, then the command will simply not support output as
+	// a table and will fail if someone asks for it
+	Table TableDefinition[T]
+
+	// A function which will convert T into a string suitable for basic text display
+	// If you leave this as nil, then the command will simply not support output as basic text and will
+	// fail if someone asks for it
+	Basic func(item T) string
+
+	// NOTE: We might have some kinds of entities where table formatting doesn't make sense, and we want to
+	// render those as basic text instead. This seems unlikely though, defer it until the issue comes up.
+
+	// NOTE: The structure for printing tables would also work for CSV... perhaps we can have --outputFormat=csv for free?
+}


### PR DESCRIPTION
This PR introduces a new helper method to add support for output formatting for `view` commands, similar to what there is for `list` commands.

This PR also converts the `tenant view` command to use this new formatting helper. Output below:

**Default (Table) output formatting**
```
❯ ./octopus tenant view "Tenant A" --space Default
NAME      DESCRIPTION  ID           TAGS
Tenant A               Tenants-301  Test/Foo, Hosting/Shared
```
**Basic output formatting**
```
❯ ./octopus tenant view "Tenant A" --space Default -f basic
Tenant A (Tenants-301)
Tags: Test/Foo, Hosting/Shared
No description provided
http://localhost:8065/app#/Spaces-1/tenants/Tenants-301/overview
View this tenant in Octopus Deploy: http://localhost:8065/app#/Spaces-1/tenants/Tenants-301/overview
```
**JSON output formatting**
```
❯ ./octopus tenant view "Tenant A" --space Default -f json
{
  "ClonedFromTenantId": "",
  "Description": "",
  "Name": "Tenant A",
  "SpaceId": "Spaces-1",
  "TenantTags": [
    "Test/Foo",
    "Hosting/Shared"
  ],
  "Id": "Tenants-301",
  "ProjectEnvironments": [
    {
      "Project": {
        "Id": "Projects-501",
        "Name": "Tenant test"
      },
      "Environments": [
        {
          "Id": "Environments-401",
          "Name": "Local"
        }
      ]
    }
  ]
}
```