### PR TITLE
Do not prompt for space name (for client) on space creation

### DIFF
--- a/pkg/cmd/space/create/create.go
+++ b/pkg/cmd/space/create/create.go
@@ -48,7 +48,7 @@ type CreateOptions struct {
 }
 
 func NewCreateOptions(f factory.Factory, flags *CreateFlags, c *cobra.Command) *CreateOptions {
-	dependencies := cmd.NewDependencies(f, c)
+	dependencies := cmd.NewSystemDependencies(f, c)
 	client, err := f.GetSystemClient(apiclient.NewRequester(c))
 	dependencies.Client = client // override the default space client
 	if err != nil {


### PR DESCRIPTION
Do not prompt for existing space when creating a new space.
[sc-73470]
![image](https://github.com/user-attachments/assets/63b2e0a8-2e1d-458d-a149-223b9eca8f15)
