### PR TITLE
Nj/6.4 fix

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -207,32 +207,6 @@ step "publish-to-rpm-repo" {
     }
 }
 
-step "extra-debug" {
-    name = "extra debug "
-
-    action {
-        action_type = "Octopus.Script"
-        properties = {
-            Octopus.Action.Script.ScriptBody = <<-EOT
-                echo "SDKs"
-                dotnet --list-sdks
-                
-                echo "runtimes"
-                dotnet --list-runtimes
-                EOT
-            Octopus.Action.Script.ScriptSource = "Inline"
-            Octopus.Action.Script.Syntax = "PowerShell"
-            OctopusUseBundledTooling = "False"
-        }
-        worker_pool = "hosted-windows"
-
-        container {
-            feed = "docker-hub"
-            image = "octopusdeploy/worker-tools:6.4-windows.ltsc2022"
-        }
-    }
-}
-
 step "publish-winget-update-pr" {
     name = "Publish winget update PR"
     start_trigger = "StartWithPrevious"
@@ -247,6 +221,12 @@ step "publish-winget-update-pr" {
                 $version = $OctopusParameters["Octopus.Release.Number"]
                 
                 $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$($version)_windows_amd64.msi|x64"
+                
+                echo "SDKs"
+                dotnet --list-sdks
+                
+                echo "runtimes"
+                dotnet --list-runtimes
                 
                 # This will perform the update and also create a PR with the relevant update
                 .\wingetcreate.exe update OctopusDeploy.Cli --urls $packageUrls --version $version --token $OctopusParameters["Publish:Winget:GitHubPAT"] --submit

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -228,6 +228,8 @@ step "publish-winget-update-pr" {
                 echo "runtimes"
                 dotnet --list-runtimes
                 
+                $Env:DOTNET_ROOT = "C:\Users\ContainerAdministrator\AppData\Local\Microsoft\dotnet"
+                
                 # This will perform the update and also create a PR with the relevant update
                 .\wingetcreate.exe update OctopusDeploy.Cli --urls $packageUrls --version $version --token $OctopusParameters["Publish:Winget:GitHubPAT"] --submit
                 EOT

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -259,7 +259,7 @@ step "publish-winget-update-pr" {
 
         container {
             feed = "docker-hub"
-            image = "octopusdeploy/worker-tools:6.4.0-windows.ltsc2022"
+            image = "octopusdeploy/worker-tools:6.4-windows.ltsc2022"
         }
     }
 }


### PR DESCRIPTION
$Env:DOTNET_ROOT = "C:\Users\ContainerAdministrator\AppData\Local\Microsoft\dotnet"

is a fix until we can work out what's special about either wingetcreate, this version of botnet and how it's being installed in a our worker-tools container image.