### PR TITLE
fix: no program args now outputs the root help again

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -133,10 +133,10 @@ func NewCmdRoot(f factory.Factory, clientFactory apiclient.ClientFactory, askPro
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if versionParameter {
-			versionCommand.RunE(cmd, args)
+			return versionCommand.RunE(cmd, args)
+		} else {
+			return cmd.Help()
 		}
-
-		return nil
 	}
 
 	return cmd


### PR DESCRIPTION
`2.8.0` included #391, however, if you just do `octopus` with no args, it no longer prints the root help output.

`2.7.0`
<img width="927" alt="{0D39E626-5E39-4E0F-805A-09EE0B7C5E86}" src="https://github.com/user-attachments/assets/4e58a044-89e6-47f9-a76a-3b7780720280">

`2.8.0`
<img width="142" alt="{03207CB0-76FD-44BF-A37F-34E0F75A7605}" src="https://github.com/user-attachments/assets/1a296d35-185e-4e89-a5d6-a470299b4e36">

Fixed
<img width="380" alt="{B54B986A-5B88-423F-B396-F29BA784A602}" src="https://github.com/user-attachments/assets/84e1494e-ae14-40a8-9c36-103735f136eb">

This PR fixes that by returning `Help` from the root command if the version parameter is not set (previously it was returning `nil`)