### PR TITLE
feat: add commands to manage release progression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.48.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.49.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.47.0 h1:X6Ksq+LHMeAuTM1DNf5Noj9X
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.47.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.48.0 h1:/kSfQ44LNsAZB0ylv5hUlXWAfcFadFXqYNrIgUIeN/Y=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.48.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.49.0 h1:HozuwjREQ2881fBGTB5NbxKeAvKD5z5gBTXf6Cu8HPY=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.49.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/release/progression/allow/allow.go
+++ b/pkg/cmd/release/progression/allow/allow.go
@@ -1,0 +1,158 @@
+package allow
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/release/progression/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/defects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagProject                  = "project"
+	FlagVersion                  = "version"
+	FlagAliasReleaseNumberLegacy = "releaseNumber" // alias for FlagVersion
+)
+
+type AllowFlags struct {
+	Project *flag.Flag[string]
+	Version *flag.Flag[string]
+}
+
+type AllowOptions struct {
+	ReleaseID string
+	*AllowFlags
+	*cmd.Dependencies
+}
+
+func NewAllowFlags() *AllowFlags {
+	return &AllowFlags{
+		Project: flag.New[string](FlagProject, false),
+		Version: flag.New[string](FlagVersion, false),
+	}
+}
+
+func NewAllowOptions(flags *AllowFlags, dependencies *cmd.Dependencies) *AllowOptions {
+	return &AllowOptions{
+		AllowFlags:   flags,
+		Dependencies: dependencies,
+	}
+}
+
+func NewCmdAllow(f factory.Factory) *cobra.Command {
+	allowFlags := NewAllowFlags()
+
+	cmd := &cobra.Command{
+		Use:   "allow",
+		Short: "Allows a release to progress to the next phase.",
+		Long:  "Allows a release to progress to the next phase in Octopus Deploy.",
+		Example: heredoc.Docf(`
+			$ %[1]s release progression allow --project MyProject --version 1.2.3
+			$ %[1]s release progression allow -p MyProject -v 1.2.3
+			$ %[1]s release progression allow -p MyProject -v 1.2.3 --no-prompt
+		`, constants.ExecutableName),
+		Aliases: []string{"allow-releaseprogression"},
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewAllowOptions(allowFlags, cmd.NewDependencies(f, c))
+			return resolveReleaseDefectRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&allowFlags.Project.Value, allowFlags.Project.Name, "p", "", "Name or ID of the project.")
+	flags.StringVarP(&allowFlags.Version.Value, allowFlags.Version.Name, "v", "", "Release version/number.")
+
+	flags.SortFlags = false
+
+	flagAliases := make(map[string][]string, 1)
+	util.AddFlagAliasesString(flags, FlagVersion, flagAliases, FlagAliasReleaseNumberLegacy)
+
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		util.ApplyFlagAliases(cmd.Flags(), flagAliases)
+		return nil
+	}
+
+	return cmd
+}
+
+func resolveReleaseDefectRun(opts *AllowOptions) error {
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	var err error
+	opts.ReleaseID, err = shared.GetReleaseID(opts.Client, opts.Client.GetSpaceID(), opts.Project.Value, opts.Version.Value)
+	if err != nil {
+		return err
+	}
+
+	resolveDefectCommand, err := defects.NewResolveReleaseDefectCommand(opts.ReleaseID)
+	if err != nil {
+		return err
+	}
+
+	existingDefects, err := defects.GetAll(opts.Client, opts.Client.GetSpaceID(), opts.ReleaseID)
+	if err != nil {
+		return err
+	}
+
+	isReleaseAllowedToProgressAlready := util.SliceContainsAll(existingDefects, func(item *defects.Defect) bool {
+		return item.Status == defects.DefectStatusResolved
+	})
+	if isReleaseAllowedToProgressAlready {
+		_, _ = fmt.Fprintf(opts.Out, "Release with version/release number '%s' (%s) is already allowed to progress to the next phase.\n", opts.Version.Value, output.Dim(opts.ReleaseID))
+		return nil
+	}
+
+	_, err = defects.Resolve(opts.Client, opts.Client.GetSpaceID(), resolveDefectCommand)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(opts.Out, "Successfully allowed progression for release %s (%s) in project %s\n", opts.Version.Value, output.Dim(opts.ReleaseID), opts.Project.Value)
+	if err != nil {
+		return err
+	}
+
+	if !opts.NoPrompt {
+		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Project, opts.Version)
+		_, _ = fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
+	}
+
+	return nil
+}
+
+func PromptMissing(opts *AllowOptions) error {
+	var err error
+	var selectedProject *projects.Project
+	if opts.Project.Value == "" {
+		selectedProject, err = selectors.Project("Select the project in which the blocked release exists", opts.Client, opts.Ask)
+		if err != nil {
+			return err
+		}
+	}
+	opts.Project.Value = selectedProject.GetName()
+
+	var selectedRelease *releases.Release
+	if opts.Version.Value == "" {
+		selectedRelease, err = shared.SelectRelease(opts.Client, selectedProject, opts.Ask, "Allow")
+		if err != nil {
+			return err
+		}
+	}
+	opts.Version.Value = selectedRelease.Version
+
+	return nil
+}

