### PR TITLE
feat: add upload build info command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.45.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.44.2-0.20240629192925-20edc738f1
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.44.2-0.20240629192925-20edc738f146/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.45.0 h1:eTNAHSimCL5d0vTawIEB7TZJQ6Pt8KhcB8wUHS6rwq8=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.45.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.0 h1:B91TiQolB939nCCMDJ+EUUnNqDUvvInvC1bEIqrXkBo=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/buildinformation/build-information.go
+++ b/pkg/cmd/buildinformation/build-information.go
@@ -16,6 +16,7 @@ func NewCmdBuildInformation(f factory.Factory) *cobra.Command {
 		Short:   "Manage build information",
 		Long:    "Manage build information in Octopus Deploy",
 		Example: fmt.Sprintf("$ %s build-information upload", constants.ExecutableName),
+		Aliases: []string{"build-info"},
 		Annotations: map[string]string{
 			annotations.IsCore: "true",
 		},

--- a/pkg/cmd/buildinformation/build-information.go
+++ b/pkg/cmd/buildinformation/build-information.go
@@ -1,0 +1,26 @@
+package buildinformation
+
+import (
+	"fmt"
+
+	cmdUpload "github.com/OctopusDeploy/cli/pkg/cmd/buildinformation/upload"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdBuildInformation(f factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "build-information <command>",
+		Short:   "Manage build information",
+		Long:    "Manage build information in Octopus Deploy",
+		Example: fmt.Sprintf("$ %s build-information upload", constants.ExecutableName),
+		Annotations: map[string]string{
+			annotations.IsCore: "true",
+		},
+	}
+
+	cmd.AddCommand(cmdUpload.NewCmdUpload(f))
+	return cmd
+}

--- a/pkg/cmd/buildinformation/upload/upload.go
+++ b/pkg/cmd/buildinformation/upload/upload.go
@@ -196,20 +196,21 @@ func PromptMissing(opts *UploadOptions) error {
 		}
 	}
 
-	if opts.OverwriteMode.Value == "" {
-		if err := opts.Ask(&survey.Select{
-			Message: "Overwrite mode",
-			Help:    "Determines behavior if the package already exists in the repository. Valid values are 'fail', 'overwrite' and 'ignore'. Default is 'fail'.",
-			Options: []string{
-				"fail",
-				"ignore",
-				"overwrite",
-			},
-			Default: "fail",
-		}, &opts.OverwriteMode.Value); err != nil {
-			return err
-		}
-	}
+	// by default we use 'fail' so shouldn't need to ask the user for this option
+	// if opts.OverwriteMode.Value == "" {
+	// 	if err := opts.Ask(&survey.Select{
+	// 		Message: "Overwrite mode",
+	// 		Help:    "Determines behavior if the package already exists in the repository. Valid values are 'fail', 'overwrite' and 'ignore'. Default is 'fail'.",
+	// 		Options: []string{
+	// 			"fail",
+	// 			"ignore",
+	// 			"overwrite",
+	// 		},
+	// 		Default: "fail",
+	// 	}, &opts.OverwriteMode.Value); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }

