### PR TITLE
feat: Add support for fixed package versions in release creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.51.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.54.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.51.1 h1:iHh6HQyjN2IrJHnsrpgG9xq0Tj3DJmVIVFVZPkRYtUU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.51.1/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.54.0 h1:cmtRQZxy4W+871TnhebdaKCg/Woxu5JOgasl/hHWUjA=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.54.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -371,12 +371,7 @@ func BuildPackageVersionBaseline(octopus *octopusApiClient.Client, deploymentPro
 	for _, pkg := range deploymentProcessTemplate.Packages {
 
 		if pkg.FixedVersion != "" {
-			result = append(result, &StepPackageVersion{
-				PackageID:            pkg.PackageID,
-				ActionName:           pkg.ActionName,
-				PackageReferenceName: pkg.PackageReferenceName,
-				Version:              pkg.FixedVersion,
-			})
+			// If a package has a fixed version it shouldn't be displayed or overridable at all
 			continue
 		}
 

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -370,6 +370,16 @@ func BuildPackageVersionBaseline(octopus *octopusApiClient.Client, deploymentPro
 	feedsToQuery := make(map[string][]releases.ReleaseTemplatePackage)
 	for _, pkg := range deploymentProcessTemplate.Packages {
 
+		if pkg.FixedVersion != "" {
+			result = append(result, &StepPackageVersion{
+				PackageID:            pkg.PackageID,
+				ActionName:           pkg.ActionName,
+				PackageReferenceName: pkg.PackageReferenceName,
+				Version:              pkg.FixedVersion,
+			})
+			continue
+		}
+
 		// If a package is not considered resolvable by the server, don't attempt to query it's feed or lookup
 		// any potential versions for it; we can't succeed in that because variable templates won't get expanded
 		// until deployment time

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1958,6 +1958,68 @@ func TestReleaseCreate_BuildPackageVersionBaseline(t *testing.T) {
 		assert.Equal(t, []*create.StepPackageVersion{}, packageVersions)
 	})
 
+	t.Run("builds list containing only selectable package/step when a different step has a fixed package version", func(t *testing.T) {
+		api := testutil.NewMockHttpServer()
+		processTemplate := &deployments.DeploymentProcessTemplate{
+			Packages: []releases.ReleaseTemplatePackage{
+				{
+					ActionName:           "Install",
+					FeedID:               builtinFeedID,
+					PackageID:            "pterm",
+					PackageReferenceName: "pterm-on-install",
+					IsResolvable:         true,
+				},
+				{
+					ActionName:           "Install",
+					FeedID:               builtinFeedID,
+					PackageID:            "pterm",
+					PackageReferenceName: "pterm-on-install",
+					IsResolvable:         true,
+					FixedVersion:         "0.11.23",
+				},
+			},
+			Resource: resources.Resource{},
+		}
+
+		channel := fixtures.NewChannel(spaceID, "Channels-1", "Default", "Projects-1")
+
+		receiver := testutil.GoBegin2(func() ([]*create.StepPackageVersion, error) {
+			defer api.Close()
+			octopus, _ := octopusApiClient.NewClient(testutil.NewMockHttpClientWithTransport(api), serverUrl, placeholderApiKey, "")
+			return create.BuildPackageVersionBaseline(octopus, processTemplate, channel)
+		})
+
+		api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+		api.ExpectRequest(t, "GET", "/api/spaces").RespondWith(rootResource)
+
+		// it needs to load the feeds to find the links
+		api.ExpectRequest(t, "GET", "/api/Spaces-1/feeds?ids=feeds-builtin&take=1").RespondWith(&feeds.Feeds{Items: []feeds.IFeed{
+			&feeds.FeedResource{Name: "Builtin", FeedType: feeds.FeedTypeBuiltIn, Resource: resources.Resource{
+				ID: builtinFeedID,
+				Links: map[string]string{
+					constants.LinkSearchPackageVersionsTemplate: "/api/Spaces-1/feeds/feeds-builtin/packages/versions{?packageId,take,skip,includePreRelease,versionRange,preReleaseTag,filter,includeReleaseNotes}",
+				}}},
+		}})
+
+		// now it will search for the package versions
+		api.ExpectRequest(t, "GET", "/api/Spaces-1/feeds/feeds-builtin/packages/versions?packageId=pterm&take=1").RespondWith(&resources.Resources[*packages.PackageVersion]{
+			Items: []*packages.PackageVersion{
+				{PackageID: "pterm", Version: "0.12.51"},
+			},
+		})
+
+		packageVersions, err := testutil.ReceivePair(receiver)
+		assert.Nil(t, err)
+		assert.Equal(t, []*create.StepPackageVersion{
+			{
+				PackageID:            "pterm",
+				ActionName:           "Install",
+				Version:              "0.12.51",
+				PackageReferenceName: "pterm-on-install",
+			},
+		}, packageVersions)
+	})
+
 	t.Run("builds list for multiple package/steps with some overlapping packages; no duplicate requests sent to server", func(t *testing.T) {
 		api := testutil.NewMockHttpServer()
 		processTemplate := &deployments.DeploymentProcessTemplate{


### PR DESCRIPTION
This PR adds support to release creation for detecting when a package reference in a step has been configured with a fixed version. This feature is currently rolling out through Octopus Cloud. If a fixed version is configured on the step then the CLI will no longer attempt to get a version from the feed or ask the user to confirm the version.

This PR needs https://github.com/OctopusDeploy/go-octopusdeploy/pull/276 to be merged and a new version of the library made available.