### PR TITLE
feat: add delete package command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.47.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.48.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.1 h1:Z9LH289a46I5y1W9gQpr/h1t
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.46.1/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.47.0 h1:X6Ksq+LHMeAuTM1DNf5Noj9XK5NHzn5awS4v+eypcW8=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.47.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.48.0 h1:/kSfQ44LNsAZB0ylv5hUlXWAfcFadFXqYNrIgUIeN/Y=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.48.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/package/delete/delete.go
+++ b/pkg/cmd/package/delete/delete.go
@@ -96,7 +96,7 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 
 	if opts.ConfirmFlags.Confirm.Value {
-		return delete(opts.Client, nil)
+		return delete(opts.Client, packageToDelete)
 	} else {
 		return question.DeleteWithConfirmation(opts.Ask, "package", packageToDelete.PackageID+" "+packageToDelete.Version, packageToDelete.GetID(), func() error {
 			return delete(opts.Client, packageToDelete)

--- a/pkg/cmd/package/delete/delete.go
+++ b/pkg/cmd/package/delete/delete.go
@@ -1,0 +1,175 @@
+package delete
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagPackageId = "package-id"
+	FlagVersion   = "version"
+)
+
+type DeleteFlags struct {
+	PackageId *flag.Flag[string]
+	Version   *flag.Flag[string]
+}
+
+func NewDeleteFlags() *DeleteFlags {
+	return &DeleteFlags{
+		PackageId: flag.New[string](FlagPackageId, false),
+		Version:   flag.New[string](FlagVersion, false),
+	}
+}
+
+type DeleteOptions struct {
+	*cmd.Dependencies
+	*DeleteFlags
+	*question.ConfirmFlags
+	ID string
+}
+
+func NewDeleteOptions(id string, deleteFlags *DeleteFlags, confirmFlags *question.ConfirmFlags, dependencies *cmd.Dependencies) *DeleteOptions {
+	return &DeleteOptions{
+		Dependencies: dependencies,
+		DeleteFlags:  deleteFlags,
+		ConfirmFlags: confirmFlags,
+		ID:           id,
+	}
+}
+
+func NewCmdDelete(f factory.Factory) *cobra.Command {
+	deleteFlags := NewDeleteFlags()
+	confirmFlags := question.NewConfirmFlags()
+	cmd := &cobra.Command{
+		Use:     "delete {<id>}",
+		Short:   "Delete a package",
+		Long:    "Delete a package in Octopus Deploy",
+		Aliases: []string{"del", "rm", "remove"},
+		Example: heredoc.Docf(`
+			$ %[1]s package delete Packages-1
+			$ %[1]s package rm Packages-1
+			$ %[1]s package del --package-id ThePackage --version 1.0.0
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				args = append(args, "")
+			}
+
+			opts := NewDeleteOptions(args[0], deleteFlags, confirmFlags, cmd.NewDependencies(f, c))
+			return deleteRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&deleteFlags.PackageId.Value, deleteFlags.PackageId.Name, "p", "", "The Package ID of the package to delete")
+	flags.StringVarP(&deleteFlags.Version.Value, deleteFlags.Version.Name, "v", "", "The version of the package to delete")
+	question.RegisterConfirmDeletionFlag(cmd, &confirmFlags.Confirm.Value, "package")
+
+	return cmd
+}
+
+func deleteRun(opts *DeleteOptions) error {
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	if opts.ID == "" {
+		return fmt.Errorf("package identifier is required but was not provided")
+	}
+
+	packageToDelete, err := packages.GetByID(opts.Client, opts.Client.GetSpaceID(), opts.ID)
+	if err != nil {
+		return err
+	}
+
+	if opts.ConfirmFlags.Confirm.Value {
+		return delete(opts.Client, nil)
+	} else {
+		return question.DeleteWithConfirmation(opts.Ask, "package", packageToDelete.PackageID+" "+packageToDelete.Version, packageToDelete.GetID(), func() error {
+			return delete(opts.Client, packageToDelete)
+		})
+	}
+}
+
+func PromptMissing(opts *DeleteOptions) error {
+	if opts.ID == "" {
+		packageToDelete, err := selectPackage(opts)
+		if err != nil {
+			return err
+		}
+
+		packageVersionToDelete, err := selectVersion(opts, packageToDelete.PackageID)
+		if err != nil {
+			return err
+		}
+
+		opts.ID = packageVersionToDelete.GetID()
+	}
+
+	return nil
+}
+
+func selectPackage(opts *DeleteOptions) (*packages.Package, error) {
+	allExistingPackages, err := packages.GetAll(opts.Client, opts.Client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.DeleteFlags.PackageId.Value != "" {
+		idx := slices.IndexFunc(allExistingPackages, func(p *packages.Package) bool { return p.PackageID == opts.DeleteFlags.PackageId.Value })
+		if idx == -1 {
+			return nil, fmt.Errorf("unable to find a package matching the specifed ID: '%s'", opts.DeleteFlags.PackageId.Value)
+		}
+		return allExistingPackages[idx], nil
+	} else {
+		return question.SelectMap(opts.Ask, "Select the package you wish to delete:", allExistingPackages, func(item *packages.Package) string {
+			return item.PackageID
+		})
+	}
+}
+
+func selectVersion(opts *DeleteOptions, packageID string) (*packages.Package, error) {
+	packageVersions, err := packages.Get(opts.Client, opts.Client.GetSpaceID(), packages.PackagesQuery{
+		NuGetPackageID: packageID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	allPackageVersions, err := packageVersions.GetAllPages(opts.Client.Sling())
+	if err != nil {
+		return nil, err
+	}
+
+	var packageVersionToDelete *packages.Package
+	if opts.DeleteFlags.Version.Value != "" {
+		idx := slices.IndexFunc(allPackageVersions, func(p *packages.Package) bool { return p.Version == opts.DeleteFlags.Version.Value })
+		if idx == -1 {
+			return nil, fmt.Errorf("unable to find a version matching the specified version: '%s", opts.DeleteFlags.Version.Value)
+		}
+		packageVersionToDelete = allPackageVersions[idx]
+	} else {
+		packageVersionToDelete, err = question.SelectMap(opts.Ask, "Select the version you wish to delete:", allPackageVersions, func(item *packages.Package) string { return item.Version })
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return packageVersionToDelete, nil
+}
+
+func delete(client *client.Client, packageToDelete *packages.Package) error {
+	return packages.DeleteByID(client, client.GetSpaceID(), packageToDelete.GetID())
+}

--- a/pkg/cmd/package/package.go
+++ b/pkg/cmd/package/package.go
@@ -2,6 +2,8 @@ package _package
 
 import (
 	"fmt"
+
+	cmdDelete "github.com/OctopusDeploy/cli/pkg/cmd/package/delete"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/package/list"
 	cmdNuget "github.com/OctopusDeploy/cli/pkg/cmd/package/nuget"
 	cmdUpload "github.com/OctopusDeploy/cli/pkg/cmd/package/upload"
@@ -29,5 +31,7 @@ func NewCmdPackage(f factory.Factory) *cobra.Command {
 	cmd.AddCommand(cmdVersions.NewCmdVersions(f))
 	cmd.AddCommand(cmdNuget.NewCmdPackageNuget(f))
 	cmd.AddCommand(cmdZip.NewCmdPackageZip(f))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f))
+
 	return cmd
 }


### PR DESCRIPTION
Depends on https://github.com/OctopusDeploy/go-octopusdeploy/pull/260

delete with no arguments
```
$ octopus package delete
? Select the package you wish to delete: toolscripts
? Select the version you wish to delete: 0.0.3
? You are about to delete the package "toolscripts 0.0.3" (packages-toolscripts.0.0.3). This action cannot be reversed. To confirm, type the package identity (toolscripts 0.0.3): toolscripts 0.0.3
✔ The package, "toolscripts 0.0.3" (packages-toolscripts.0.0.3) was deleted successfully.
```

delete with package specified
```
$ octopus package delete --package-id toolscripts
? You are about to delete the package "toolscripts 0.0.3" (packages-toolscripts.0.0.3). This action cannot be reversed. To confirm, type the package name: toolscripts 0.0.3
✔ The package, "toolscripts 0.0.3" (packages-toolscripts.0.0.3) was deleted successfully.
```

delete with package and version specified
```
$ octopus package delete --package-id toolscripts --version 0.0.3
? You are about to delete the package "toolscripts 0.0.3" (packages-toolscripts.0.0.3). This action cannot be reversed. To confirm, type the package name: toolscripts 0.0.3
✔ The package, "toolscripts 0.0.3" (packages-toolscripts.0.0.3) was deleted successfully.
```

delete with confirmation flag
```
$ octopus package delete --package-id toolscripts --version 0.0.3 -y
$
```

[sc-83932]