### PR TITLE
List scoped common variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.3
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.4
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.3 h1:WLvvQGg7TXECnq3m/yawwYVaASfRaIUn8ndwMvkxiaw=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.3/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.4 h1:tC8Wc31r9BPIkzEo1LF8chOG7ehGOpViVnQAALprNss=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.4/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/tenant/variables/list/list.go
+++ b/pkg/cmd/tenant/variables/list/list.go
@@ -323,17 +323,26 @@ func unwrapProjectVariablesV1(variables variables.ProjectVariable, environmentMa
 
 func unwrapCommonVariables(variable variables.TenantCommonVariable, environmentMap map[string]string) []*VariableValue {
 	var results []*VariableValue = nil
+	var isDefault = variable.ID == ""
+	var displayValue string
+
+	if isDefault {
+		displayValue = getDisplayValue(variable.Template.DefaultValue)
+	} else {
+		displayValue = getDisplayValue(&variable.Value)
+	}
+
 	for _, environmentId := range variable.Scope.EnvironmentIds {
 
 		results = append(results, &VariableValue{
 			Type:            LibraryVariableSetType,
 			OwnerName:       variable.LibraryVariableSetName,
 			Name:            variable.Template.Name,
-			Value:           getDisplayValue(&variable.Value),
+			Value:           displayValue,
 			IsSensitive:     variable.Value.IsSensitive,
-			IsDefaultValue:  variable.ID == "", // Variables without an ID are sourced from the MissingVariables list. For consistency with V1, IsDefault applies to both default and missing variables
+			IsDefaultValue:  isDefault, // Variables without an ID are sourced from the MissingVariables list. For consistency with V1, IsDefault applies to both default and missing variables
 			ScopeName:       environmentMap[environmentId],
-			HasMissingValue: variable.Value.Value == "",
+			HasMissingValue: isDefault && displayValue == "",
 		})
 	}
 
@@ -342,18 +351,26 @@ func unwrapCommonVariables(variable variables.TenantCommonVariable, environmentM
 
 func unwrapProjectVariables(variable variables.TenantProjectVariable, environmentMap map[string]string) []*VariableValue {
 	var results []*VariableValue = nil
+	var isDefault = variable.ID == ""
+	var displayValue string
+
+	if isDefault {
+		displayValue = getDisplayValue(variable.Template.DefaultValue)
+	} else {
+		displayValue = getDisplayValue(&variable.Value)
+	}
+
 	for _, environmentId := range variable.Scope.EnvironmentIds {
 
 		results = append(results, &VariableValue{
-			Type:      LibraryVariableSetType,
-			OwnerName: variable.ProjectName,
-			Name:      variable.Template.Name,
-			// TODO: Sensitive value should be displayed as ***
-			Value:           getDisplayValue(&variable.Value),
+			Type:            LibraryVariableSetType,
+			OwnerName:       variable.ProjectName,
+			Name:            variable.Template.Name,
+			Value:           displayValue,
 			IsSensitive:     variable.Value.IsSensitive,
-			IsDefaultValue:  variable.ID == "", // Variables without an ID are sourced from the MissingVariables list. For consistency with V1, IsDefault applies to both default and missing variables
+			IsDefaultValue:  isDefault, // Variables without an ID are sourced from the MissingVariables list. For consistency with V1, IsDefault applies to both default and missing variables
 			ScopeName:       environmentMap[environmentId],
-			HasMissingValue: variable.Value.Value == "",
+			HasMissingValue: isDefault && displayValue == "",
 		})
 	}
 

--- a/pkg/cmd/tenant/variables/list/list.go
+++ b/pkg/cmd/tenant/variables/list/list.go
@@ -8,9 +8,9 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util/featuretoggle"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/configuration"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
@@ -102,16 +102,9 @@ func listRun(cmd *cobra.Command, f factory.Factory, id string) error {
 		return err
 	}
 
-	toggleRequest := &configuration.FeatureToggleConfigurationQuery{
-		Name: "CommonVariableScopingFeatureToggle",
-	}
-	toggleResponse, err := configuration.Get(client, toggleRequest)
-	if err != nil {
-		return err
-	}
-	toggleValue := toggleResponse.FeatureToggles[0]
+	toggleValue, err := featuretoggle.IsToggleEnabled(client, "CommonVariableScopingFeatureToggle")
 
-	if toggleValue.IsEnabled {
+	if toggleValue {
 		projectVariablesQuery := variables.GetTenantProjectVariablesQuery{
 			TenantID:                tenant.ID,
 			SpaceID:                 tenant.SpaceID,

--- a/pkg/cmd/tenant/variables/list/list.go
+++ b/pkg/cmd/tenant/variables/list/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/configuration"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/spf13/cobra"
@@ -103,11 +102,10 @@ func listRun(cmd *cobra.Command, f factory.Factory, id string) error {
 		return err
 	}
 
-	newClient := newclient.NewClient(client.HttpSession())
 	toggleRequest := &configuration.FeatureToggleConfigurationQuery{
 		Name: "CommonVariableScopingFeatureToggle",
 	}
-	toggleResponse, err := configuration.Get(newClient, toggleRequest)
+	toggleResponse, err := configuration.Get(client, toggleRequest)
 	if err != nil {
 		return err
 	}
@@ -115,23 +113,23 @@ func listRun(cmd *cobra.Command, f factory.Factory, id string) error {
 
 	if toggleValue.IsEnabled {
 		projectVariablesQuery := variables.GetTenantProjectVariablesQuery{
-			TenantID:                       tenant.ID,
-			SpaceID:                        tenant.SpaceID,
-			IncludeMissingProjectVariables: true,
+			TenantID:                tenant.ID,
+			SpaceID:                 tenant.SpaceID,
+			IncludeMissingVariables: true,
 		}
 
-		projectVariables, err := tenants.GetProjectVariables(newClient, projectVariablesQuery)
+		projectVariables, err := tenants.GetProjectVariables(client, projectVariablesQuery)
 		if err != nil {
 			return err
 		}
 
 		commonVariablesQuery := variables.GetTenantCommonVariablesQuery{
-			TenantID:                      tenant.ID,
-			SpaceID:                       tenant.SpaceID,
-			IncludeMissingCommonVariables: true,
+			TenantID:                tenant.ID,
+			SpaceID:                 tenant.SpaceID,
+			IncludeMissingVariables: true,
 		}
 
-		commonVariables, err := tenants.GetCommonVariables(newClient, commonVariablesQuery)
+		commonVariables, err := tenants.GetCommonVariables(client, commonVariablesQuery)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/tenant/variables/list/list.go
+++ b/pkg/cmd/tenant/variables/list/list.go
@@ -354,7 +354,7 @@ func unwrapProjectVariables(variable variables.TenantProjectVariable, environmen
 	for _, environmentId := range variable.Scope.EnvironmentIds {
 
 		results = append(results, &VariableValue{
-			Type:            LibraryVariableSetType,
+			Type:            ProjectType,
 			OwnerName:       variable.ProjectName,
 			Name:            variable.Template.Name,
 			Value:           displayValue,

--- a/pkg/util/featuretoggle/feature_toggles.go
+++ b/pkg/util/featuretoggle/feature_toggles.go
@@ -17,5 +17,16 @@ func IsToggleEnabled(client *client.Client, toggleName string) (bool, error) {
 		return false, err
 	}
 
-	return returnToggleResponse.FeatureToggles[0].IsEnabled, err
+	if len(returnToggleResponse.FeatureToggles) == 0 {
+		return false, err
+	}
+
+	var toggleValue = returnToggleResponse.FeatureToggles[0]
+
+	// Verify name to avoid error in older versions of Octopus where Name param is not recognised
+	if toggleValue.Name != toggleName {
+		return false, err
+	}
+
+	return toggleValue.IsEnabled, err
 }

--- a/pkg/util/featuretoggle/feature_toggles.go
+++ b/pkg/util/featuretoggle/feature_toggles.go
@@ -1,0 +1,21 @@
+package featuretoggle
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/configuration"
+)
+
+// IsToggleEnabled retrieves an Octopus feature toggle by name. If an error occurs, it returns false.
+func IsToggleEnabled(client *client.Client, toggleName string) (bool, error) {
+	toggleRequest := &configuration.FeatureToggleConfigurationQuery{
+		Name: toggleName,
+	}
+
+	returnToggleResponse, err := configuration.Get(client, toggleRequest)
+
+	if err != nil {
+		return false, err
+	}
+
+	return returnToggleResponse.FeatureToggles[0].IsEnabled, err
+}


### PR DESCRIPTION
[SC-93474]

When scoped tenant common variables are enabled, both common and project variables can be scoped by multiple environments. This PR provides support for variables with an array of environment scopes.

## Before
Tenant common variables had no environment scoping, so Environment was blank. Project variables were only scoped to one environment, so per template, one row existed per environment.

```
$ ./octopus tenant variables list "t1"
NAME                        LABEL         TYPE     OWNER                    ENVIRONMENT  VALUE                   SENSITIVE  DEFAULT VALUE
template1                                 Library  set1                                  default                 false      true
secret template                           Library  set1                                  ***                     true       true
missing t1                                Library  missing set 1                         <missing>                      false      true
missing t2                                Library  missing set 1                         default                 false      true
proj template1                            Project  var scopes               Dev          default                 false      true
proj template1                            Project  var scopes               Test         CLI missing update 1    false      false
proj template1                            Project  var scopes               Prod         default                 false      true
Missing Proj template 1     missing vars  Project  var scopes               Test         <missing>               false      true
Missing Proj template 1     missing vars  Project  var scopes               Prod         <missing>               false      true
Missing Proj template 1     missing vars  Project  var scopes               Dev          <missing>               false      true
```

## After
Tenant common variables now have environment scoping, and both common and project variables can have multiple environment scopes. We still list one row per template and environment because each environment can only have one value. Tested combining environment names for shared scopes into a comma separated list, but values were cut off when the list was long.

```
$ ./octopus tenant variables list "t1"
NAME                        LABEL  TYPE     OWNER                    ENVIRONMENT  VALUE                   SENSITIVE  DEFAULT VALUE
missing t1                         Library  missing set 1            Prod         <missing>               false      true
missing t1                         Library  missing set 1            Test         <missing>               false      true
missing t1                         Library  missing set 1            Dev          Dev scope only          false      false
missing t2                         Library  missing set 1            Dev          default                 false      true
missing t2                         Library  missing set 1            Test         default                 false      true
missing t2                         Library  missing set 1            Prod         default                 false      true
no scope common template 1         Library  no scope set1            Prod         default                 false      true
no scope common template 1         Library  no scope set1            Dev          default                 false      true
no scope common template 1         Library  no scope set1            Test         default                 false      true
secret template                    Library  set1                     Prod         ***                     true       true
secret template                    Library  set1                     Test         ***                     true       true
secret template                    Library  set1                     Dev          ***                     true       true
template1                          Library  set1                     Test         default                 false      true
template1                          Library  set1                     Prod         default                 false      true
template1                          Library  set1                     Dev          latest cli              false      false
Missing Proj template 1            Project  var scopes               Prod         <missing>               false      true
Missing Proj template 1            Project  var scopes               Dev          <missing>               false      true
Missing Proj template 1            Project  var scopes               Test         <missing>               false      true
proj template1                     Project  var scopes               Test         update 1                false      false
proj template1                     Project  var scopes               Dev          default                 false      true
proj template1                     Project  var scopes               Prod         default                 false      true
proj template 1                    Project  var scopes 2             Dev          project-template1-test  false      false
proj template 1                    Project  var scopes 2             Test         project-template1-test  false      false
```