### PR TITLE
feat: runbook snapshot create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.38.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.40.2
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.38.1 h1:XxaJaWRD+dyTYKkY+Rbw1kZS9G3KkNECvn2Hmk5Bsls=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.38.1/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.40.2 h1:gdNtnSV75JIguS5z/gb215C0cJVGjQ1rRcjATv54PpY=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.40.2/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -454,16 +453,9 @@ func BuildPackageVersionBaseline(octopus *octopusApiClient.Client, deploymentPro
 	return result, nil
 }
 
-type PackageVersionOverride struct {
-	ActionName           string // optional, but one or both of ActionName or PackageID must be supplied
-	PackageID            string // optional, but one or both of ActionName or PackageID must be supplied
-	PackageReferenceName string // optional; use for advanced situations where the same package is referenced multiple times by a single step
-	Version              string // required
-}
-
 // ToPackageOverrideString converts the struct back into a string which the server can parse e.g. StepName:Version.
 // This is the inverse of ParsePackageOverrideString
-func (p *PackageVersionOverride) ToPackageOverrideString() string {
+func ToPackageOverrideString(p *executionscommon.PackageVersionOverride) string {
 	components := make([]string, 0, 3)
 
 	// stepNameOrPackageID always comes first if we have it
@@ -487,235 +479,6 @@ func (p *PackageVersionOverride) ToPackageOverrideString() string {
 	components = append(components, p.Version)
 
 	return strings.Join(components, ":")
-}
-
-// splitPackageOverrideString splits the input string into components based on delimiter characters.
-// we want to pick up empty entries here; so "::5" and ":pterm:5" should both return THREE components, rather than one or two
-// and we want to allow for multiple different delimeters.
-// neither the builtin golang strings.Split or strings.FieldsFunc support this. Logic borrowed from strings.FieldsFunc with heavy modifications
-func splitPackageOverrideString(s string) []string {
-	// pass 1: collect spans; golang strings.FieldsFunc says it's much more efficient this way
-	type span struct {
-		start int
-		end   int
-	}
-	spans := make([]span, 0, 3)
-
-	// Find the field start and end indices.
-	start := 0 // we always start the first span at the beginning of the string
-	for idx, ch := range s {
-		if ch == ':' || ch == '/' || ch == '=' {
-			if start >= 0 { // we found a delimiter and we are already in a span; end the span and start a new one
-				spans = append(spans, span{start, idx})
-				start = idx + 1
-			} else { // we found a delimiter and we are not in a span; start a new span
-				if start < 0 {
-					start = idx
-				}
-			}
-		}
-	}
-
-	// Last field might end at EOF.
-	if start >= 0 {
-		spans = append(spans, span{start, len(s)})
-	}
-
-	// pass 2: create strings from recorded field indices.
-	a := make([]string, len(spans))
-	for i, span := range spans {
-		a[i] = s[span.start:span.end]
-	}
-	return a
-}
-
-// AmbiguousPackageVersionOverride tells us that we want to set the version of some package to `Version`
-// but it's not clear whether ActionNameOrPackageID refers to an ActionName or PackageID at this point
-type AmbiguousPackageVersionOverride struct {
-	ActionNameOrPackageID string
-	PackageReferenceName  string
-	Version               string
-}
-
-// taken from here https://github.com/OctopusDeploy/Versioning/blob/main/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs#L29
-// but simplified, and removed the support for optional whitespace around version numbers (OctopusVersion would allow "1 . 2 . 3" whereas we won't
-// otherwise this is very lenient
-var validVersionRegex, _ = regexp.Compile("(?i)" + `^\s*(v|V)?\d+(\.\d+)?(\.\d+)?(\.\d+)?[.\-_\\]?([a-z0-9]*?)([.\-_\\]([a-z0-9.\-_\\]*?)?)?(\+([a-z0-9_\-.\\+]*?))?$`)
-
-func isValidVersion(version string) bool {
-	return validVersionRegex.MatchString(version)
-}
-
-// ParsePackageOverrideString parses a package version override string into a structure.
-// Logic should align with PackageVersionResolver in the Octopus Server and .NET CLI
-// In cases where things are ambiguous, we look in steps for matching values to see if something is a PackageID or a StepName
-func ParsePackageOverrideString(packageOverride string) (*AmbiguousPackageVersionOverride, error) {
-	if packageOverride == "" {
-		return nil, errors.New("empty package version specification")
-	}
-
-	components := splitPackageOverrideString(packageOverride)
-	packageReferenceName, stepNameOrPackageID, version := "", "", ""
-
-	switch len(components) {
-	case 2:
-		// if there are two components it is (StepName|PackageID):Version
-		stepNameOrPackageID, version = strings.TrimSpace(components[0]), strings.TrimSpace(components[1])
-	case 3:
-		// if there are three components it is (StepName|PackageID):PackageReferenceName:Version
-		stepNameOrPackageID, packageReferenceName, version = strings.TrimSpace(components[0]), strings.TrimSpace(components[1]), strings.TrimSpace(components[2])
-	default:
-		return nil, fmt.Errorf("package version specification \"%s\" does not use expected format", packageOverride)
-	}
-
-	// must always specify a version; must specify either packageID, stepName or both
-	if version == "" {
-		return nil, fmt.Errorf("package version specification \"%s\" does not use expected format", packageOverride)
-	}
-	if !isValidVersion(version) {
-		return nil, fmt.Errorf("version component \"%s\" is not a valid version", version)
-	}
-
-	// compensate for wildcards
-	if packageReferenceName == "*" {
-		packageReferenceName = ""
-	}
-	if stepNameOrPackageID == "*" {
-		stepNameOrPackageID = ""
-	}
-
-	return &AmbiguousPackageVersionOverride{
-		ActionNameOrPackageID: stepNameOrPackageID,
-		PackageReferenceName:  packageReferenceName,
-		Version:               version,
-	}, nil
-}
-
-func ResolvePackageOverride(override *AmbiguousPackageVersionOverride, steps []*executionscommon.StepPackageVersion) (*PackageVersionOverride, error) {
-	// shortcut for wildcard matches; these match everything so we don't need to do any work
-	if override.PackageReferenceName == "" && override.ActionNameOrPackageID == "" {
-		return &PackageVersionOverride{
-			ActionName:           "",
-			PackageID:            "",
-			PackageReferenceName: "",
-			Version:              override.Version,
-		}, nil
-	}
-
-	actionNameOrPackageID := override.ActionNameOrPackageID
-
-	// it could be either a stepname or a package ID; match against the list of packages to try and guess.
-	// logic matching the server:
-	//  - exact match on stepName + refName
-	//  - then exact match on packageId + refName
-	//  - then match on * + refName
-	//  - then match on stepName + *
-	//  - then match on packageID + *
-	type match struct {
-		priority             int
-		actionName           string // if set we matched on actionName, else we didn't
-		packageID            string // if set we matched on packageID, else we didn't
-		packageReferenceName string // if set we matched on packageReferenceName, else we didn't
-	}
-
-	matches := make([]match, 0, 2) // common case is likely to be 2; if we have a packageID then we may match both exactly and partially on the ID depending on referenceName
-	for _, p := range steps {
-		if p.ActionName != "" && p.ActionName == actionNameOrPackageID {
-			if p.PackageReferenceName == override.PackageReferenceName {
-				matches = append(matches, match{priority: 100, actionName: p.ActionName, packageReferenceName: p.PackageReferenceName})
-			} else {
-				matches = append(matches, match{priority: 50, actionName: p.ActionName})
-			}
-		} else if p.PackageID != "" && p.PackageID == actionNameOrPackageID {
-			if p.PackageReferenceName == override.PackageReferenceName {
-				matches = append(matches, match{priority: 90, packageID: p.PackageID, packageReferenceName: p.PackageReferenceName})
-			} else {
-				matches = append(matches, match{priority: 40, packageID: p.PackageID})
-			}
-		} else if p.PackageReferenceName != "" && p.PackageReferenceName == override.PackageReferenceName {
-			matches = append(matches, match{priority: 80, packageReferenceName: p.PackageReferenceName})
-		}
-	}
-
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("could not resolve step name or package matching %s", actionNameOrPackageID)
-	}
-	sort.SliceStable(matches, func(i, j int) bool { // want a stable sort so if there's more than one possible match we pick the first one
-		return matches[i].priority > matches[j].priority
-	})
-
-	return &PackageVersionOverride{
-		ActionName:           matches[0].actionName,
-		PackageID:            matches[0].packageID,
-		PackageReferenceName: matches[0].packageReferenceName,
-		Version:              override.Version,
-	}, nil
-}
-
-func ApplyPackageOverrides(packages []*executionscommon.StepPackageVersion, overrides []*PackageVersionOverride) []*executionscommon.StepPackageVersion {
-	for _, o := range overrides {
-		packages = applyPackageOverride(packages, o)
-	}
-	return packages
-}
-
-func applyPackageOverride(packages []*executionscommon.StepPackageVersion, override *PackageVersionOverride) []*executionscommon.StepPackageVersion {
-	if override.Version == "" {
-		return packages // not specifying a version is technically an error, but we'll just no-op it for safety; should have been filtered out by ParsePackageOverrideString before we get here
-	}
-
-	var matcher func(pkg *executionscommon.StepPackageVersion) bool = nil
-
-	switch {
-	case override.PackageID == "" && override.ActionName == "": // match everything
-		matcher = func(pkg *executionscommon.StepPackageVersion) bool {
-			return true
-		}
-	case override.PackageID != "" && override.ActionName == "": // match on package ID only
-		matcher = func(pkg *executionscommon.StepPackageVersion) bool {
-			return pkg.PackageID == override.PackageID
-		}
-	case override.PackageID == "" && override.ActionName != "": // match on step only
-		matcher = func(pkg *executionscommon.StepPackageVersion) bool {
-			return pkg.ActionName == override.ActionName
-		}
-	case override.PackageID != "" && override.ActionName != "": // match on both; shouldn't be possible but let's ensure it works anyway
-		matcher = func(pkg *executionscommon.StepPackageVersion) bool {
-			return pkg.PackageID == override.PackageID && pkg.ActionName == override.ActionName
-		}
-	}
-
-	if override.PackageReferenceName != "" { // must also match package reference name
-		if matcher == nil {
-			matcher = func(pkg *executionscommon.StepPackageVersion) bool {
-				return pkg.PackageReferenceName == override.PackageReferenceName
-			}
-		} else {
-			prevMatcher := matcher
-			matcher = func(pkg *executionscommon.StepPackageVersion) bool {
-				return pkg.PackageReferenceName == override.PackageReferenceName && prevMatcher(pkg)
-			}
-		}
-	}
-
-	if matcher == nil {
-		return packages // we can't possibly match against anything; no-op. Should have been filtered out by ParsePackageOverrideString
-	}
-
-	result := make([]*executionscommon.StepPackageVersion, len(packages))
-	for i, p := range packages {
-		if matcher(p) {
-			result[i] = &executionscommon.StepPackageVersion{
-				PackageID:            p.PackageID,
-				ActionName:           p.ActionName,
-				PackageReferenceName: p.PackageReferenceName,
-				Version:              override.Version, // Important bit
-			}
-		} else {
-			result[i] = p
-		}
-	}
-	return result
 }
 
 // Note this always uses the Table Printer, it pays no respect to outputformat=json, because it's only part of the interactive flow
@@ -907,7 +670,7 @@ func AskQuestions(octopus *octopusApiClient.Client, stdout io.Writer, asker ques
 		if len(packageVersionOverrides) > 0 {
 			options.PackageVersionOverrides = make([]string, 0, len(packageVersionOverrides))
 			for _, ov := range packageVersionOverrides {
-				options.PackageVersionOverrides = append(options.PackageVersionOverrides, ov.ToPackageOverrideString())
+				options.PackageVersionOverrides = append(options.PackageVersionOverrides, ToPackageOverrideString(ov))
 			}
 		}
 	} else {
@@ -985,28 +748,28 @@ func AskPackageOverrideLoop(
 	defaultPackageVersion string, // the --package-version command line flag
 	initialPackageOverrideFlags []string, // the --package command line flag (multiple occurrences)
 	asker question.Asker,
-	stdout io.Writer) ([]*executionscommon.StepPackageVersion, []*PackageVersionOverride, error) {
-	packageVersionOverrides := make([]*PackageVersionOverride, 0)
+	stdout io.Writer) ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
+	packageVersionOverrides := make([]*executionscommon.PackageVersionOverride, 0)
 
 	// pickup any partial package specifications that may have arrived on the commandline
 	if defaultPackageVersion != "" {
 		// blind apply to everything
-		packageVersionOverrides = append(packageVersionOverrides, &PackageVersionOverride{Version: defaultPackageVersion})
+		packageVersionOverrides = append(packageVersionOverrides, &executionscommon.PackageVersionOverride{Version: defaultPackageVersion})
 	}
 
 	for _, s := range initialPackageOverrideFlags {
-		ambOverride, err := ParsePackageOverrideString(s)
+		ambOverride, err := executionscommon.ParsePackageOverrideString(s)
 		if err != nil {
 			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
 		}
-		resolvedOverride, err := ResolvePackageOverride(ambOverride, packageVersionBaseline)
+		resolvedOverride, err := executionscommon.ResolvePackageOverride(ambOverride, packageVersionBaseline)
 		if err != nil {
 			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
 		}
 		packageVersionOverrides = append(packageVersionOverrides, resolvedOverride)
 	}
 
-	overriddenPackageVersions := ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+	overriddenPackageVersions := executionscommon.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
 
 outerLoop:
 	for {
@@ -1028,7 +791,7 @@ outerLoop:
 						if !ok {
 							return errors.New("internal error; answer was not a string")
 						}
-						if !isValidVersion(str) {
+						if !executionscommon.IsValidVersion(str) {
 							return fmt.Errorf("\"%s\" is not a valid version", str)
 						}
 						return nil
@@ -1039,10 +802,10 @@ outerLoop:
 					}
 				}
 
-				override := &PackageVersionOverride{Version: answer, ActionName: pkgVersionEntry.ActionName, PackageReferenceName: pkgVersionEntry.PackageReferenceName}
+				override := &executionscommon.PackageVersionOverride{Version: answer, ActionName: pkgVersionEntry.ActionName, PackageReferenceName: pkgVersionEntry.PackageReferenceName}
 				if override != nil {
 					packageVersionOverrides = append(packageVersionOverrides, override)
-					overriddenPackageVersions = ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+					overriddenPackageVersions = executionscommon.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
 				}
 				continue outerLoop
 			}
@@ -1051,7 +814,7 @@ outerLoop:
 		// After all packages have versions attached, we can let people freely tweak things until they're happy
 
 		// side-channel return value from the validator
-		var resolvedOverride *PackageVersionOverride = nil
+		var resolvedOverride *executionscommon.PackageVersionOverride = nil
 		var answer = ""
 		err = asker(&survey.Input{
 			Message: "Package override string (y to accept, u to undo, ? for help):",
@@ -1067,11 +830,11 @@ outerLoop:
 				return nil
 			}
 
-			ambOverride, err := ParsePackageOverrideString(str)
+			ambOverride, err := executionscommon.ParsePackageOverrideString(str)
 			if err != nil {
 				return err
 			}
-			resolvedOverride, err = ResolvePackageOverride(ambOverride, packageVersionBaseline)
+			resolvedOverride, err = executionscommon.ResolvePackageOverride(ambOverride, packageVersionBaseline)
 			if err != nil {
 				return err
 			}
@@ -1093,18 +856,18 @@ outerLoop:
 			if len(packageVersionOverrides) > 0 {
 				packageVersionOverrides = packageVersionOverrides[:len(packageVersionOverrides)-1]
 				// always reset to the baseline and apply everything in order, there's less room for logic errors
-				overriddenPackageVersions = ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+				overriddenPackageVersions = executionscommon.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
 			}
 		case "r": // reset! All the way back to the calculated versions, discarding even the stuff that came in from the cmdline
 			if len(packageVersionOverrides) > 0 {
-				packageVersionOverrides = make([]*PackageVersionOverride, 0)
-				overriddenPackageVersions = ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+				packageVersionOverrides = make([]*executionscommon.PackageVersionOverride, 0)
+				overriddenPackageVersions = executionscommon.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
 			}
 		default:
 			if resolvedOverride != nil {
 				packageVersionOverrides = append(packageVersionOverrides, resolvedOverride)
 				// always reset to the baseline and apply everything in order, there's less room for logic errors
-				overriddenPackageVersions = ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+				overriddenPackageVersions = executionscommon.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
 			}
 		}
 		// loop around and let them put in more input

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/cmd/release/create"
 	cmdRoot "github.com/OctopusDeploy/cli/pkg/cmd/root"
+	"github.com/OctopusDeploy/cli/pkg/executionscommon"
 	"github.com/OctopusDeploy/cli/pkg/executor"
 	"github.com/OctopusDeploy/cli/pkg/surveyext"
 	"github.com/OctopusDeploy/cli/test/fixtures"
@@ -703,7 +704,7 @@ func TestReleaseCreate_AskQuestions_VersionControlledProject(t *testing.T) {
 
 func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
-	baseline := []*create.StepPackageVersion{
+	baseline := []*executionscommon.StepPackageVersion{
 		{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 		{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 		{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
@@ -715,7 +716,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 	}{
 		// this is the happy path where the CLI presents the list of server-selected packages and they just go 'yep'
 		{"no-op test", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -728,7 +729,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"override package based on package ID", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -738,7 +739,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
@@ -749,7 +750,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"override package based on step name", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -759,7 +760,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
@@ -770,7 +771,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"override package based on package reference", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -780,7 +781,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
@@ -793,7 +794,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		{"entering the loop with --package-version picked up from the command line", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
 			defaultPackageVersion := "2.5"
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, defaultPackageVersion, make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -801,7 +802,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
@@ -814,7 +815,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		{"entering the loop with --package picked up from the command line", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
 			cmdlinePackages := []string{"Install:pterm:2.5", "NuGet.CommandLine:7.1"}
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", cmdlinePackages, qa.AsAsker(), stdout)
 			})
 
@@ -822,7 +823,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "7.1"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
@@ -837,7 +838,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 			defaultPackageVersion := "9.9"
 			cmdlinePackages := []string{"Install:pterm:2.5", "NuGet.CommandLine:7.1"}
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, defaultPackageVersion, cmdlinePackages, qa.AsAsker(), stdout)
 			})
 
@@ -845,7 +846,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "7.1"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "9.9"},
@@ -858,7 +859,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"blank answer retries the question", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -878,7 +879,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"can't specify garbage; question loop retries", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -904,7 +905,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
@@ -915,7 +916,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"can't specify packages or steps that aren't there due to validator; question loop retries", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -932,7 +933,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
@@ -943,7 +944,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"question loop doesn't retry if it gets a hard error", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -956,7 +957,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"multiple overrides with undo", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -972,7 +973,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "7.1"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"}, // this would have been hit by pterm:35 but we undid it
@@ -984,7 +985,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"multiple overrides with reset", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1000,7 +1001,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"}, // this would have been hit by pterm:35 but we undid it
@@ -1012,13 +1013,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 		// this is the happy path where the CLI presents the list of server-selected packages and they just go 'yep'
 		{"if we enter the loop with any unresolved packages, force version selection for them before entering the main loop", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			baselineSomeUnresolved := []*create.StepPackageVersion{
+			baselineSomeUnresolved := []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: ""},                         // unresolved
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: ""}, // unresolved
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1054,7 +1055,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "75"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "1.0.0"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
@@ -1066,12 +1067,12 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"if we enter the loop with any unresolved packages, forced version selection doesn't accept bad input", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			baselineSomeUnresolved := []*create.StepPackageVersion{
+			baselineSomeUnresolved := []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: ""}, // unresolved
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1098,7 +1099,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "25.0"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
@@ -1108,13 +1109,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"if we enter the loop with any unresolved packages, pick up --package-version before assuming they're unresolved", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			baselineSomeUnresolved := []*create.StepPackageVersion{
+			baselineSomeUnresolved := []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: ""},                         // unresolved
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: ""}, // unresolved
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "12.7.5", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1130,7 +1131,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "12.7.5"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "12.7.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "12.7.5"},
@@ -1142,13 +1143,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"if we enter the loop with any unresolved packages, pick up --package before assuming they're unresolved", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			baselineSomeUnresolved := []*create.StepPackageVersion{
+			baselineSomeUnresolved := []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: ""},                         // unresolved
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: ""}, // unresolved
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*create.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "", []string{"Install:pterm:12.9.2"}, qa.AsAsker(), stdout)
 			})
 
