### PR TITLE
chore: fixed go-releaser deprecated option

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -50,7 +50,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v3
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
`rm-dist` has been deprecated https://goreleaser.com/deprecations/#-rm-dist