### PR TITLE
Update deployment process to publish updates to winget

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -220,7 +220,7 @@ step "publish-winget-update-pr" {
                 
                 $version = $OctopusParameters["Octopus.Release.Number"]
                 
-                $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$version_windows_amd64.msi|"
+                $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$version_windows_amd64.msi|x64"
                 
                 # This will perform the update and also create a PR with the relevant update
                 .\wingetcreate.exe update OctopusDeploy.Cli --urls $(packageUrls) --version $version --token $OctopusParameters["Publish:Winget:GitHubPAT"] --submit

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -206,3 +206,27 @@ step "publish-to-rpm-repo" {
         }
     }
 }
+
+step "publish-winget-update-pr" {
+    name = "Publish winget update PR"
+    start_trigger = "StartWithPrevious"
+
+    action {
+        action_type = "Octopus.Script"
+        properties = {
+            Octopus.Action.Script.ScriptBody = <<-EOT
+                # Install winget-create
+                Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+                
+                $version = $OctopusParameters["Octopus.Release.Number"]
+                
+                $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$version_windows_amd64.msi"
+                
+                .\wingetcreate.exe update OctopusDeploy.Cli -u $(packageUrls) -v $version -t $(GITHUB_PAT)
+                EOT
+            Octopus.Action.Script.ScriptSource = "Inline"
+            Octopus.Action.Script.Syntax = "PowerShell"
+        }
+        worker_pool = "hosted-windows"
+    }
+}

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -220,9 +220,10 @@ step "publish-winget-update-pr" {
                 
                 $version = $OctopusParameters["Octopus.Release.Number"]
                 
-                $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$version_windows_amd64.msi"
+                $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$version_windows_amd64.msi|"
                 
-                .\wingetcreate.exe update OctopusDeploy.Cli -u $(packageUrls) -v $version -t $(GITHUB_PAT)
+                # This will perform the update and also create a PR with the relevant update
+                .\wingetcreate.exe update OctopusDeploy.Cli --urls $(packageUrls) --version $version --token $OctopusParameters["Publish:Winget:GitHubPAT"] --submit
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -149,7 +149,7 @@ step "publish-to-apt-repo" {
                   --env PUBLISH_ARTIFACTORY_PASSWORD="$(get_octopusvariable "Publish:Artifactory:Password")" \
                   --env AWS_ACCESS_KEY_ID="$(get_octopusvariable "LinuxPackagePublisherAwsAccount.AccessKey")" \
                   --env AWS_SECRET_ACCESS_KEY="$(get_octopusvariable "LinuxPackagePublisherAwsAccount.SecretKey")" \
-                  octopusdeploy/publish-linux bash -c 'cd /working && bash publish-apt.sh' 2>&1 || exit
+                  docker.packages.octopushq.com/octopusdeploy/publish-linux bash -c 'cd /working && bash publish-apt.sh' 2>&1 || exit
                 
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
@@ -187,7 +187,7 @@ step "publish-to-rpm-repo" {
                   --env PUBLISH_ARTIFACTORY_PASSWORD="$(get_octopusvariable "Publish:Artifactory:Password")" \
                   --env AWS_ACCESS_KEY_ID="$(get_octopusvariable "LinuxPackagePublisherAwsAccount.AccessKey")" \
                   --env AWS_SECRET_ACCESS_KEY="$(get_octopusvariable "LinuxPackagePublisherAwsAccount.SecretKey")" \
-                  octopusdeploy/publish-linux bash -c 'cd /working && bash publish-rpm.sh' 2>&1 || exit
+                  docker.packages.octopushq.com/octopusdeploy/publish-linux bash -c 'cd /working && bash publish-rpm.sh' 2>&1 || exit
                 
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"


### PR DESCRIPTION
Uses the [winget-create](https://github.com/microsoft/winget-create) tool to create a new update of the `OctopusDeploy.Cli` manifests.

I also updated the RPM & APT steps to pull the `publish-linux` via Artifactory to avoid Docker rate-limiting issues (as Artifactory will cache the image). This is not a long term plan, but just alleviates the current issue.

I can't really test this, so will wait for the next release of the CLI to see the results