### PR TITLE
Fix uploading of artifacts

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -178,11 +178,16 @@ jobs:
       if: "!contains(needs.goreleaser.outputs.version, '-')" # skip prereleases
       run: gh release upload "${{ needs.goreleaser.outputs.tag_name }}" "$MSI_FILE"
 
-    - name: Append MSI to artifact octopus-cli.${{ needs.goreleaser.outputs.version }}
+    - name: Copy MSI into artifacts folder
+      shell: bash
+      run: cp "${{ steps.buildmsi.outputs.msi }}" "artifacts/${{ steps.buildmsi.outputs.msi }}"
+
+    - name: Re-upload artifacts with MSI to octopus-cli.${{ needs.goreleaser.outputs.version }}
       uses: actions/upload-artifact@v4
       with:
         name: octopus-cli.${{ needs.goreleaser.outputs.version }}
-        path: ${{ steps.buildmsi.outputs.msi }}
+        path: artifacts/
+        overwrite: true
 
   generate-packages-and-publish:
     needs: [goreleaser, msi]


### PR DESCRIPTION
`upload-artifact/v4` doesn't allow upload artifacts to the same name. We were using this to build a `.zip` file with all the artifacts.

The solution is to copy the MSI into the `artifacts` folder (which was downloaded from earlier), then re-upload with `overwrite` which should give us the full `.zip` 