@@ -1174,7 +1175,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
-			assert.Equal(t, []*create.StepPackageVersion{
+			assert.Equal(t, []*executionscommon.StepPackageVersion{
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "12.9.2"},
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "75"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
@@ -1806,7 +1807,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		channel := fixtures.NewChannel(spaceID, "Channels-1", "Default", "Projects-1")
 
-		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+		receiver := testutil.GoBegin2(func() ([]*executionscommon.StepPackageVersion, error) {
 			defer api.Close()
 			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
@@ -1818,7 +1819,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		packageVersions, err := testutil.ReceivePair(receiver)
 		assert.Nil(t, err)
-		assert.Equal(t, []*create.StepPackageVersion{}, packageVersions)
+		assert.Equal(t, []*executionscommon.StepPackageVersion{}, packageVersions)
 	})
 
 	t.Run("builds list for single package/step", func(t *testing.T) {
@@ -1838,7 +1839,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		channel := fixtures.NewChannel(spaceID, "Channels-1", "Default", "Projects-1")
 
-		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+		receiver := testutil.GoBegin2(func() ([]*executionscommon.StepPackageVersion, error) {
 			defer api.Close()
 			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
@@ -1865,7 +1866,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		packageVersions, err := testutil.ReceivePair(receiver)
 		assert.Nil(t, err)
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{
 				PackageID:            "pterm",
 				ActionName:           "Install",
@@ -1913,7 +1914,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		channel := fixtures.NewChannel(spaceID, "Channels-1", "Default", "Projects-1")
 
-		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+		receiver := testutil.GoBegin2(func() ([]*executionscommon.StepPackageVersion, error) {
 			defer api.Close()
 			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
@@ -1952,7 +1953,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		packageVersions, err := testutil.ReceivePair(receiver)
 		assert.Nil(t, err)
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{
 				PackageID:            "pterm",
 				ActionName:           "Install",
@@ -2036,7 +2037,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 			},
 		}
 
-		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+		receiver := testutil.GoBegin2(func() ([]*executionscommon.StepPackageVersion, error) {
 			defer api.Close()
 			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
@@ -2080,7 +2081,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		packageVersions, err := testutil.ReceivePair(receiver)
 		assert.Nil(t, err)
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{
 				PackageID:            "pterm",
 				ActionName:           "Install",
@@ -2122,7 +2123,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		channel := fixtures.NewChannel(spaceID, "Channels-1", "Default", "Projects-1")
 
-		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+		receiver := testutil.GoBegin2(func() ([]*executionscommon.StepPackageVersion, error) {
 			defer api.Close()
 			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
@@ -2150,7 +2151,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		packageVersions, err := testutil.ReceivePair(receiver)
 		assert.Nil(t, err)
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{
 				PackageID:            "pterm",
 				ActionName:           "Install",
@@ -2180,7 +2181,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		channel := fixtures.NewChannel(spaceID, "Channels-1", "Default", "Projects-1")
 
-		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+		receiver := testutil.GoBegin2(func() ([]*executionscommon.StepPackageVersion, error) {
 			defer api.Close()
 			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
 			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
@@ -2206,7 +2207,7 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 
 		packageVersions, err := testutil.ReceivePair(receiver)
 		assert.Nil(t, err)
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{
 				PackageID:            "pterm-#{Octopus.Environment.Name}",
 				ActionName:           "Install",
@@ -2305,7 +2306,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on package ID", func(t *testing.T) { // this is probably the most common thing people will do
 		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
@@ -2318,7 +2319,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on step name", func(t *testing.T) { // this is probably the most common thing people will do
 		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "Install", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
@@ -2331,7 +2332,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on packageRef", func(t *testing.T) {
 		nugetPackage := &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet-B"},
 		}
@@ -2345,7 +2346,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on just version", func(t *testing.T) { // this is probably the most common thing people will do
 		nugetPackage := &create.AmbiguousPackageVersionOverride{Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
@@ -2357,7 +2358,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on just version doesn't even need any packages to look at", func(t *testing.T) { // this is probably the most common thing people will do
 		nugetPackage := &create.AmbiguousPackageVersionOverride{Version: "5.0"}
 
-		steps := make([]*create.StepPackageVersion, 0) // baseline
+		steps := make([]*executionscommon.StepPackageVersion, 0) // baseline
 
 		r, err := create.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
@@ -2367,7 +2368,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on action+packageRef before packageID", func(t *testing.T) { // this is probably the most common thing people will do
 		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "Verify", PackageReferenceName: "NuGet", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
@@ -2380,7 +2381,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on packageID+packageRef picks the first one where they are the same", func(t *testing.T) {
 		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", PackageReferenceName: "NuGet", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
@@ -2393,7 +2394,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	t.Run("match on packageID+packageRef picks the correct one where they are different", func(t *testing.T) {
 		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", PackageReferenceName: "NuGet-B", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet-B"},
 		}
@@ -2407,7 +2408,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 		// we shouldn't get in this situation, but just in case we do :shrug:
 		nugetPackage := &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", ActionNameOrPackageID: "Cheese", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet-B"},
 			{PackageID: "OtherPackage", ActionName: "Cheese", Version: "0.1", PackageReferenceName: "Cheese"},
@@ -2422,7 +2423,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 		// we shouldn't get in this situation, but just in case we do :shrug:
 		nugetPackage := &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", ActionNameOrPackageID: "Cheese", Version: "5.0"}
 
-		steps := []*create.StepPackageVersion{ // baseline
+		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet-B"},
 			{PackageID: "Cheese", ActionName: "OtherAction", Version: "0.1", PackageReferenceName: "OtherAction"},
@@ -2435,7 +2436,7 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 }
 
 func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
-	standardPackageSpec := []*create.StepPackageVersion{
+	standardPackageSpec := []*executionscommon.StepPackageVersion{
 		{PackageID: "pterm", ActionName: "Install", Version: "0.12", PackageReferenceName: "pterm-on-install"},
 		{PackageID: "pterm", ActionName: "Push", Version: "0.12", PackageReferenceName: "pterm-on-push"},
 		{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "5.4", PackageReferenceName: "nuget-on-install"},
@@ -2447,7 +2448,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{Version: "99"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", Version: "99", PackageReferenceName: "pterm-on-install"},
 			{PackageID: "pterm", ActionName: "Push", Version: "99", PackageReferenceName: "pterm-on-push"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "99", PackageReferenceName: "nuget-on-install"},
@@ -2460,7 +2461,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageID: "pterm", Version: "99"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", Version: "99", PackageReferenceName: "pterm-on-install"},
 			{PackageID: "pterm", ActionName: "Push", Version: "99", PackageReferenceName: "pterm-on-push"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "5.4", PackageReferenceName: "nuget-on-install"},
@@ -2473,7 +2474,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{ActionName: "Install", Version: "99"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", Version: "99", PackageReferenceName: "pterm-on-install"},
 			{PackageID: "pterm", ActionName: "Push", Version: "0.12", PackageReferenceName: "pterm-on-push"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "99", PackageReferenceName: "nuget-on-install"},
@@ -2486,7 +2487,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageID: "pterm", ActionName: "Install", Version: "99"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", Version: "99", PackageReferenceName: "pterm-on-install"},
 			{PackageID: "pterm", ActionName: "Push", Version: "0.12", PackageReferenceName: "pterm-on-push"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "5.4", PackageReferenceName: "nuget-on-install"},
@@ -2501,7 +2502,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageID: "NuGet.CommandLine", ActionName: "Push", Version: "6"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", Version: "2", PackageReferenceName: "pterm-on-install"},
 			{PackageID: "pterm", ActionName: "Push", Version: "2", PackageReferenceName: "pterm-on-push"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "0.1", PackageReferenceName: "nuget-on-install"},
@@ -2516,7 +2517,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{Version: "0.1"}, // overwrites everything
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", Version: "0.1", PackageReferenceName: "pterm-on-install"},
 			{PackageID: "pterm", ActionName: "Push", Version: "0.1", PackageReferenceName: "pterm-on-push"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", Version: "0.1", PackageReferenceName: "nuget-on-install"},
@@ -2525,7 +2526,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	})
 
 	t.Run("apply single override targeting only package-ref", func(t *testing.T) {
-		packageSpec := []*create.StepPackageVersion{
+		packageSpec := []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", PackageReferenceName: "pterm-on-install", Version: "0.12"},
 			{PackageID: "pterm", ActionName: "Push", PackageReferenceName: "pterm", Version: "0.12"},
 			{PackageID: "pterm", ActionName: "Verify", PackageReferenceName: "pterm", Version: "0.12"},
@@ -2536,7 +2537,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageReferenceName: "pterm", Version: "2000"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", PackageReferenceName: "pterm-on-install", Version: "0.12"},
 			{PackageID: "pterm", ActionName: "Push", PackageReferenceName: "pterm", Version: "2000"},
 			{PackageID: "pterm", ActionName: "Verify", PackageReferenceName: "pterm", Version: "2000"},
@@ -2546,7 +2547,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 
 	t.Run("target both of package-ref:action where package referencename matches another package too", func(t *testing.T) {
 		// real bug observed with manual testing
-		packageSpec := []*create.StepPackageVersion{
+		packageSpec := []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", PackageReferenceName: "pterm-on-install", Version: "0.12"},
 			{PackageID: "pterm", ActionName: "Push", PackageReferenceName: "pterm", Version: "0.12"},
 			{PackageID: "pterm", ActionName: "Verify", PackageReferenceName: "pterm", Version: "0.12"},
@@ -2557,7 +2558,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageReferenceName: "pterm-on-install", ActionName: "Install", Version: "20000"},
 		})
 
-		assert.Equal(t, []*create.StepPackageVersion{
+		assert.Equal(t, []*executionscommon.StepPackageVersion{
 			{PackageID: "pterm", ActionName: "Install", PackageReferenceName: "pterm-on-install", Version: "20000"}, // only this one should be overridden
 			{PackageID: "pterm", ActionName: "Push", PackageReferenceName: "pterm", Version: "0.12"},
 			{PackageID: "pterm", ActionName: "Verify", PackageReferenceName: "pterm", Version: "0.12"},

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -716,7 +716,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 	}{
 		// this is the happy path where the CLI presents the list of server-selected packages and they just go 'yep'
 		{"no-op test", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -725,11 +725,11 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
 			assert.Equal(t, baseline, versions)
-			assert.Equal(t, make([]*create.PackageVersionOverride, 0), overrides)
+			assert.Equal(t, make([]*executionscommon.PackageVersionOverride, 0), overrides)
 		}},
 
 		{"override package based on package ID", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -744,13 +744,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageID: "pterm", Version: "2.5"},
 			}, overrides)
 		}},
 
 		{"override package based on step name", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -765,13 +765,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{ActionName: "Install", Version: "2.5"},
 			}, overrides)
 		}},
 
 		{"override package based on package reference", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -786,7 +786,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "2.5"},
 			}, overrides)
 		}},
@@ -794,7 +794,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		{"entering the loop with --package-version picked up from the command line", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
 			defaultPackageVersion := "2.5"
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, defaultPackageVersion, make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -807,7 +807,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{Version: "2.5"}, // TODO the "regenerate command line flags" code is going to re-interpret this as "--package *:2.5" rather than the input which was "--package-version 2.5". Does that matter?
 			}, overrides)
 		}},
@@ -815,7 +815,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		{"entering the loop with --package picked up from the command line", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
 			cmdlinePackages := []string{"Install:pterm:2.5", "NuGet.CommandLine:7.1"}
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", cmdlinePackages, qa.AsAsker(), stdout)
 			})
 
@@ -828,7 +828,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "7.1"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "2.5"},
 				{PackageID: "NuGet.CommandLine", Version: "7.1"},
 			}, overrides)
@@ -838,7 +838,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 			defaultPackageVersion := "9.9"
 			cmdlinePackages := []string{"Install:pterm:2.5", "NuGet.CommandLine:7.1"}
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, defaultPackageVersion, cmdlinePackages, qa.AsAsker(), stdout)
 			})
 
@@ -851,7 +851,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "7.1"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "9.9"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{Version: "9.9"}, // TODO the "regenerate command line flags" code is going to re-interpret this as "--package *:9.9" rather than the input which was "--package-version 9.9". Does that matter?
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "2.5"},
 				{PackageID: "NuGet.CommandLine", Version: "7.1"},
@@ -859,7 +859,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"blank answer retries the question", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -875,11 +875,11 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 			versions, overrides, err := testutil.ReceiveTriple(receiver)
 			assert.Nil(t, err)
 			assert.Equal(t, baseline, versions)
-			assert.Equal(t, make([]*create.PackageVersionOverride, 0), overrides)
+			assert.Equal(t, make([]*executionscommon.PackageVersionOverride, 0), overrides)
 		}},
 
 		{"can't specify garbage; question loop retries", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -910,13 +910,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{Version: "2.5"},
 			}, overrides)
 		}},
 
 		{"can't specify packages or steps that aren't there due to validator; question loop retries", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -938,13 +938,13 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "2.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "2.5"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{Version: "2.5"},
 			}, overrides)
 		}},
 
 		{"question loop doesn't retry if it gets a hard error", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -957,7 +957,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 		}},
 
 		{"multiple overrides with undo", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -978,14 +978,14 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "7.1"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"}, // this would have been hit by pterm:35 but we undid it
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageID: "NuGet.CommandLine", Version: "7.1"},
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "2.5"},
 			}, overrides)
 		}},
 
 		{"multiple overrides with reset", func(t *testing.T, qa *testutil.AskMocker, stdout *bytes.Buffer) {
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baseline, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1006,7 +1006,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "6.1.2"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"}, // this would have been hit by pterm:35 but we undid it
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "2.5"},
 			}, overrides)
 		}},
