### PR TITLE
Rob/update worker pool

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -31,7 +31,7 @@ step "push-cli-to-chocolatey" {
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
         }
-        worker_pool = "hosted-windows-2019"
+        worker_pool = "hosted-windows"
 
         packages "cli" {
             acquisition_location = "Server"

--- a/.octopus/schema_version.ocl
+++ b/.octopus/schema_version.ocl
@@ -1,1 +1,1 @@
-version = 6
+version = 8


### PR DESCRIPTION
The `hosted-windows-2019` worker pool is currently deprecated. This uses the latest `hosted-windows` worker pool instead