--- a/pkg/cmd/buildinformation/upload/upload.go
+++ b/pkg/cmd/buildinformation/upload/upload.go
@@ -1,0 +1,215 @@
+package upload
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/output"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/buildinformation"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagPackageId = "package-id"
+	FlagVersion   = "version"
+	FlagFile      = "file"
+
+	FlagOverwriteMode      = "overwrite-mode"
+	FlagAliasOverwrite     = "overwrite"
+	FlagAliasOverwriteMode = "overwritemode" // I keep forgetting the hyphen
+)
+
+type UploadFlags struct {
+	PackageId     *flag.Flag[[]string]
+	Version       *flag.Flag[string]
+	File          *flag.Flag[string]
+	OverwriteMode *flag.Flag[string]
+}
+
+func NewUploadFlags() *UploadFlags {
+	return &UploadFlags{
+		PackageId:     flag.New[[]string](FlagPackageId, false),
+		Version:       flag.New[string](FlagVersion, false),
+		File:          flag.New[string](FlagFile, false),
+		OverwriteMode: flag.New[string](FlagOverwriteMode, false),
+	}
+}
+
+type UploadOptions struct {
+	*cmd.Dependencies
+	*UploadFlags
+}
+
+func NewUploadOptions(uploadFlags *UploadFlags, dependencies *cmd.Dependencies) *UploadOptions {
+	return &UploadOptions{
+		UploadFlags:  uploadFlags,
+		Dependencies: dependencies,
+	}
+}
+
+func NewCmdUpload(f factory.Factory) *cobra.Command {
+	uploadFlags := NewUploadFlags()
+	cmd := &cobra.Command{
+		Use:     "upload",
+		Short:   "upload build information for one or more packages to Octopus Deploy",
+		Long:    "upload build information one or more packages to Octopus Deploy.",
+		Aliases: []string{"push"},
+		Example: heredoc.Docf(`
+			$ %[1]s build-information upload --package-id SomePackage --version 1.0.0 --file buildinfo.octopus
+			$ %[1]s build-information upload SomePackage --version 1.0.0 --file buildinfo.octopus --overwrite-mode overwrite
+			$ %[1]s build-information push SomePackage --version 1.0.0 --file buildinfo.octopus
+			$ %[1]s build-information upload PkgA PkgB PkgC --version 1.0.0 --file buildinfo.octopus
+		`, constants.ExecutableName),
+		Annotations: map[string]string{annotations.IsCore: "true"},
+		RunE: func(c *cobra.Command, args []string) error {
+			// any bare args are assumed to be package ids to upload build information for
+			uploadFlags.PackageId.Value = append(uploadFlags.PackageId.Value, args...)
+
+			opts := NewUploadOptions(uploadFlags, cmd.NewDependencies(f, c))
+			return uploadRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringArrayVarP(&uploadFlags.PackageId.Value, uploadFlags.PackageId.Name, "p", nil, "The ID of the package, may be specified multiple times. Any arguments without flags will be treated as package IDs")
+	flags.StringVarP(&uploadFlags.Version.Value, uploadFlags.Version.Name, "", "", "The version of the package")
+	flags.StringVarP(&uploadFlags.File.Value, uploadFlags.File.Name, "", "", "Path to Octopus Build Information Json file")
+	flags.StringVarP(&uploadFlags.OverwriteMode.Value, uploadFlags.OverwriteMode.Name, "", "", "Action when a build information already exists. Valid values are 'fail', 'overwrite', 'ignore'. Default is 'fail'")
+	flags.SortFlags = false
+
+	flagAliases := make(map[string][]string, 1)
+	util.AddFlagAliasesString(flags, FlagOverwriteMode, flagAliases, FlagAliasOverwrite, FlagAliasOverwriteMode)
+
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		util.ApplyFlagAliases(cmd.Flags(), flagAliases)
+		return nil
+	}
+	return cmd
+}
+
+func uploadRun(opts *UploadOptions) error {
+	if !opts.NoPrompt {
+		// Prompt for missing arguments
+		err := PromptMissing(opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	overwriteMode := opts.OverwriteMode.Value
+	resolvedOverwriteMode := buildinformation.OverwriteMode("")
+	switch strings.ToLower(overwriteMode) {
+	case "fail", "failifexists", "": // include aliases from old CLI, default (empty string) = fail
+		resolvedOverwriteMode = buildinformation.OverwriteModeFailIfExists
+	case "ignore", "ignoreifexists":
+		resolvedOverwriteMode = buildinformation.OverwriteModeIgnoreIfExists
+	case "overwrite", "overwriteexisting", "replace":
+		resolvedOverwriteMode = buildinformation.OverwriteModeOverwriteExisting
+	default:
+		return fmt.Errorf("invalid value '%s' for --overwrite-mode. Valid values are 'fail', 'ignore', 'overwrite'", overwriteMode)
+	}
+
+	var buildInformation buildinformation.OctopusBuildInformation
+	if opts.File.Value != "" {
+		jsonFile, err := os.ReadFile(opts.File.Value)
+		if err != nil {
+			return err
+		}
+
+		err = json.Unmarshal(jsonFile, &buildInformation)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Build information:\n%s\n", string(jsonFile))
+	}
+
+	for _, pkgIdString := range opts.PackageId.Value {
+		cmd := buildinformation.NewCreateBuildInformationCommand(opts.Space.GetID(), pkgIdString, opts.Version.Value, buildInformation)
+		cmd.OverwriteMode = resolvedOverwriteMode
+
+		uploadedBuildInfo, err := buildinformation.Add(opts.Client, cmd)
+		if err != nil {
+			return err
+		}
+
+		_, err = fmt.Fprintf(opts.Out, "\nSuccessfully uploaded build information for '%s' version '%s'  (%s).\n", uploadedBuildInfo.PackageID, uploadedBuildInfo.Version, uploadedBuildInfo.ID)
+		if err != nil {
+			return err
+		}
+
+		link := output.Bluef("%s/app#/%s/library/buildinformation/%s", opts.Host, opts.Space.GetID(), uploadedBuildInfo.GetID())
+		fmt.Fprintf(opts.Out, "View this build information on Octopus Deploy: %s\n", link)
+	}
+
+	if !opts.NoPrompt {
+		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.PackageId, opts.Version, opts.File, opts.OverwriteMode)
+		fmt.Fprintf(opts.Out, "%s\n", autoCmd)
+	}
+
+	return nil
+}
+
+func PromptMissing(opts *UploadOptions) error {
+	if len(opts.PackageId.Value) == 0 {
+		var packageIdString string
+		if err := opts.Ask(&survey.Multiline{
+			Message: "Package ID(s)",
+			Help:    "A multi-line list of Package IDs.",
+		}, &packageIdString, survey.WithValidator(survey.ComposeValidators(
+			survey.Required,
+		))); err != nil {
+			return err
+		}
+		opts.PackageId.Value = strings.Split(packageIdString, "\n")
+	}
+
+	if opts.Version.Value == "" {
+		if err := opts.Ask(&survey.Input{
+			Message: "Version",
+			Help:    "The version of the package.",
+		}, &opts.Version.Value, survey.WithValidator(survey.ComposeValidators(
+			survey.Required,
+		))); err != nil {
+			return err
+		}
+	}
+
+	if opts.File.Value == "" {
+		if err := opts.Ask(&survey.Input{
+			Message: "Build information file",
+			Help:    "Octopus Build Information JSON file.",
+		}, &opts.File.Value, survey.WithValidator(survey.ComposeValidators(
+			survey.Required,
+		))); err != nil {
+			return err
+		}
+	}
+
+	if opts.OverwriteMode.Value == "" {
+		if err := opts.Ask(&survey.Select{
+			Message: "Overwrite mode",
+			Help:    "Determines behavior if the package already exists in the repository. Valid values are 'fail', 'overwrite' and 'ignore'. Default is 'fail'.",
+			Options: []string{
+				"fail",
+				"ignore",
+				"overwrite",
+			},
+			Default: "fail",
+		}, &opts.OverwriteMode.Value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/buildinformation/upload/upload.go
+++ b/pkg/cmd/buildinformation/upload/upload.go
@@ -131,6 +131,7 @@ func uploadRun(opts *UploadOptions) error {
 		if err != nil {
 			return err
 		}
+
 		fmt.Printf("Build information:\n%s\n", string(jsonFile))
 	}
 
@@ -195,22 +196,6 @@ func PromptMissing(opts *UploadOptions) error {
 			return err
 		}
 	}
-
-	// by default we use 'fail' so shouldn't need to ask the user for this option
-	// if opts.OverwriteMode.Value == "" {
-	// 	if err := opts.Ask(&survey.Select{
-	// 		Message: "Overwrite mode",
-	// 		Help:    "Determines behavior if the package already exists in the repository. Valid values are 'fail', 'overwrite' and 'ignore'. Default is 'fail'.",
-	// 		Options: []string{
-	// 			"fail",
-	// 			"ignore",
-	// 			"overwrite",
-	// 		},
-	// 		Default: "fail",
-	// 	}, &opts.OverwriteMode.Value); err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	return nil
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
 	accountCmd "github.com/OctopusDeploy/cli/pkg/cmd/account"
+	buildInfoCmd "github.com/OctopusDeploy/cli/pkg/cmd/buildInformation"
 	configCmd "github.com/OctopusDeploy/cli/pkg/cmd/config"
 	environmentCmd "github.com/OctopusDeploy/cli/pkg/cmd/environment"
 	loginCmd "github.com/OctopusDeploy/cli/pkg/cmd/login"
@@ -45,6 +46,7 @@ func NewCmdRoot(f factory.Factory, clientFactory apiclient.ClientFactory, askPro
 	cmd.AddCommand(accountCmd.NewCmdAccount(f))
 	cmd.AddCommand(environmentCmd.NewCmdEnvironment(f))
 	cmd.AddCommand(packageCmd.NewCmdPackage(f))
+	cmd.AddCommand(buildInfoCmd.NewCmdBuildInformation(f))
 	cmd.AddCommand(deploymentTargetCmd.NewCmdDeploymentTarget(f))
 	cmd.AddCommand(workerCmd.NewCmdWorker(f))
 	cmd.AddCommand(workerPoolCmd.NewCmdWorkerPool(f))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,7 +3,7 @@ package root
 import (
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
 	accountCmd "github.com/OctopusDeploy/cli/pkg/cmd/account"
-	buildInfoCmd "github.com/OctopusDeploy/cli/pkg/cmd/buildInformation"
+	buildInfoCmd "github.com/OctopusDeploy/cli/pkg/cmd/buildinformation"
 	configCmd "github.com/OctopusDeploy/cli/pkg/cmd/config"
 	environmentCmd "github.com/OctopusDeploy/cli/pkg/cmd/environment"
 	loginCmd "github.com/OctopusDeploy/cli/pkg/cmd/login"


### PR DESCRIPTION
This PR adds a command to upload build information to Octopus.

```
octopus build-information upload --package-id ThePackage --version 1.2.3 --file /path/to/octopus/buildinformation/file.json --overwrite-mode ignore
```

```
octopus build-info upload ThePackage --version 1.2.3 --file /path/to/octopus/buildinfo/file.json --overwrite-mode fail
```

[sc-83928]