@@ -1019,7 +1019,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1060,7 +1060,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "1.0.0"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "75"}, // fully qualify packagereference+actionname to be sure
 				{PackageReferenceName: "NuGet.CommandLine", ActionName: "Install", Version: "1.0.0"},
 			}, overrides)
@@ -1072,7 +1072,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1103,7 +1103,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "pterm", PackageReferenceName: "pterm", Version: "25.0"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "25.0"}, // fully qualify packagereference+actionname to be sure
 			}, overrides)
 		}},
@@ -1115,7 +1115,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "12.7.5", make([]string, 0), qa.AsAsker(), stdout)
 			})
 
@@ -1136,7 +1136,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "12.7.5"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "12.7.5"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{Version: "12.7.5"}, // the --package-version input produces this as the first 'override'
 				// and that's all we did there
 			}, overrides)
@@ -1149,7 +1149,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}
 
-			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*create.PackageVersionOverride, error) {
+			receiver := testutil.GoBegin3(func() ([]*executionscommon.StepPackageVersion, []*executionscommon.PackageVersionOverride, error) {
 				return create.AskPackageOverrideLoop(baselineSomeUnresolved, "", []string{"Install:pterm:12.9.2"}, qa.AsAsker(), stdout)
 			})
 
@@ -1180,7 +1180,7 @@ func TestReleaseCreate_AskQuestions_AskPackageOverrideLoop(t *testing.T) {
 				{ActionName: "Install", PackageID: "NuGet.CommandLine", PackageReferenceName: "NuGet.CommandLine", Version: "75"},
 				{ActionName: "Verify", PackageID: "pterm", PackageReferenceName: "pterm", Version: "0.12"},
 			}, versions)