--- a/pkg/cmd/release/progression/prevent/prevent.go
+++ b/pkg/cmd/release/progression/prevent/prevent.go
@@ -1,0 +1,176 @@
+package prevent
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/release/progression/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/defects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FlagProject                  = "project"
+	FlagVersion                  = "version"
+	FlagAliasReleaseNumberLegacy = "releaseNumber" // alias for FlagVersion
+	FlagReason                   = "reason"
+)
+
+type PreventFlags struct {
+	Project *flag.Flag[string]
+	Version *flag.Flag[string]
+	Reason  *flag.Flag[string]
+}
+
+type PreventOptions struct {
+	ReleaseID string
+	*PreventFlags
+	*cmd.Dependencies
+}
+
+func NewPreventFlags() *PreventFlags {
+	return &PreventFlags{
+		Project: flag.New[string](FlagProject, false),
+		Version: flag.New[string](FlagVersion, false),
+		Reason:  flag.New[string](FlagReason, false),
+	}
+}
+
+func NewPreventOptions(flags *PreventFlags, dependencies *cmd.Dependencies) *PreventOptions {
+	return &PreventOptions{
+		PreventFlags: flags,
+		Dependencies: dependencies,
+	}
+}
+
+func NewCmdPrevent(f factory.Factory) *cobra.Command {
+	preventFlags := NewPreventFlags()
+
+	cmd := &cobra.Command{
+		Use:   "prevent",
+		Short: "Prevents a release from progression to the next phase",
+		Long:  "Prevents a release from progression to the next phase in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s release progression prevent --project MyProject --version 1.2.3 --reason "It's broken"
+			$ %[1]s release progression prevent -p MyProject -v 1.2.3 -r "It's broken"
+			$ %[1]s release progression prevent -p MyProject -v 1.2.3 -r "It's broken" --no-prompt
+		`, constants.ExecutableName),
+		Aliases: []string{"prevent-releaseprogression"},
+		RunE: func(c *cobra.Command, _ []string) error {
+			opts := NewPreventOptions(preventFlags, cmd.NewDependencies(f, c))
+			return createReleaseDefectRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&preventFlags.Project.Value, preventFlags.Project.Name, "p", "", "Name or ID of the project.")
+	flags.StringVarP(&preventFlags.Version.Value, preventFlags.Version.Name, "v", "", "Release version/number.")
+	flags.StringVarP(&preventFlags.Reason.Value, preventFlags.Reason.Name, "r", "", "Reason to prevent this release from progressing to the next phase.")
+
+	flags.SortFlags = false
+
+	flagAliases := make(map[string][]string, 1)
+	util.AddFlagAliasesString(flags, FlagVersion, flagAliases, FlagAliasReleaseNumberLegacy)
+
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		util.ApplyFlagAliases(cmd.Flags(), flagAliases)
+		return nil
+	}
+
+	return cmd
+}
+
+func createReleaseDefectRun(opts *PreventOptions) error {
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	var err error
+	opts.ReleaseID, err = shared.GetReleaseID(opts.Client, opts.Client.GetSpaceID(), opts.Project.Value, opts.Version.Value)
+	if err != nil {
+		return err
+	}
+
+	existingDefects, err := defects.GetAll(opts.Client, opts.Client.GetSpaceID(), opts.ReleaseID)
+	if err != nil {
+		return err
+	}
+
+	isReleasePreventedToProgressAlready := util.SliceContainsAny(existingDefects, func(item *defects.Defect) bool {
+		return item.Status == defects.DefectStatusUnresolved
+	})
+
+	if isReleasePreventedToProgressAlready {
+		_, _ = fmt.Fprintf(opts.Out, "Release with version/release number '%s' (%s) is already prevented from progressing to the next phase.\n", opts.Version.Value, output.Dim(opts.ReleaseID))
+		return nil
+	}
+
+	if opts.Reason.Value == "" {
+		if err := opts.Ask(&survey.Input{
+			Message: "Reason",
+			Help:    "Reason to prevent this release from progressing to the next phase.",
+		}, &opts.Reason.Value, survey.WithValidator(survey.ComposeValidators(
+			survey.MinLength(1),
+			survey.Required,
+		))); err != nil {
+			return err
+		}
+	}
+
+	createReleaseDefectCommand, err := defects.NewCreateReleaseDefectCommand(opts.ReleaseID, opts.Reason.Value)
+	if err != nil {
+		return err
+	}
+
+	_, err = defects.Create(opts.Client, opts.Client.GetSpaceID(), createReleaseDefectCommand)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(opts.Out, "Successfully prevented progression for release %s (%s) in project %s", opts.Version.Value, output.Dim(opts.ReleaseID), opts.Project.Value)
+	if err != nil {
+		return err
+	}
+
+	if !opts.NoPrompt {
+		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Project, opts.Version, opts.Reason)
+		_, _ = fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
+	}
+
+	return nil
+}
+
+func PromptMissing(opts *PreventOptions) error {
+	var err error
+	var selectedProject *projects.Project
+	if opts.Project.Value == "" {
+		selectedProject, err = selectors.Project("Selected the project in which the release to be blocked exists", opts.Client, opts.Ask)
+		if err != nil {
+			return err
+		}
+		opts.Project.Value = selectedProject.GetName()
+	}
+
+	var selectedRelease *releases.Release
+	if opts.Version.Value == "" {
+		selectedRelease, err = shared.SelectRelease(opts.Client, selectedProject, opts.Ask, "Prevent")
+		if err != nil {
+			return err
+		}
+		opts.Version.Value = selectedRelease.Version
+	}
+
+	return nil
+}

--- a/pkg/cmd/release/progression/progression.go
+++ b/pkg/cmd/release/progression/progression.go
@@ -1,0 +1,27 @@
+package progression
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	cmdAllow "github.com/OctopusDeploy/cli/pkg/cmd/release/progression/allow"
+	cmdPrevent "github.com/OctopusDeploy/cli/pkg/cmd/release/progression/prevent"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdProgression(f factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "progression <command>",
+		Short: "Manage progression of a release",
+		Long:  "Manage progression of a release in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s release progression prevent
+			$ %[1]s release progression allow
+		`, constants.ExecutableName),
+	}
+
+	cmd.AddCommand(cmdAllow.NewCmdAllow(f))
+	cmd.AddCommand(cmdPrevent.NewCmdPrevent(f))
+
+	return cmd
+}

