### PR TITLE
feat: handle failures in task wait

### DIFF
--- a/pkg/cmd/task/wait/wait_test.go
+++ b/pkg/cmd/task/wait/wait_test.go
@@ -29,7 +29,7 @@ func TestWait(t *testing.T) {
 		tasks.NewTask(),
 	}
 
-	// bool vars as bool contsants can't be used as pointers for IsCompleted
+	// bool vars as bool constants can't be used as pointers for IsCompleted
 	boolFalse := false
 	boolTrue := true
 
@@ -70,6 +70,81 @@ func TestWait(t *testing.T) {
   Deploy Bar 1 release 0.0.2 to Foo: Executing
   Deploy Bar 2 release 0.0.2 to Foo: Success
   Deploy Bar 1 release 0.0.2 to Foo: Success
+  `)
+	assert.Equal(t, expectedOutput, out.String())
+}
+
+func TestWait_FailedTask(t *testing.T) {
+	out := bytes.Buffer{}
+	defaultTaskIDs := []string{
+		"TaskID1",
+	}
+
+	taskList := []*tasks.Task{
+		tasks.NewTask(),
+	}
+
+	// bool vars as bool constants can't be used as pointers for IsCompleted
+	boolFalse := false
+	boolTrue := true
+
+	taskList[0].ID = defaultTaskIDs[0]
+	taskList[0].IsCompleted = &boolTrue
+	taskList[0].FinishedSuccessfully = &boolFalse
+	taskList[0].Description = "Deploy Bar 1 release 0.0.2 to Foo"
+	taskList[0].State = "Failed"
+
+	getServerTaskCallback := func(taskIDs []string) ([]*tasks.Task, error) {
+		return taskList, nil
+	}
+	err := taskWaitCreate.WaitRun(&out, defaultTaskIDs, getServerTaskCallback, taskWaitCreate.DefaultTimeout)
+	assert.EqualError(t, err, "One or more deployment tasks failed.")
+	expectedOutput := heredoc.Doc(`
+  Deploy Bar 1 release 0.0.2 to Foo: Failed
+  `)
+	assert.Equal(t, expectedOutput, out.String())
+}
+
+func TestWait_FailedPendingTask(t *testing.T) {
+	out := bytes.Buffer{}
+	defaultTaskIDs := []string{
+		"TaskID1",
+	}
+
+	taskList := []*tasks.Task{
+		tasks.NewTask(),
+	}
+
+	// bool vars as bool constants can't be used as pointers for IsCompleted
+	boolFalse := false
+	boolTrue := true
+
+	taskList[0].ID = defaultTaskIDs[0]
+	taskList[0].IsCompleted = &boolFalse
+	taskList[0].Description = "Deploy Bar 1 release 0.0.2 to Foo"
+	taskList[0].State = "Executing"
+
+	timesCalled := 0
+
+	getServerTaskCallback := func(taskIDs []string) ([]*tasks.Task, error) {
+		timesCalled += 1
+		switch timesCalled {
+		case 1:
+			return taskList, nil
+		case 2:
+			taskList[0].IsCompleted = &boolTrue
+			taskList[0].FinishedSuccessfully = &boolFalse
+			taskList[0].State = "Failed"
+			return taskList, nil
+		}
+		return nil, fmt.Errorf("getServerTaskCallback was called more then the expected amount of times")
+	}
+	err := taskWaitCreate.WaitRun(&out, defaultTaskIDs, getServerTaskCallback, taskWaitCreate.DefaultTimeout)
+	assert.EqualError(t, err, "One or more deployment tasks failed.")
+	assert.Equal(t, 2, timesCalled)
+	expectedOutput := heredoc.Doc(`
+  Deploy Bar 1 release 0.0.2 to Foo: Executing
+  Deploy Bar 1 release 0.0.2 to Foo: Failed
   `)
 	assert.Equal(t, expectedOutput, out.String())
 }


### PR DESCRIPTION
#### Summary

Checks for `FinishedSuccessfully`, and returns an error for non-successful tasks. The error message used comes from the C# implementation ("One or more deployment tasks failed.").

Fixes #390.

#### Notes

By adding more tests to `task wait`, the test runtime has increased quite a bit due to `time.Sleep(5 * time.Second)`. I would like some input on this. I could potentially replace it with a mock timer to speed things back up. The overhead of adding more tests to `task wait` is pretty significant currently 😅 