### PR TITLE
feat: add list build information command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.1
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.45.0 h1:eTNAHSimCL5d0vTawIEB7TZJ
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.45.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.0 h1:B91TiQolB939nCCMDJ+EUUnNqDUvvInvC1bEIqrXkBo=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.1 h1:Z9LH289a46I5y1W9gQpr/h1t8fdNInNy/KJS1I8NCv0=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.1/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/buildinformation/build-information.go
+++ b/pkg/cmd/buildinformation/build-information.go
@@ -3,6 +3,7 @@ package buildinformation
 import (
 	"fmt"
 
+	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/buildinformation/list"
 	cmdUpload "github.com/OctopusDeploy/cli/pkg/cmd/buildinformation/upload"
 	cmdView "github.com/OctopusDeploy/cli/pkg/cmd/buildinformation/view"
 	"github.com/OctopusDeploy/cli/pkg/constants"
@@ -24,6 +25,7 @@ func NewCmdBuildInformation(f factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(cmdView.NewCmdView(f))
+	cmd.AddCommand(cmdList.NewCmdList(f))
 	cmd.AddCommand(cmdUpload.NewCmdUpload(f))
 	return cmd
 }

--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -57,7 +57,7 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&listFlags.Latest.Value, listFlags.Latest.Name, "", false, "only return the latest build information")
+	flags.BoolVarP(&listFlags.Latest.Value, listFlags.Latest.Name, "", false, "only return the latest build information according to SemVer")
 	flags.StringVarP(&listFlags.Filter.Value, listFlags.Filter.Name, "q", "", "filter build information by version")
 	flags.StringVarP(&listFlags.PackageId.Value, listFlags.PackageId.Name, "p", "", "filter build information by package id")
 