--- a/pkg/cmd/release/progression/shared/shared.go
+++ b/pkg/cmd/release/progression/shared/shared.go
@@ -1,0 +1,53 @@
+package shared
+
+import (
+	"fmt"
+
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+)
+
+func GetReleaseID(octopus *client.Client, spaceID string, projectIdentifier string, version string) (string, error) {
+	selectedProject, err := selectors.FindProject(octopus, projectIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	selectedRelease, err := FindRelease(octopus, selectedProject, version)
+	if err != nil {
+		return "", err
+	}
+	return selectedRelease.GetID(), nil
+}
+
+func SelectRelease(octopus *client.Client, project *projects.Project, ask question.Asker, action string) (*releases.Release, error) {
+	existingReleases, err := octopus.Projects.GetReleases(project)
+	if err != nil {
+		return nil, err
+	}
+
+	selectedRelease, err := question.SelectMap(ask, fmt.Sprintf("Select Release to %s Progression for", action), existingReleases, func(r *releases.Release) string {
+		return r.Version
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return selectedRelease, nil
+}
+
+func FindRelease(octopus *client.Client, project *projects.Project, version string) (*releases.Release, error) {
+	existingRelease, err := releases.GetReleaseInProject(octopus, octopus.GetSpaceID(), project.GetID(), version)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingRelease == nil {
+		return nil, fmt.Errorf("unable to locate a release with version/release number '%s'", version)
+	}
+
+	return existingRelease, nil
+}

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -6,6 +6,7 @@ import (
 	cmdDelete "github.com/OctopusDeploy/cli/pkg/cmd/release/delete"
 	cmdDeploy "github.com/OctopusDeploy/cli/pkg/cmd/release/deploy"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/release/list"
+	cmdProgression "github.com/OctopusDeploy/cli/pkg/cmd/release/progression"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/constants/annotations"
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -27,5 +28,7 @@ func NewCmdRelease(f factory.Factory) *cobra.Command {
 	cmd.AddCommand(cmdDeploy.NewCmdDeploy(f))
 	cmd.AddCommand(cmdList.NewCmdList(f))
 	cmd.AddCommand(cmdDelete.NewCmdDelete(f))
+	cmd.AddCommand(cmdProgression.NewCmdProgression(f))
+
 	return cmd
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -48,6 +48,16 @@ func SliceContainsAny[T comparable](slice []T, predicate func(item T) bool) bool
 	return false
 }
 
+// SliceContainsAll returns true if it finds that all items in the slice for which `predicate` returns true
+func SliceContainsAll[T comparable](slice []T, predicate func(item T) bool) bool {
+	for _, item := range slice {
+		if !predicate(item) {
+			return false
+		}
+	}
+	return true
+}
+
 // ExtractValuesMatchingKeys returns a collection of values which matched a specified set of keys, in the exact order of keys.
 // Given a collection of items, and a collection of keys to match within that collection
 // This makes no sense, hopefully an example helps:


### PR DESCRIPTION
This PR adds the following commands to allow managing the progression of releases in Octopus:
- `octopus release progression allow`
- `octopus release progression prevent`

### Allow progression of a release
```
$ octopus release progression allow --project 'Available Function App Locations' --version '0.0.4' --no-prompt
Successfully allowed progression for release 0.0.4 (Releases-1686) in project Available Function App Locations

$ octopus release progression allow --project 'Available Function App Locations' --version '0.0.4' --no-prompt
Release with version/release number '0.0.4' (Releases-1686) is already allowed to progress to the next phase.

$ octopus release progression prevent
? Selected the project in which the release to be blocked exists Available Function App Locations
? Select Release to Prevent Progression for 0.0.4
? Reason It's broken
Successfully prevented progression for release 0.0.4 (Releases-1686) in project Available Function App Locations
Automation Command: octopus release progression prevent --project 'Available Function App Locations' --version '0.0.4' --reason 'It'\''s broken' --no-prompt
```

### Prevent progression of a release
```
$ octopus release progression prevent --project 'Available Function App Locations' --version '0.0.4' --reason "It\'s bokrer" --no-prompt
Successfully prevented progression for release 0.0.4 (Releases-1686) in project Available Function App Locations

$ octopus release progression prevent --project 'Available Function App Locations' --version '0.0.4' --reason "It\'s bokrer" --no-prompt
Release with version/release number '0.0.4' (Releases-1686) is already prevented from progressing to the next phase.

$ octopus release progression allow
? Select the project in which the blocked release exists Available Function App Locations
? Select Release to Allow Progression for 0.0.4
Successfully allowed progression for release 0.0.4 (Releases-1686) in project Available Function App Locations

Automation Command: octopus release progression allow --project 'Available Function App Locations' --version '0.0.4' --no-prompt
```

Fixes #381 

[sc-87084]