### PR TITLE
Removes a whitespace between Path key and value when creating a zip p…

### DIFF
--- a/pkg/cmd/package/nuget/create/create.go
+++ b/pkg/cmd/package/nuget/create/create.go
@@ -151,14 +151,15 @@ func createRun(cmd *cobra.Command, opts *NuPkgCreateOptions) error {
 	}
 
 	nuget, err := pack.BuildPackage(opts.PackageCreateOptions, outFilePath)
-	if (nuget != nil) {
+	if nuget != nil {
 		switch outputFormat {
-			case constants.OutputFormatBasic:
-				cmd.Printf("%s\n", nuget.Name())
-			case constants.OutputFormatJson:
-				cmd.Printf(`{"Path": "%s"}`, nuget.Name())
-			default: // table
-				cmd.Printf("Successfully created package %s\n", nuget.Name())
+		case constants.OutputFormatBasic:
+			cmd.Printf("%s\n", nuget.Name())
+		case constants.OutputFormatJson:
+			cmd.Printf(`{"Path":"%s"}`, nuget.Name())
+			cmd.Println()
+		default: // table
+			cmd.Printf("Successfully created package %s\n", nuget.Name())
 		}
 	}
 	return err

--- a/pkg/cmd/package/zip/create/create.go
+++ b/pkg/cmd/package/zip/create/create.go
@@ -78,14 +78,15 @@ func createRun(cmd *cobra.Command, opts *pack.PackageCreateOptions) error {
 	outFilePath := pack.BuildOutFileName("zip", opts.Id.Value, opts.Version.Value)
 
 	zip, err := pack.BuildPackage(opts, outFilePath)
-	if (zip != nil) {
+	if zip != nil {
 		switch outputFormat {
-			case constants.OutputFormatBasic:
-				cmd.Printf("%s\n", zip.Name())
-			case constants.OutputFormatJson:
-				cmd.Printf(`{"Path": "%s"}`, zip.Name())
-			default: // table
-				cmd.Printf("Successfully created package %s\n", zip.Name())
+		case constants.OutputFormatBasic:
+			cmd.Printf("%s\n", zip.Name())
+		case constants.OutputFormatJson:
+			cmd.Printf(`{"Path":"%s"}`, zip.Name())
+			cmd.Println()
+		default: // table
+			cmd.Printf("Successfully created package %s\n", zip.Name())
 		}
 	}
 	return err


### PR DESCRIPTION
…ackage with json output format. Additionally prints a new line so it's consistent with the other output options.

This is to make it consistent with our other json output formats, like release creation or deploy.

![image](https://github.com/user-attachments/assets/857a158e-70fd-47ea-8b32-3070f393d81f)


