### PR TITLE
fix: fix command use value as it was capitalised

### DIFF
--- a/pkg/cmd/buildinformation/list/list.go
+++ b/pkg/cmd/buildinformation/list/list.go
@@ -40,7 +40,7 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 	listFlags := NewListFlags()
 
 	cmd := &cobra.Command{
-		Use:   "List",
+		Use:   "list",
 		Short: "List build information",
 		Long:  "List build information in Octopus Deploy",
 		Example: heredoc.Docf(`


### PR DESCRIPTION
Accidentally specified `List` rather than `list` as the command name