### PR TITLE
fix: include release notes and assembled date in json output after creating a release

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -288,12 +288,16 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 	}
 
 	if options.Response != nil {
-		printReleaseVersion := func(releaseVersion string, channel *channels.Channel) {
+		printReleaseVersion := func(release *releases.Release, channel *channels.Channel) {
 			switch outputFormat {
 			case constants.OutputFormatBasic:
-				cmd.Printf("%s\n", releaseVersion)
+				cmd.Printf("%s\n", release.Version)
 			case constants.OutputFormatJson:
-				v := &list.ReleaseViewModel{Version: releaseVersion}
+				v := &list.ReleaseViewModel{
+					Version:      release.Version,
+					Assembled:    release.Assembled,
+					ReleaseNotes: release.ReleaseNotes,
+				}
 				if channel != nil {
 					v.Channel = channel.Name
 				}
@@ -306,9 +310,9 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 				}
 			default: // table
 				if channel != nil {
-					cmd.Printf("Successfully created release version %s using channel %s\n", releaseVersion, channel.Name)
+					cmd.Printf("Successfully created release version %s using channel %s\n", release.Version, channel.Name)
 				} else {
-					cmd.Printf("Successfully created release version %s\n", releaseVersion)
+					cmd.Printf("Successfully created release version %s\n", release.Version)
 				}
 			}
 		}
@@ -317,14 +321,14 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 		newlyCreatedRelease, lookupErr := octopus.Releases.GetByID(options.Response.ReleaseID)
 		if lookupErr != nil {
 			cmd.PrintErrf("Warning: cannot fetch release details: %v\n", lookupErr)
-			printReleaseVersion(options.Response.ReleaseVersion, nil)
+			printReleaseVersion(newlyCreatedRelease, nil)
 		} else {
 			releaseChan, lookupErr := octopus.Channels.GetByID(newlyCreatedRelease.ChannelID)
 			if lookupErr != nil {
 				cmd.PrintErrf("Warning: cannot fetch release channel details: %v\n", lookupErr)
-				printReleaseVersion(options.Response.ReleaseVersion, nil)
+				printReleaseVersion(newlyCreatedRelease, nil)
 			} else {
-				printReleaseVersion(options.Response.ReleaseVersion, releaseChan)
+				printReleaseVersion(newlyCreatedRelease, releaseChan)
 			}
 		}
 


### PR DESCRIPTION
## Before
```
❯ octopus release create --space Default --project "Test function" --version 0.0.36 --output-format json --package "henrik-test-function:0.0.1" --release-notes "test release notes" --no-prompt
{"ReleaseNotes":"","Assembled":"0001-01-01T00:00:00Z","Channel":"Default","Version":"0.0.36"}
```

## After
```
❯ ./octopus release create --space Default --project "Test function" --version 0.0.37 --output-format json --package "henrik-test-function:0.0.1" --release-notes "test release notes" --no-prompt
{"ReleaseNotes":"test release notes","Assembled":"2024-09-18T14:49:56.675+10:00","Channel":"Default","Version":"0.0.37"}
```

[sc-93329]