### PR TITLE
chore: further fixes for go-releaser deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,12 +65,12 @@ signs:
     stdin: "{{ .Env.GPG_PASSWORD }}"
 
 changelog:
-  skip: true
+  disable: true
 
 brews:
   - name: "octopus-cli"
 
-    tap:
+    repository:
       owner: OctopusDeploy
       name: homebrew-taps
 


### PR DESCRIPTION
Further deprecations for updating to go-releaser v2, which we had no control over 😞 


`changelog.skip` replaced with `changelog.disable`: https://goreleaser.com/deprecations/#changelogskip
`brews.tap` replaced with `brews.repository`:  https://goreleaser.com/deprecations/#brewstap