-			assert.Equal(t, []*create.PackageVersionOverride{
+			assert.Equal(t, []*executionscommon.PackageVersionOverride{
 				{PackageReferenceName: "pterm", ActionName: "Install", Version: "12.9.2"},         // input commandline switch produces this output
 				{PackageReferenceName: "NuGet.CommandLine", ActionName: "Install", Version: "75"}, // our first question produces this
 			}, overrides)
@@ -2234,24 +2234,24 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 func TestReleaseCreate_ToPackageOverrideString(t *testing.T) {
 	tests := []struct {
 		name   string
-		input  *create.PackageVersionOverride
+		input  *executionscommon.PackageVersionOverride
 		expect string
 	}{
-		{name: "ver-only", input: &create.PackageVersionOverride{Version: "0.12"}, expect: "*:0.12"},
-		{name: "action-ver", input: &create.PackageVersionOverride{ActionName: "Install", Version: "0.12"}, expect: "Install:0.12"},
-		{name: "action-ver-2", input: &create.PackageVersionOverride{ActionName: "Verify", Version: "6.1.2-beta"}, expect: "Verify:6.1.2-beta"},
-		{name: "pkg-ver", input: &create.PackageVersionOverride{PackageID: "pterm", Version: "0.12"}, expect: "pterm:0.12"},
-		{name: "pkg-ver-2", input: &create.PackageVersionOverride{PackageID: "NuGet.CommandLine", Version: "6.1.2-beta"}, expect: "NuGet.CommandLine:6.1.2-beta"},
-		{name: "pkg-action-ver", input: &create.PackageVersionOverride{PackageID: "pterm", ActionName: "Install", Version: "0.12"}, expect: "pterm:0.12"}, // this isn't valid, but if it did happen it should pick packageID
-		{name: "pkg-ref-ver", input: &create.PackageVersionOverride{PackageReferenceName: "pterm-on-install", PackageID: "pterm", Version: "6.1.2"}, expect: "pterm:pterm-on-install:6.1.2"},
-		{name: "action-ref-ver", input: &create.PackageVersionOverride{PackageReferenceName: "pterm-on-install", ActionName: "Install", Version: "6.1.2"}, expect: "Install:pterm-on-install:6.1.2"},
-		{name: "star-ref-ver", input: &create.PackageVersionOverride{PackageReferenceName: "pterm-on-install", Version: "6.1.2"}, expect: "*:pterm-on-install:6.1.2"},
-		{name: "pkg-action-ref-ver", input: &create.PackageVersionOverride{PackageReferenceName: "pterm", PackageID: "pterm", ActionName: "Install", Version: "1.2.3"}, expect: "pterm:pterm:1.2.3"},
+		{name: "ver-only", input: &executionscommon.PackageVersionOverride{Version: "0.12"}, expect: "*:0.12"},
+		{name: "action-ver", input: &executionscommon.PackageVersionOverride{ActionName: "Install", Version: "0.12"}, expect: "Install:0.12"},
+		{name: "action-ver-2", input: &executionscommon.PackageVersionOverride{ActionName: "Verify", Version: "6.1.2-beta"}, expect: "Verify:6.1.2-beta"},
+		{name: "pkg-ver", input: &executionscommon.PackageVersionOverride{PackageID: "pterm", Version: "0.12"}, expect: "pterm:0.12"},
+		{name: "pkg-ver-2", input: &executionscommon.PackageVersionOverride{PackageID: "NuGet.CommandLine", Version: "6.1.2-beta"}, expect: "NuGet.CommandLine:6.1.2-beta"},
+		{name: "pkg-action-ver", input: &executionscommon.PackageVersionOverride{PackageID: "pterm", ActionName: "Install", Version: "0.12"}, expect: "pterm:0.12"}, // this isn't valid, but if it did happen it should pick packageID
+		{name: "pkg-ref-ver", input: &executionscommon.PackageVersionOverride{PackageReferenceName: "pterm-on-install", PackageID: "pterm", Version: "6.1.2"}, expect: "pterm:pterm-on-install:6.1.2"},
+		{name: "action-ref-ver", input: &executionscommon.PackageVersionOverride{PackageReferenceName: "pterm-on-install", ActionName: "Install", Version: "6.1.2"}, expect: "Install:pterm-on-install:6.1.2"},
+		{name: "star-ref-ver", input: &executionscommon.PackageVersionOverride{PackageReferenceName: "pterm-on-install", Version: "6.1.2"}, expect: "*:pterm-on-install:6.1.2"},
+		{name: "pkg-action-ref-ver", input: &executionscommon.PackageVersionOverride{PackageReferenceName: "pterm", PackageID: "pterm", ActionName: "Install", Version: "1.2.3"}, expect: "pterm:pterm:1.2.3"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := test.input.ToPackageOverrideString()
+			result := create.ToPackageOverrideString(test.input)
 			assert.Equal(t, test.expect, result)
 		})
 	}
@@ -2260,25 +2260,25 @@ func TestReleaseCreate_ToPackageOverrideString(t *testing.T) {
 func TestReleaseCreate_ParsePackageOverrideString(t *testing.T) {
 	tests := []struct {
 		input     string
-		expect    *create.AmbiguousPackageVersionOverride
+		expect    *executionscommon.AmbiguousPackageVersionOverride
 		expectErr error
 	}{
-		{input: ":5", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
-		{input: "::5", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
-		{input: "*:5", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
-		{input: "*:*:5", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
-		{input: ":*:5", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
-		{input: "NuGet:NuGet:0.1", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet", ActionNameOrPackageID: "NuGet", Version: "0.1"}},
-		{input: "NuGet:nuget-on-install:0.1", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "nuget-on-install", ActionNameOrPackageID: "NuGet", Version: "0.1"}},
-		{input: "Install:nuget-on-install:0.1", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "nuget-on-install", ActionNameOrPackageID: "Install", Version: "0.1"}},
-		{input: "pterm:9.7-pre-xyz", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "pterm", Version: "9.7-pre-xyz"}},
-		{input: "pterm:55", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "pterm", Version: "55"}},
-		{input: "pterm::55", expect: &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "pterm", Version: "55"}},
-		{input: ":Push Package:55", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "", Version: "55"}},
-		{input: "*:Push Package:55", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "", Version: "55"}},
+		{input: ":5", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
+		{input: "::5", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
+		{input: "*:5", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
+		{input: "*:*:5", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
+		{input: ":*:5", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "", Version: "5"}},
+		{input: "NuGet:NuGet:0.1", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet", ActionNameOrPackageID: "NuGet", Version: "0.1"}},
+		{input: "NuGet:nuget-on-install:0.1", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "nuget-on-install", ActionNameOrPackageID: "NuGet", Version: "0.1"}},
+		{input: "Install:nuget-on-install:0.1", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "nuget-on-install", ActionNameOrPackageID: "Install", Version: "0.1"}},
+		{input: "pterm:9.7-pre-xyz", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "pterm", Version: "9.7-pre-xyz"}},
+		{input: "pterm:55", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "pterm", Version: "55"}},
+		{input: "pterm::55", expect: &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "pterm", Version: "55"}},
+		{input: ":Push Package:55", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "", Version: "55"}},
+		{input: "*:Push Package:55", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "", Version: "55"}},
 
-		{input: "pterm/Push Package=9.7-pre-xyz", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "pterm", Version: "9.7-pre-xyz"}},
-		{input: "pterm=Push Package/9.7-pre-xyz", expect: &create.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "pterm", Version: "9.7-pre-xyz"}},
+		{input: "pterm/Push Package=9.7-pre-xyz", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "pterm", Version: "9.7-pre-xyz"}},
+		{input: "pterm=Push Package/9.7-pre-xyz", expect: &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "Push Package", ActionNameOrPackageID: "pterm", Version: "9.7-pre-xyz"}},
 
 		{input: "", expectErr: errors.New("empty package version specification")},
 
