### PR TITLE
fix: disable/enable tenant command docs

### DIFF
--- a/pkg/cmd/tenant/disable/disable.go
+++ b/pkg/cmd/tenant/disable/disable.go
@@ -25,10 +25,13 @@ func NewDisableOptions(args []string, dependencies *cmd.Dependencies) *DisableOp
 
 func NewCmdDisable(f factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "disable",
-		Short:   "Disable a tenant",
-		Long:    "Disable a tenant in Octopus Deploy",
-		Example: heredoc.Docf("$ %[1]s tenant enable", constants.ExecutableName),
+		Use:   "disable {<name> | <id>}",
+		Short: "Disable a tenant",
+		Long:  "Disable a tenant in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s disable view Tenants-1
+			$ %[1]s disable view 'Tenant'
+		`, constants.ExecutableName),
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				args = append(args, "")

--- a/pkg/cmd/tenant/enable/enable.go
+++ b/pkg/cmd/tenant/enable/enable.go
@@ -25,10 +25,13 @@ func NewEnableOptions(args []string, dependencies *cmd.Dependencies) *EnableOpti
 
 func NewCmdEnable(f factory.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "enable",
-		Short:   "Enable a tenant",
-		Long:    "Enable a tenant in Octopus Deploy",
-		Example: heredoc.Docf("$ %[1]s tenant enable", constants.ExecutableName),
+		Use:   "enable {<name> | <id>}",
+		Short: "Enable a tenant",
+		Long:  "Enable a tenant in Octopus Deploy",
+		Example: heredoc.Docf(`
+			$ %[1]s tenant enable Tenants-1
+			$ %[1]s tenant enable 'Tenant'
+		`, constants.ExecutableName),
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				args = append(args, "")


### PR DESCRIPTION
Generating docs for CLI resulted in incorrect docs for `tenant enable` and `tenant disable` - https://github.com/OctopusDeploy/docs/pull/2565

Fix this by updating `Use` and `Example` to include  the name/id argument.