--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -1,0 +1,106 @@
+package list
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/buildinformation"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagLatest    = "latest"
+	FlagFilter    = "filter"
+	FlagPackageId = "package-id"
+)
+
+type ListFlags struct {
+	Latest    *flag.Flag[bool]
+	Filter    *flag.Flag[string]
+	PackageId *flag.Flag[string]
+}
+
+func NewListFlags() *ListFlags {
+	return &ListFlags{
+		Latest:    flag.New[bool](FlagLatest, false),
+		Filter:    flag.New[string](FlagFilter, false),
+		PackageId: flag.New[string](FlagPackageId, false),
+	}
+}
+
+func NewCmdList(f factory.Factory) *cobra.Command {
+	listFlags := NewListFlags()
+
+	cmd := &cobra.Command{
+		Use:   "List",
+		Short: "List build information",
+		Long:  "List build information in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s build-information list
+			$ %[1]s build-information ls
+			$ %[1]s build-info list
+		`, constants.ExecutableName),
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listRun(cmd, f, listFlags)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&listFlags.Latest.Value, listFlags.Latest.Name, "", false, "only return the latest build information")
+	flags.StringVarP(&listFlags.Filter.Value, listFlags.Filter.Name, "q", "", "filter build information by version")
+	flags.StringVarP(&listFlags.PackageId.Value, listFlags.PackageId.Name, "p", "", "filter build information by package id")
+
+	return cmd
+}
+
+type BuildInfoAsJson struct {
+	Id        string `json:"Id"`
+	PackageId string `json:"PackageId"`
+	Version   string `json:"Version"`
+}
+
+func listRun(cmd *cobra.Command, f factory.Factory, listFlags *ListFlags) error {
+	octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
+	if err != nil {
+		return err
+	}
+
+	query := buildinformation.BuildInformationQuery{
+		Latest:    listFlags.Latest.Value,
+		Filter:    listFlags.Filter.Value,
+		PackageID: listFlags.PackageId.Value,
+	}
+
+	buildInfoResources, err := buildinformation.Get(octopus, f.GetCurrentSpace().ID, query)
+	if err != nil {
+		return err
+	}
+
+	allBuildInfo, err := buildInfoResources.GetAllPages(octopus.Sling())
+	if err != nil {
+		return err
+	}
+
+	return output.PrintArray(allBuildInfo, cmd, output.Mappers[*buildinformation.BuildInformation]{
+		Json: func(b *buildinformation.BuildInformation) any {
+			return BuildInfoAsJson{
+				Id:        b.GetID(),
+				PackageId: b.PackageID,
+				Version:   b.Version,
+			}
+		},
+		Table: output.TableDefinition[*buildinformation.BuildInformation]{
+			Header: []string{"PACKAGE ID", "VERSION"},
+			Row: func(b *buildinformation.BuildInformation) []string {
+				return []string{output.Bold(b.PackageID), b.Version}
+			},
+		},
+		Basic: func(b *buildinformation.BuildInformation) string {
+			return b.PackageID
+		},
+	})
+}

--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -58,7 +58,7 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&listFlags.Latest.Value, listFlags.Latest.Name, "", false, "only return the latest build information according to SemVer")
-	flags.StringVarP(&listFlags.Filter.Value, listFlags.Filter.Name, "q", "", "filter build information by version")
+	flags.StringVarP(&listFlags.Filter.Value, listFlags.Filter.Name, "q", "", "filter build information by version that contains the filter")
 	flags.StringVarP(&listFlags.PackageId.Value, listFlags.PackageId.Name, "p", "", "filter build information by package id")
 
 	return cmd

--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/cmd/buildinformation/shared"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
@@ -61,30 +62,6 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 	return cmd
 }
 
-type WorkItemAsJson struct {
-	Id          string `json:"Id"`
-	Source      string `json:"Source"`
-	Description string `json:"Description"`
-}
-
-type CommitAsJson struct {
-	Id      string `json:"Id"`
-	Comment string `json:"Comment"`
-}
-
-type BuildInfoAsJson struct {
-	Id               string            `json:"Id"`
-	PackageId        string            `json:"PackageId"`
-	Version          string            `json:"Version"`
-	Branch           string            `json:"Branch"`
-	BuildEnvironment string            `json:"BuildEnvironment"`
-	VcsCommitNumber  string            `json:"VcsCommitNumber"`
-	VcsType          string            `json:"VcsType"`
-	VcsRoot          string            `json:"VcsRoot"`
-	Commits          []*CommitAsJson   `json:"Commits,omitempty"`
-	WorkItems        []*WorkItemAsJson `json:"WorkItems,omitempty"`
-}
-
 func listRun(cmd *cobra.Command, f factory.Factory, listFlags *ListFlags) error {
 	octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
 	if err != nil {
@@ -109,7 +86,7 @@ func listRun(cmd *cobra.Command, f factory.Factory, listFlags *ListFlags) error 
 
 	return output.PrintArray(allBuildInfo, cmd, output.Mappers[*buildinformation.BuildInformation]{
 		Json: func(b *buildinformation.BuildInformation) any {
-			buildInfo := BuildInfoAsJson{
+			buildInfo := shared.BuildInfoAsJson{
 				Id:               b.GetID(),
 				PackageId:        b.PackageID,
 				Version:          b.Version,
@@ -122,13 +99,13 @@ func listRun(cmd *cobra.Command, f factory.Factory, listFlags *ListFlags) error 
 
 			if len(b.Commits) > 0 {
 				for _, c := range b.Commits {
-					buildInfo.Commits = append(buildInfo.Commits, &CommitAsJson{Id: c.ID, Comment: c.Comment})
+					buildInfo.Commits = append(buildInfo.Commits, &shared.CommitAsJson{Id: c.ID, Comment: c.Comment})
 				}
 			}
 
 			if len(b.WorkItems) > 0 {
 				for _, w := range b.WorkItems {
-					buildInfo.WorkItems = append(buildInfo.WorkItems, &WorkItemAsJson{Id: w.ID, Source: w.Source, Description: w.Description})
+					buildInfo.WorkItems = append(buildInfo.WorkItems, &shared.WorkItemAsJson{Id: w.ID, Source: w.Source, Description: w.Description})
 				}
 			}
 

--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -152,16 +152,20 @@ func listRun(cmd *cobra.Command, f factory.Factory, listFlags *ListFlags) error 
 				for _, commit := range b.Commits {
 					s.WriteString(fmt.Sprintf("%s %s\n", output.Dim(commit.ID[0:8]), commit.Comment))
 				}
+			} else {
+				s.WriteString("No commits included\n")
 			}
 
+			s.WriteString(output.Bold("\nWork items\n"))
 			if len(b.WorkItems) > 0 {
-				s.WriteString(output.Bold("\nWork items\n"))
 				if b.IssueTrackerName != "" {
 					s.WriteString(output.Dim(fmt.Sprintf("Issue tracker: %s\n", b.IssueTrackerName)))
 				}
 				for _, workItem := range b.WorkItems {
 					s.WriteString(fmt.Sprintf("%s %s\n", output.Dim(workItem.ID), workItem.Description))
 				}
+			} else {
+				s.WriteString("No work items included\n")
 			}
 
 			return s.String()

--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -47,6 +47,8 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 			$ %[1]s build-information list
 			$ %[1]s build-information ls
 			$ %[1]s build-info list
+			$ %[1]s build-info ls --package-id ThePackage
+			$ %[1]s build-info ls --package-id ThePackage --filter 1.2.3
 		`, constants.ExecutableName),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
List all build information
```
octopus build-information list
octopus build-info ls
```

List only latest build information for all packages
```
octopus build-info ls --latest
```

List all build information for a specific package id
```
octopus build-info ls --package-id ThePackage
```

List only latest build information for a specific package id
```
octopus build-info ls --package-id --latest
```

default (table) output
```
$ octopus build-info ls --package-id package-11383 --latest --output-format table
PACKAGE ID     VERSION   ENVIRONMENT  BUILD NO  BRANCH  COMMITS  WORKITEMS
package-11383  0.1.1000  BitBucket    288       main    3        0
```

json output
```
$ octopus build-info ls --package-id package-11383 --output-format json --latest
[
  {
    "Id": "BuildInformation-7000",
    "PackageId": "package-11383",
    "Version": "0.1.1000",
    "Branch": "main",
    "BuildEnvironment": "BitBucket",
    "VcsCommitNumber": "314cf2c3ee916c92a384c2796a6abe332d678e4f",
    "VcsType": "Git",
    "VcsRoot": "http://bitbucket.org/org/repo",
    "Commits": [
      {
        "Id": "314cf2c3ee916c92a384c2796a6abe332d678e4f",
        "Comment": "MAN-1 - test runbook with 0.15.0 of pipe"
      },
      {
        "Id": "4fa86f8a9da6475eb195dd4dad817259",
        "Comment": "MAN-2 - antoher runbook that is broked"
      },
      {
        "Id": "e4c5e95bb0f54a3fbb2eb445ecd1557f",
        "Comment": "MAN-22 - this is a missing work item"
      }
    ]
  }
]
```

basic output
```
$ octopus build-info ls --package-id package-11383 --latest --output-format basic
package-11383 0.1.1000 (BuildInformation-7000)

Build details
Environment: BitBucket
Branch: main
URL: https://bitbucket.org/org/repo/addon/pipelines/home#!/results/288

VCS Details
Type: Git
URL: http://bitbucket.org/org/repo

Commit details
Hash: 314cf2c3ee916c92a384c2796a6abe332d678e4f
URL: http://bitbucket.org/org/repo/commits/314cf2c3ee916c92a384c2796a6abe332d678e4f
314cf2c3 MAN-1 - test runbook with 0.15.0 of pipe
4fa86f8a MAN-2 - antoher runbook that is broked
e4c5e95b MAN-22 - this is a missing work item
```

[sc-83928]