### PR TITLE
Order interactive variables by name when deploying releases

### DIFF
--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/exp/maps"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -691,7 +693,13 @@ func askDeploymentPreviewVariables(octopus *octopusApiClient.Client, variablesFr
 		lcaseVarsFromCmd[strings.ToLower(k)] = v
 	}
 
-	for key, control := range flattenedControls {
+	keys := maps.Keys(flattenedControls)
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] > keys[j]
+	})
+
+	for _, key := range keys {
+		control := flattenedControls[key]
 		valueFromCmd, foundValueOnCommandLine := lcaseVarsFromCmd[strings.ToLower(control.Name)]
 		if foundValueOnCommandLine {
 			// implicitly fixes up variable casing

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
 	"github.com/AlecAivazis/survey/v2"
 	surveyCore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/MakeNowJust/heredoc/v2"
@@ -28,9 +32,6 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"net/url"
-	"testing"
-	"time"
 )
 
 var serverUrl, _ = url.Parse("http://server")
@@ -1722,12 +1723,12 @@ func TestDeployCreate_GenerationOfAutomationCommand_MasksSensitiveVariables(t *t
 	}).AnswerWith("BORING")
 
 	_ = qa.ExpectQuestion(t, &survey.Password{
-		Message: "Nuclear Launch Codes",
-	}).AnswerWith("9001")
-
-	_ = qa.ExpectQuestion(t, &survey.Password{
 		Message: "Secret Password",
 	}).AnswerWith("donkey")
+
+	_ = qa.ExpectQuestion(t, &survey.Password{
+		Message: "Nuclear Launch Codes",
+	}).AnswerWith("9001")
 
 	q := qa.ExpectQuestion(t, &survey.Select{
 		Message: "Change additional options?",


### PR DESCRIPTION
When deploying a release with required variables, we ask the user for values via the command line.

Previously the order of these variables was not deterministic, causing the related test to be flakey.
I've now sorted these variable controls alphabetically, which will fix the flakey test and provide a more consistent UX.

[sc-76938]