### PR TITLE
feat: runbook delete

### DIFF
--- a/pkg/cmd/runbook/delete/delete.go
+++ b/pkg/cmd/runbook/delete/delete.go
@@ -1,0 +1,140 @@
+package delete
+
+import (
+	"errors"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/spf13/cobra"
+)
+
+const resourceDescription = "runbook"
+
+const (
+	FlagProject = "project"
+	FlagRunbook = "runbook"
+)
+
+type DeleteFlags struct {
+	Project          *flag.Flag[string]
+	Runbook          *flag.Flag[string]
+	SkipConfirmation bool
+}
+
+func NewDeleteFlags() *DeleteFlags {
+	return &DeleteFlags{
+		Project: flag.New[string](FlagProject, false),
+		Runbook: flag.New[string](FlagRunbook, false),
+	}
+}
+
+type DeleteOptions struct {
+	*DeleteFlags
+	*cmd.Dependencies
+	*shared.RunbooksOptions
+	GetAllProjectsCallback shared.GetAllProjectsCallback
+}
+
+func NewDeleteOptions(dependencies *cmd.Dependencies, flags *DeleteFlags) *DeleteOptions {
+	return &DeleteOptions{
+		DeleteFlags:            flags,
+		Dependencies:           dependencies,
+		RunbooksOptions:        shared.NewGetRunbooksOptions(dependencies),
+		GetAllProjectsCallback: func() ([]*projects.Project, error) { return shared.GetAllProjects(dependencies.Client) },
+	}
+}
+
+func NewCmdDelete(f factory.Factory) *cobra.Command {
+	deleteFlags := NewDeleteFlags()
+	cmd := &cobra.Command{
+		Use:     "delete {<name> | <id>}",
+		Short:   "Delete a runbook",
+		Long:    "Delete a runbook in Octopus Deploy",
+		Aliases: []string{"del", "rm", "remove"},
+		Example: heredoc.Docf(`
+			$ %[1]s runbook delete
+			$ %[1]s runbook rm
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			deps := cmd.NewDependencies(f, c)
+
+			opts := NewDeleteOptions(deps, deleteFlags)
+			if deleteFlags.Runbook.Value == "" {
+				deleteFlags.Runbook.Value = args[0]
+			}
+
+			return deleteRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&deleteFlags.Project.Value, deleteFlags.Project.Name, "p", "", "Name or ID of the project to delete a runbook from")
+	flags.StringVarP(&deleteFlags.Runbook.Value, deleteFlags.Runbook.Name, "r", "", "Name or ID of the runbook to delete")
+	question.RegisterConfirmDeletionFlag(cmd, &deleteFlags.SkipConfirmation, resourceDescription)
+
+	return cmd
+}
+
+func deleteRun(opts *DeleteOptions) error {
+	project, err := getProject(opts)
+	if err != nil {
+		return err
+	}
+
+	runbook, err := getRunbook(opts, project)
+	if err != nil {
+		return err
+	}
+
+	if opts.SkipConfirmation {
+		return delete(opts.Client, runbook)
+	} else {
+		return question.DeleteWithConfirmation(opts.Ask, resourceDescription, runbook.Name, runbook.GetID(), func() error {
+			return delete(opts.Client, runbook)
+		})
+	}
+}
+
+func getRunbook(opts *DeleteOptions, project *projects.Project) (*runbooks.Runbook, error) {
+	var runbook *runbooks.Runbook
+	var err error
+	if opts.Runbook.Value == "" {
+		runbook, err = selectors.Select(opts.Ask, "Select the runbook you wish to delete:", func() ([]*runbooks.Runbook, error) { return opts.GetRunbooksCallback(project.GetID()) }, func(runbook *runbooks.Runbook) string { return runbook.Name })
+	} else {
+		runbook, err = selectors.FindRunbook(opts.Client, project.GetID(), opts.Runbook.Value)
+	}
+
+	if runbook == nil {
+		return nil, errors.New("unable to find runbook")
+	}
+
+	return runbook, err
+}
+
+func getProject(opts *DeleteOptions) (*projects.Project, error) {
+	var project *projects.Project
+	var err error
+	if opts.Project.Value == "" {
+		project, err = selectors.Select(opts.Ask, "Select the project containing the runbook you wish to delete:", opts.GetAllProjectsCallback, func(project *projects.Project) string { return project.GetName() })
+	} else {
+		project, err = selectors.FindProject(opts.Client, opts.Project.Value)
+	}
+
+	if project == nil {
+		return nil, errors.New("unable to find project")
+	}
+
+	return project, err
+}
+
+func delete(client *client.Client, itemToDelete *runbooks.Runbook) error {
+	return client.Runbooks.DeleteByID(itemToDelete.GetID())
+}

--- a/pkg/cmd/runbook/runbook.go
+++ b/pkg/cmd/runbook/runbook.go
@@ -2,6 +2,7 @@ package runbook
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	cmdDelete "github.com/OctopusDeploy/cli/pkg/cmd/runbook/delete"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/runbook/list"
 	cmdRun "github.com/OctopusDeploy/cli/pkg/cmd/runbook/run"
 	"github.com/OctopusDeploy/cli/pkg/constants"
@@ -26,5 +27,6 @@ func NewCmdRunbook(f factory.Factory) *cobra.Command {
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
 	cmd.AddCommand(cmdRun.NewCmdRun(f))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f))
 	return cmd
 }

--- a/pkg/cmd/runbook/shared/shared.go
+++ b/pkg/cmd/runbook/shared/shared.go
@@ -1,0 +1,43 @@
+package shared
+
+import (
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"math"
+)
+
+type GetRunbooksCallback func(projectID string) ([]*runbooks.Runbook, error)
+type GetAllProjectsCallback func() ([]*projects.Project, error)
+
+type RunbooksOptions struct {
+	GetRunbooksCallback
+	GetAllProjectsCallback
+}
+
+func NewGetRunbooksOptions(dependencies *cmd.Dependencies) *RunbooksOptions {
+	return &RunbooksOptions{
+		GetRunbooksCallback: func(projectID string) ([]*runbooks.Runbook, error) {
+			return GetAllRunbooks(dependencies.Client, projectID)
+		},
+	}
+}
+
+func GetAllRunbooks(client newclient.Client, projectID string) ([]*runbooks.Runbook, error) {
+	res, err := runbooks.List(client, client.GetSpaceID(), projectID, "", math.MaxInt32)
+	if err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+func GetAllProjects(client *client.Client) ([]*projects.Project, error) {
+	res, err := client.Projects.GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/pkg/question/selectors/runbooks.go
+++ b/pkg/question/selectors/runbooks.go
@@ -1,0 +1,39 @@
+package selectors
+
+import (
+	"errors"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	octopusApiClient "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"math"
+)
+
+func Runbook(questionText string, octopus *octopusApiClient.Client, ask question.Asker, projectID string) (*runbooks.Runbook, error) {
+	existingRunbooks, err := runbooks.List(octopus, octopus.GetSpaceID(), projectID, "", math.MaxInt32)
+	if len(existingRunbooks.Items) == 0 {
+		return nil, errors.New("no runbooks found")
+	}
+
+	if len(existingRunbooks.Items) == 1 {
+		return existingRunbooks.Items[0], nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return question.SelectMap(ask, questionText, existingRunbooks.Items, func(p *runbooks.Runbook) string {
+
+		return p.Name
+	})
+}
+
+func FindRunbook(octopus *octopusApiClient.Client, projectID string, runbookIdentifier string) (*runbooks.Runbook, error) {
+	runbook, err := runbooks.GetByName(octopus, octopus.GetSpaceID(), projectID, runbookIdentifier)
+	if err != nil {
+		runbook, err = runbooks.GetByID(octopus, octopus.GetSpaceID(), runbookIdentifier)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return runbook, nil
+}


### PR DESCRIPTION
listing runbooks
```
❯ octopus runbook list -s default -p just-runbooks
Project just runbooks
NAME       DESCRIPTION
runbook
runbook-2
```

delete with prompts and confirmation
```
❯ octopus runbook delete -s default
? Select the project containing the runbook you wish to delete: just runbooks
? Select the runbook you wish to delete: runbook-2
? You are about to delete the runbook "runbook-2" (Runbooks-144). This action cannot be reversed. To confirm, type the runbook name: runbook-2
✔ The runbook, "runbook-2" (Runbooks-144) was deleted successfully.
```

delete with confirmation parameter
```
❯ octopus runbook delete -s default -p just-runbooks -r "runbook-2" --confirm

❯ octopus runbook list -s default -p just-runbooks
Project just runbooks
NAME     DESCRIPTION
runbook
```

