### PR TITLE
fix: wait task command printing there was a failed task even though all tasks were successful

### DIFF
--- a/pkg/cmd/task/wait/wait.go
+++ b/pkg/cmd/task/wait/wait.go
@@ -81,15 +81,12 @@ func WaitRun(out io.Writer, taskIDs []string, getServerTasksCallback ServerTasks
 		if t.IsCompleted == nil || !*t.IsCompleted {
 			pendingTaskIDs = append(pendingTaskIDs, t.ID)
 		}
-		if t.FinishedSuccessfully != nil && !*t.FinishedSuccessfully {
-			failedTaskIDs = append(failedTaskIDs, t.ID)
-		}
 		fmt.Fprintf(out, "%s: %s\n", t.Description, t.State)
 	}
 
 	if len(pendingTaskIDs) == 0 {
 		if len(failedTaskIDs) != 0 {
-			return fmt.Errorf("One or more deployment tasks failed.")
+			return fmt.Errorf("one or more deployment tasks failed")
 		}
 		return nil
 	}
@@ -115,7 +112,7 @@ func WaitRun(out io.Writer, taskIDs []string, getServerTasksCallback ServerTasks
 			}
 		}
 		if len(failedTaskIDs) != 0 {
-			gotError <- fmt.Errorf("One or more deployment tasks failed.")
+			gotError <- fmt.Errorf("one or more deployment tasks failed")
 			return
 		}
 		done <- true

--- a/pkg/cmd/task/wait/wait.go
+++ b/pkg/cmd/task/wait/wait.go
@@ -80,6 +80,8 @@ func WaitRun(out io.Writer, taskIDs []string, getServerTasksCallback ServerTasks
 	for _, t := range tasks {
 		if t.IsCompleted == nil || !*t.IsCompleted {
 			pendingTaskIDs = append(pendingTaskIDs, t.ID)
+		} else if t.FinishedSuccessfully != nil && !*t.FinishedSuccessfully {
+			failedTaskIDs = append(failedTaskIDs, t.ID)
 		}
 		fmt.Fprintf(out, "%s: %s\n", t.Description, t.State)
 	}

--- a/pkg/cmd/task/wait/wait.go
+++ b/pkg/cmd/task/wait/wait.go
@@ -86,7 +86,7 @@ func WaitRun(out io.Writer, taskIDs []string, getServerTasksCallback ServerTasks
 
 	if len(pendingTaskIDs) == 0 {
 		if len(failedTaskIDs) != 0 {
-			return fmt.Errorf("one or more deployment tasks failed")
+			return fmt.Errorf("One or more deployment tasks failed.")
 		}
 		return nil
 	}
@@ -112,7 +112,7 @@ func WaitRun(out io.Writer, taskIDs []string, getServerTasksCallback ServerTasks
 			}
 		}
 		if len(failedTaskIDs) != 0 {
-			gotError <- fmt.Errorf("one or more deployment tasks failed")
+			gotError <- fmt.Errorf("One or more deployment tasks failed.")
 			return
 		}
 		done <- true


### PR DESCRIPTION
## Before
```
❯ ./octopus release deploy -p "Test 2" --version 0.0.9 -e Local --no-prompt --output-format basic | ./octopus task wait
Deploy Test 2 release 0.0.9 to Local: Executing
Deploy Test 2 release 0.0.9 to Local: Success
one or more deployment tasks failed
```

## After
```
❯ ./octopus release deploy -p "Test 2" --version 0.0.9 -e Local --no-prompt --output-format basic | ./octopus task wait
Deploy Test 2 release 0.0.9 to Local: Executing
Deploy Test 2 release 0.0.9 to Local: Success
❯ ./octopus release deploy -p "Test 2" --version 0.0.9 -e Local --no-prompt --output-format basic | ./octopus task wait
Deploy Test 2 release 0.0.9 to Local: Executing
Deploy Test 2 release 0.0.9 to Local: Canceled
one or more deployment tasks failed
```

Fixes https://github.com/OctopusDeploy/cli/issues/421