@@ -2294,7 +2294,7 @@ func TestReleaseCreate_ParsePackageOverrideString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			result, err := create.ParsePackageOverrideString(test.input)
+			result, err := executionscommon.ParsePackageOverrideString(test.input)
 			assert.Equal(t, test.expectErr, err)
 			assert.Equal(t, test.expect, result)
 		})
@@ -2304,109 +2304,109 @@ func TestReleaseCreate_ParsePackageOverrideString(t *testing.T) {
 func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 	// this is the packageId:5.0 syntax
 	t.Run("match on package ID", func(t *testing.T) { // this is probably the most common thing people will do
-		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "NuGet", ActionName: "", Version: "5.0", PackageReferenceName: ""}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "NuGet", ActionName: "", Version: "5.0", PackageReferenceName: ""}, r)
 	})
 
 	// this is the stepName:5.0 syntax
 	t.Run("match on step name", func(t *testing.T) { // this is probably the most common thing people will do
-		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "Install", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "Install", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "Install", Version: "5.0", PackageReferenceName: ""}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "Install", Version: "5.0", PackageReferenceName: ""}, r)
 	})
 
 	// this is the packageRef:*:5.0 syntax
 	t.Run("match on packageRef", func(t *testing.T) {
-		nugetPackage := &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet-B"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
 	})
 
 	// this is the *:5.0 or :5.0 or just 5.0 syntax
 	t.Run("match on just version", func(t *testing.T) { // this is probably the most common thing people will do
-		nugetPackage := &create.AmbiguousPackageVersionOverride{Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: ""}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: ""}, r)
 	})
 
 	t.Run("match on just version doesn't even need any packages to look at", func(t *testing.T) { // this is probably the most common thing people will do
-		nugetPackage := &create.AmbiguousPackageVersionOverride{Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{Version: "5.0"}
 
 		steps := make([]*executionscommon.StepPackageVersion, 0) // baseline
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: ""}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: ""}, r)
 	})
 
 	t.Run("match on action+packageRef before packageID", func(t *testing.T) { // this is probably the most common thing people will do
-		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "Verify", PackageReferenceName: "NuGet", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "Verify", PackageReferenceName: "NuGet", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "Verify", Version: "5.0", PackageReferenceName: "NuGet"}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "Verify", Version: "5.0", PackageReferenceName: "NuGet"}, r)
 	})
 
 	t.Run("match on packageID+packageRef picks the first one where they are the same", func(t *testing.T) {
-		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", PackageReferenceName: "NuGet", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", PackageReferenceName: "NuGet", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "NuGet", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet"}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "NuGet", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet"}, r)
 	})
 
 	t.Run("match on packageID+packageRef picks the correct one where they are different", func(t *testing.T) {
-		nugetPackage := &create.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", PackageReferenceName: "NuGet-B", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{ActionNameOrPackageID: "NuGet", PackageReferenceName: "NuGet-B", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
 			{PackageID: "NuGet", ActionName: "Verify", Version: "0.1", PackageReferenceName: "NuGet-B"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "NuGet", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "NuGet", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
 	})
 
 	t.Run("match on packageRef wins over match on ActionName", func(t *testing.T) {
 		// we shouldn't get in this situation, but just in case we do :shrug:
-		nugetPackage := &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", ActionNameOrPackageID: "Cheese", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", ActionNameOrPackageID: "Cheese", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
@@ -2414,14 +2414,14 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 			{PackageID: "OtherPackage", ActionName: "Cheese", Version: "0.1", PackageReferenceName: "Cheese"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
 	})
 
 	t.Run("match on packageRef wins over match on PackageID", func(t *testing.T) {
 		// we shouldn't get in this situation, but just in case we do :shrug:
-		nugetPackage := &create.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", ActionNameOrPackageID: "Cheese", Version: "5.0"}
+		nugetPackage := &executionscommon.AmbiguousPackageVersionOverride{PackageReferenceName: "NuGet-B", ActionNameOrPackageID: "Cheese", Version: "5.0"}
 
 		steps := []*executionscommon.StepPackageVersion{ // baseline
 			{PackageID: "NuGet", ActionName: "Install", Version: "0.1", PackageReferenceName: "NuGet-A"},
@@ -2429,9 +2429,9 @@ func TestReleaseCreate_ResolvePackageOverride(t *testing.T) {
 			{PackageID: "Cheese", ActionName: "OtherAction", Version: "0.1", PackageReferenceName: "OtherAction"},
 		}
 
-		r, err := create.ResolvePackageOverride(nugetPackage, steps)
+		r, err := executionscommon.ResolvePackageOverride(nugetPackage, steps)
 		assert.Nil(t, err)
-		assert.Equal(t, &create.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
+		assert.Equal(t, &executionscommon.PackageVersionOverride{PackageID: "", ActionName: "", Version: "5.0", PackageReferenceName: "NuGet-B"}, r)
 	})
 }
 
@@ -2444,7 +2444,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	}
 
 	t.Run("apply wildcard override", func(t *testing.T) {
-		result := create.ApplyPackageOverrides(standardPackageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(standardPackageSpec, []*executionscommon.PackageVersionOverride{
 			{Version: "99"},
 		})
 
@@ -2457,7 +2457,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	})
 
 	t.Run("apply one override based on package ID", func(t *testing.T) {
-		result := create.ApplyPackageOverrides(standardPackageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(standardPackageSpec, []*executionscommon.PackageVersionOverride{
 			{PackageID: "pterm", Version: "99"},
 		})
 
@@ -2470,7 +2470,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	})
 
 	t.Run("apply one override based on step name", func(t *testing.T) {
-		result := create.ApplyPackageOverrides(standardPackageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(standardPackageSpec, []*executionscommon.PackageVersionOverride{
 			{ActionName: "Install", Version: "99"},
 		})
 
@@ -2483,7 +2483,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	})
 
 	t.Run("apply one override based on both package and step name", func(t *testing.T) {
-		result := create.ApplyPackageOverrides(standardPackageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(standardPackageSpec, []*executionscommon.PackageVersionOverride{
 			{PackageID: "pterm", ActionName: "Install", Version: "99"},
 		})
 
@@ -2496,7 +2496,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	})
 
 	t.Run("apply multiple overrides", func(t *testing.T) {
-		result := create.ApplyPackageOverrides(standardPackageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(standardPackageSpec, []*executionscommon.PackageVersionOverride{
 			{Version: "0.1"},
 			{PackageID: "pterm", Version: "2"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Push", Version: "6"},
@@ -2511,7 +2511,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 	})
 
 	t.Run("apply multiple overrides; order matters", func(t *testing.T) {
-		result := create.ApplyPackageOverrides(standardPackageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(standardPackageSpec, []*executionscommon.PackageVersionOverride{
 			{PackageID: "pterm", Version: "2"},
 			{PackageID: "NuGet.CommandLine", ActionName: "Push", Version: "6"},
 			{Version: "0.1"}, // overwrites everything
@@ -2533,7 +2533,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", PackageReferenceName: "NuGet.CommandLine", Version: "5.4"},
 		}
 
-		result := create.ApplyPackageOverrides(packageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(packageSpec, []*executionscommon.PackageVersionOverride{
 			{PackageReferenceName: "pterm", Version: "2000"},
 		})
 
@@ -2554,7 +2554,7 @@ func TestReleaseCreate_ApplyPackageOverride(t *testing.T) {
 			{PackageID: "NuGet.CommandLine", ActionName: "Install", PackageReferenceName: "NuGet.CommandLine", Version: "5.4"},
 		}
 
-		result := create.ApplyPackageOverrides(packageSpec, []*create.PackageVersionOverride{
+		result := executionscommon.ApplyPackageOverrides(packageSpec, []*executionscommon.PackageVersionOverride{
 			{PackageReferenceName: "pterm-on-install", ActionName: "Install", Version: "20000"},
 		})
 

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -122,7 +122,7 @@ func NewCmdRun(f factory.Factory) *cobra.Command {
 		Long:  "Run runbooks in Octopus Deploy",
 		Example: heredoc.Docf(`
 			$ %[1]s runbook run  # fully interactive
-			$ %[1]s runbook run --project MyProject ... TODO
+			$ %[1]s runbook run --project MyProject --runbook "Rebuild DB Indexes"
 		`, constants.ExecutableName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && runFlags.Project.Value == "" {

--- a/pkg/cmd/runbook/snapshot/create/create.go
+++ b/pkg/cmd/runbook/snapshot/create/create.go
@@ -1,0 +1,228 @@
+package create
+
+import (
+	"errors"
+	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/executionscommon"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+const (
+	FlagProject            = "project"
+	FlagRunbook            = "runbook"
+	FlagName               = "name"
+	FlagPackageVersionSpec = "package"
+	FlagPackageVersion     = "package-version"
+	FlagSnapshotNotes      = "snapshot-notes"
+	FlagSnapshotNotesFile  = "snapshot-notes-file"
+)
+
+type CreateFlags struct {
+	Runbook            *flag.Flag[string]
+	Project            *flag.Flag[string]
+	Name               *flag.Flag[string]
+	PackageVersion     *flag.Flag[string]
+	SnapshotNotes      *flag.Flag[string]
+	SnapshotNotesFile  *flag.Flag[string]
+	PackageVersionSpec *flag.Flag[[]string]
+}
+
+func NewCreateFlags() *CreateFlags {
+	return &CreateFlags{
+		Project:            flag.New[string](FlagProject, false),
+		Runbook:            flag.New[string](FlagRunbook, false),
+		Name:               flag.New[string](FlagName, false),
+		SnapshotNotes:      flag.New[string](FlagSnapshotNotes, false),
+		SnapshotNotesFile:  flag.New[string](FlagSnapshotNotesFile, false),
+		PackageVersionSpec: flag.New[[]string](FlagPackageVersionSpec, false),
+		PackageVersion:     flag.New[string](FlagPackageVersion, false),
+	}
+}
+
+type CreateOptions struct {
+	*CreateFlags
+	*cmd.Dependencies
+}
+
+func NewCreateOptions(createFlags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:  createFlags,
+		Dependencies: dependencies,
+	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a runbook snapshot",
+		Long:    "Create a runbook snapshot in Octopus Deploy",
+		Aliases: []string{"new", "publish"},
+		Example: heredoc.Docf(`
+			$ %[1]s runbook snapshot create --project MyProject --runbook "Rebuild DB Indexes" 
+			$ %[1]s runbook snapshot create -p MyProject -r "Restart App" --package "azure-cli:1.2.3" --no-prompt
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
+			return createRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Project.Value, createFlags.Project.Name, "p", "", "Name or ID of the project where the runbook is")
+	flags.StringVarP(&createFlags.Runbook.Value, createFlags.Runbook.Name, "r", "", "Name or ID of the runbook to create the snapshot for")
+	flags.StringVar(&createFlags.PackageVersion.Value, createFlags.PackageVersion.Name, "", "Default version to use for all Packages")
+	flags.StringArrayVarP(&createFlags.PackageVersionSpec.Value, createFlags.PackageVersionSpec.Name, "", []string{}, "Version specification a specific packages.\nFormat as {package}:{version}, {step}:{version} or {package-ref-name}:{packageOrStep}:{version}\nYou may specify this multiple times")
+	flags.StringVar(&createFlags.SnapshotNotes.Value, createFlags.SnapshotNotes.Name, "", "Release notes to attach")
+	flags.StringVar(&createFlags.SnapshotNotesFile.Value, createFlags.SnapshotNotesFile.Name, "", "Release notes to attach (from file)")
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "Override the snapshot name")
+
+	return cmd
+}
+
+func createRun(opts *CreateOptions) error {
+	if opts.SnapshotNotes.Value != "" && opts.SnapshotNotesFile.Value != "" {
+		return errors.New("cannot specify both --snapshot-notes and --snapshot-notes-file at the same time")
+	}
+
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	if opts.SnapshotNotesFile.Value != "" {
+		fileContents, err := os.ReadFile(opts.SnapshotNotesFile.Value)
+		if err != nil {
+			return err
+		}
+		opts.SnapshotNotes.Value = string(fileContents)
+	}
+
+	project, err := selectors.FindProject(opts.Client, opts.Project.Value)
+	if err != nil {
+		return err
+	}
+	if project == nil {
+		return errors.New("unable to find project")
+	}
+
+	runbook, err := selectors.FindRunbook(opts.Client, project, opts.Runbook.Value)
+	if err != nil {
+		return err
+	}
+	if runbook == nil {
+		return errors.New("unable to find runbook")
+	}
+
+	runbookTemplate, err := opts.Client.Runbooks.GetRunbookSnapshotTemplate(runbook)
+	if err != nil {
+		return err
+	}
+
+	snapshotName := getSnapshotName(opts, runbookTemplate)
+	if err != nil {
+		return err
+	}
+
+	packageVersionOverrides := make([]*executionscommon.PackageVersionOverride, 0)
+	packageVersionBaseline := buildPackageVersionBaseline(opts, runbookTemplate)
+	for _, s := range opts.PackageVersionSpec.Value {
+		ambOverride, err := executionscommon.ParsePackageOverrideString(s)
+		if err != nil {
+			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
+		}
+		resolvedOverride, err := executionscommon.ResolvePackageOverride(ambOverride, packageVersionBaseline)
+		if err != nil {
+			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
+		}
+		packageVersionOverrides = append(packageVersionOverrides, resolvedOverride)
+	}
+
+	selectedPackages := executionscommon.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+
+	snapshot := runbooks.NewRunbookSnapshot(snapshotName, project.GetID(), runbook.ID)
+	if opts.SnapshotNotes.Value != "" {
+		snapshot.Notes = opts.SnapshotNotes.Value
+	}
+	snapshot.SelectedPackages = util.SliceTransform(selectedPackages, func(p *executionscommon.StepPackageVersion) *packages.SelectedPackage {
+		return &packages.SelectedPackage{
+			ActionName:           p.ActionName,
+			PackageReferenceName: p.PackageReferenceName,
+			StepName:             p.ActionName,
+			Version:              p.Version,
+		}
+	})
+
+	createdSnapshot, err := opts.Client.RunbookSnapshots.Publish(snapshot)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(opts.Out, "\nSuccessfully created and published runbook snapshot '%s' (%s) for runbook '%s'\n", createdSnapshot.Name, createdSnapshot.GetID(), runbook.Name)
+	if err != nil {
+		return err
+	}
+
+	link := output.Bluef("%s/app#/%s/projects/%s/operations/runbooks/%s/snapshots/%s", opts.Host, opts.Space.GetID(), project.GetID(), runbook.GetID(), createdSnapshot.GetID())
+	fmt.Fprintf(opts.Out, "View this project on Octopus Deploy: %s\n", link)
+
+	return nil
+}
+
+func buildPackageVersionBaseline(opts *CreateOptions, runbookTemplate *runbooks.RunbookSnapshotTemplate) []*executionscommon.StepPackageVersion {
+	feedPackageVersions := make(map[string]string)
+	pkgs := make([]*executionscommon.StepPackageVersion, 0, len(runbookTemplate.Packages))
+	for _, p := range runbookTemplate.Packages {
+		{
+			key := fmt.Sprintf("%s/%s", p.FeedID, p.PackageID)
+			if _, ok := feedPackageVersions[key]; !ok {
+				packageVersion, err := feeds.SearchPackageVersions(opts.Client, opts.Client.GetSpaceID(), p.FeedID, p.PackageID, "", 1)
+				if err == nil && packageVersion != nil && !util.Empty(packageVersion.Items) {
+					feedPackageVersions[key] = packageVersion.Items[0].Version
+				}
+			}
+		}
+	}
+
+	for _, p := range runbookTemplate.Packages {
+		pkg := &executionscommon.StepPackageVersion{
+			PackageID:            p.PackageID,
+			ActionName:           p.ActionName,
+			PackageReferenceName: p.PackageReferenceName}
+		if !p.IsResolvable {
+			pkg.Version = ""
+		} else {
+			key := fmt.Sprintf("%s/%s", p.FeedID, p.PackageID)
+			pkg.Version = feedPackageVersions[key]
+		}
+		pkgs = append(pkgs, pkg)
+	}
+
+	return pkgs
+}
+
+func getSnapshotName(opts *CreateOptions, template *runbooks.RunbookSnapshotTemplate) string {
+	if opts.Name.Value != "" {
+		return opts.Name.Value
+	}
+
+	return template.NextNameIncrement
+}
+
+func PromptMissing(opts *CreateOptions) error {
+	return nil
+}

--- a/pkg/cmd/runbook/snapshot/create/create_test.go
+++ b/pkg/cmd/runbook/snapshot/create/create_test.go
@@ -1,0 +1,1 @@
+package create_test

--- a/pkg/cmd/runbook/snapshot/snapshot.go
+++ b/pkg/cmd/runbook/snapshot/snapshot.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	cmdCreate "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/create"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/list"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -20,5 +21,6 @@ func NewCmdSnapshot(f factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f))
 	return cmd
 }

--- a/pkg/executionscommon/executionscommon.go
+++ b/pkg/executionscommon/executionscommon.go
@@ -22,6 +22,16 @@ import (
 	"time"
 )
 
+type StepPackageVersion struct {
+	// these 3 fields are the main ones for showing the user
+	PackageID  string
+	ActionName string // "StepName is an obsolete alias for ActionName, they always contain the same value"
+	Version    string // note this may be an empty string, indicating that no version could be found for this package yet
+
+	// used to locate the deployment process VersioningStrategy Donor Package
+	PackageReferenceName string
+}
+
 func findTenantsAndTags(octopus *octopusApiClient.Client, projectID string, environmentIDs []string) ([]string, []string, error) {
 	var validTenants []string
 	var validTags []string // these are 'Canonical' values i.e. "Regions/us-east", NOT TagSets-1/Tags-1


### PR DESCRIPTION
This is WIP, not complete

Notes to future me:
This is currently only supporting creating a new snapshot and publishing it - which is a bit wrong.
Publishing an existing snapshot requires POST to the runbook with an update to the `PublishedRunbookSnapshotId` property set to the snapshot id

This should be changed to be two commands:
`runbook snapshot create` with an optional `--publish` parameter
`runbook snapshot publish` to publish an existing snapshot:
  `runbook snapshot publish --runbook "runbook name" --snapshot "Snapshot QWE123"`

will probably fix https://github.com/OctopusDeploy/cli/issues/110