### PR TITLE
Fix deleting variables from other variable sets

### DIFF
--- a/pkg/cmd/tenant/variables/update/update.go
+++ b/pkg/cmd/tenant/variables/update/update.go
@@ -935,7 +935,7 @@ func createProjectVariablePayload(variableToUpdate variables.TenantProjectVariab
 		})
 	}
 
-	// All variables within the selected project must be included in the request to avoid deletions
+	// All project variables must be included in the request to avoid deletions
 	for _, v := range allVariables {
 		if v.ID == variableToUpdate.ID {
 			updateVariablePayloads = append(updateVariablePayloads, variables.TenantProjectVariablePayload{
@@ -972,7 +972,7 @@ func createCommonVariablePayload(variableToUpdate variables.TenantCommonVariable
 		})
 	}
 
-	// All variables must be included in the request to avoid deletions
+	// All common variables must be included in the request to avoid deletions
 	for _, v := range allVariables {
 		if v.ID == variableToUpdate.ID {
 			updateVariablePayloads = append(updateVariablePayloads, variables.TenantCommonVariablePayload{

--- a/pkg/cmd/tenant/variables/update/update.go
+++ b/pkg/cmd/tenant/variables/update/update.go
@@ -779,7 +779,7 @@ func UpdateProjectVariableValue(opts *UpdateOptions, vars []variables.TenantProj
 				EnvironmentIds: environmentIds,
 			},
 		}
-		updateVariablePayloads, isSensitive, err := createProjectVariablePayload(variableToCreate, newValue, variablesWithMatchingProject)
+		updateVariablePayloads, isSensitive, err := createProjectVariablePayload(variableToCreate, newValue, vars)
 		if err != nil {
 			return false, nil, err
 		}
@@ -788,7 +788,7 @@ func UpdateProjectVariableValue(opts *UpdateOptions, vars []variables.TenantProj
 	}
 
 	if len(variablesWithMatchingScope) == 1 {
-		var updateVariablePayloads, isSensitive, err = createProjectVariablePayload(variablesWithMatchingScope[0], newValue, variablesWithMatchingProject)
+		var updateVariablePayloads, isSensitive, err = createProjectVariablePayload(variablesWithMatchingScope[0], newValue, vars)
 		if err != nil {
 			return false, nil, err
 		}
@@ -897,7 +897,7 @@ func UpdateCommonVariableValue(opts *UpdateOptions, vars []variables.TenantCommo
 				EnvironmentIds: environmentIds,
 			},
 		}
-		updateVariablePayloads, isSensitive, err := createCommonVariablePayload(variableToCreate, newValue, variablesWithMatchingVariableSet)
+		updateVariablePayloads, isSensitive, err := createCommonVariablePayload(variableToCreate, newValue, vars)
 		if err != nil {
 			return false, nil, err
 		}
@@ -906,7 +906,7 @@ func UpdateCommonVariableValue(opts *UpdateOptions, vars []variables.TenantCommo
 	}
 
 	if len(variablesWithMatchingScope) == 1 {
-		var updateVariablePayloads, isSensitive, err = createCommonVariablePayload(variablesWithMatchingScope[0], newValue, variablesWithMatchingVariableSet)
+		var updateVariablePayloads, isSensitive, err = createCommonVariablePayload(variablesWithMatchingScope[0], newValue, vars)
 		if err != nil {
 			return false, nil, err
 		}
@@ -972,7 +972,7 @@ func createCommonVariablePayload(variableToUpdate variables.TenantCommonVariable
 		})
 	}
 
-	// All variables within the selected library variable set must be included in the request to avoid deletions
+	// All variables must be included in the request to avoid deletions
 	for _, v := range allVariables {
 		if v.ID == variableToUpdate.ID {
 			updateVariablePayloads = append(updateVariablePayloads, variables.TenantCommonVariablePayload{

--- a/pkg/cmd/tenant/variables/update/update_test.go
+++ b/pkg/cmd/tenant/variables/update/update_test.go
@@ -72,6 +72,7 @@ func TestUpdate_CommonVariable_ScopeExactMatch(t *testing.T) {
 	var existingCommonVariables = []variables.TenantCommonVariable{
 		createCommonVariable("TenantVariables-1", "LibraryVariableSets-1", "Set 1", "Templates-1", "Template 1", "existing value 1", []string{"Environments-1", "Environments-2"}, false),
 		createCommonVariable("TenantVariables-2", "LibraryVariableSets-1", "Set 1", "Templates-1", "Template 1", "existing value 2", []string{"Environments-3"}, false),
+		createCommonVariable("TenantVariables-3", "LibraryVariableSets-2", "Set 2", "Templates-2", "Template 2", "existing value 3", []string{}, false),
 	}
 
 	var environmentMap = map[string]string{
@@ -83,7 +84,7 @@ func TestUpdate_CommonVariable_ScopeExactMatch(t *testing.T) {
 	isSensitive, variablePayload, err := update.UpdateCommonVariableValue(opts, existingCommonVariables, nil, environmentMap)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(variablePayload))
+	assert.Equal(t, 3, len(variablePayload))
 
 	assert.Equal(t, existingCommonVariables[0].ID, variablePayload[0].ID)
 	assert.Equal(t, core.PropertyValue{Value: "new value"}, variablePayload[0].Value)
@@ -96,6 +97,13 @@ func TestUpdate_CommonVariable_ScopeExactMatch(t *testing.T) {
 	assert.Equal(t, existingCommonVariables[1].LibraryVariableSetId, variablePayload[1].LibraryVariableSetId)
 	assert.Equal(t, existingCommonVariables[1].TemplateID, variablePayload[1].TemplateID)
 	assert.Equal(t, existingCommonVariables[1].Scope, variablePayload[1].Scope)
+	assert.False(t, isSensitive)
+
+	assert.Equal(t, existingCommonVariables[2].ID, variablePayload[2].ID)
+	assert.Equal(t, existingCommonVariables[2].Value, variablePayload[2].Value)
+	assert.Equal(t, existingCommonVariables[2].LibraryVariableSetId, variablePayload[2].LibraryVariableSetId)
+	assert.Equal(t, existingCommonVariables[2].TemplateID, variablePayload[2].TemplateID)
+	assert.Equal(t, existingCommonVariables[2].Scope, variablePayload[2].Scope)
 	assert.False(t, isSensitive)
 }
 
@@ -217,6 +225,7 @@ func TestUpdate_CommonVariable_WhenExistingValueIsMissingForScope(t *testing.T) 
 
 	var existingCommonVariables = []variables.TenantCommonVariable{
 		createCommonVariable("TenantVariables-2", "LibraryVariableSets-1", "Set 1", "Templates-1", "Template 1", "existing value 2", []string{"Environments-3"}, false),
+		createCommonVariable("TenantVariables-3", "LibraryVariableSets-2", "Set 2", "Templates-2", "Template 2", "existing value 3", []string{"Environments-3"}, false),
 	}
 
 	var missingCommonVariables = []variables.TenantCommonVariable{
@@ -232,7 +241,7 @@ func TestUpdate_CommonVariable_WhenExistingValueIsMissingForScope(t *testing.T) 
 	isSensitive, variablePayload, err := update.UpdateCommonVariableValue(opts, existingCommonVariables, missingCommonVariables, environmentMap)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(variablePayload))
+	assert.Equal(t, 3, len(variablePayload))
 
 	assert.Empty(t, variablePayload[0].ID)
 	assert.Equal(t, core.PropertyValue{Value: "new value"}, variablePayload[0].Value)
@@ -245,6 +254,12 @@ func TestUpdate_CommonVariable_WhenExistingValueIsMissingForScope(t *testing.T) 
 	assert.Equal(t, existingCommonVariables[0].LibraryVariableSetId, variablePayload[1].LibraryVariableSetId)
 	assert.Equal(t, existingCommonVariables[0].TemplateID, variablePayload[1].TemplateID)
 	assert.Equal(t, existingCommonVariables[0].Scope, variablePayload[1].Scope)
+
+	assert.Equal(t, existingCommonVariables[1].ID, variablePayload[2].ID)
+	assert.Equal(t, existingCommonVariables[1].Value, variablePayload[2].Value)
+	assert.Equal(t, existingCommonVariables[1].LibraryVariableSetId, variablePayload[2].LibraryVariableSetId)
+	assert.Equal(t, existingCommonVariables[1].TemplateID, variablePayload[2].TemplateID)
+	assert.Equal(t, existingCommonVariables[1].Scope, variablePayload[2].Scope)
 	assert.False(t, isSensitive)
 }
 
@@ -346,6 +361,7 @@ func TestUpdate_ProjectVariable_ScopeExactMatch(t *testing.T) {
 	var existingProjectVariables = []variables.TenantProjectVariable{
 		createProjectVariable("TenantVariables-1", "Projects-1", "Project 1", "Templates-1", "Template 1", "existing value 1", []string{"Environments-1", "Environments-2"}, false),
 		createProjectVariable("TenantVariables-2", "Projects-1", "Project 1", "Templates-1", "Template 1", "existing value 2", []string{"Environments-3"}, false),
+		createProjectVariable("TenantVariables-3", "Projects-2", "Project 2", "Templates-2", "Template 2", "existing value 3", []string{}, false),
 	}
 
 	var environmentMap = map[string]string{
@@ -357,7 +373,7 @@ func TestUpdate_ProjectVariable_ScopeExactMatch(t *testing.T) {
 	isSensitive, variablePayload, err := update.UpdateProjectVariableValue(opts, existingProjectVariables, nil, environmentMap)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(variablePayload))
+	assert.Equal(t, 3, len(variablePayload))
 
 	assert.Equal(t, existingProjectVariables[0].ID, variablePayload[0].ID)
 	assert.Equal(t, core.PropertyValue{Value: "new value"}, variablePayload[0].Value)
@@ -370,6 +386,12 @@ func TestUpdate_ProjectVariable_ScopeExactMatch(t *testing.T) {
 	assert.Equal(t, existingProjectVariables[1].ProjectID, variablePayload[1].ProjectID)
 	assert.Equal(t, existingProjectVariables[1].TemplateID, variablePayload[1].TemplateID)
 	assert.Equal(t, existingProjectVariables[1].Scope, variablePayload[1].Scope)
+
+	assert.Equal(t, existingProjectVariables[2].ID, variablePayload[2].ID)
+	assert.Equal(t, existingProjectVariables[2].Value, variablePayload[2].Value)
+	assert.Equal(t, existingProjectVariables[2].ProjectID, variablePayload[2].ProjectID)
+	assert.Equal(t, existingProjectVariables[2].TemplateID, variablePayload[2].TemplateID)
+	assert.Equal(t, existingProjectVariables[2].Scope, variablePayload[2].Scope)
 	assert.False(t, isSensitive)
 }
 
@@ -491,6 +513,7 @@ func TestUpdate_ProjectVariable_WhenExistingValueIsMissingForScope(t *testing.T)
 
 	var existingProjectVariables = []variables.TenantProjectVariable{
 		createProjectVariable("TenantVariables-2", "Projects-1", "Project 1", "Templates-1", "Template 1", "existing value 2", []string{"Environments-3"}, false),
+		createProjectVariable("TenantVariables-3", "Projects-2", "Project 2", "Templates-2", "Template 2", "existing value 3", []string{"Environments-3"}, false),
 	}
 
 	var missingProjectVariables = []variables.TenantProjectVariable{
@@ -506,7 +529,7 @@ func TestUpdate_ProjectVariable_WhenExistingValueIsMissingForScope(t *testing.T)
 	isSensitive, variablePayload, err := update.UpdateProjectVariableValue(opts, existingProjectVariables, missingProjectVariables, environmentMap)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(variablePayload))
+	assert.Equal(t, 3, len(variablePayload))
 
 	assert.Empty(t, variablePayload[0].ID)
 	assert.Equal(t, core.PropertyValue{Value: "new value"}, variablePayload[0].Value)
@@ -519,6 +542,12 @@ func TestUpdate_ProjectVariable_WhenExistingValueIsMissingForScope(t *testing.T)
 	assert.Equal(t, existingProjectVariables[0].ProjectID, variablePayload[1].ProjectID)
 	assert.Equal(t, existingProjectVariables[0].TemplateID, variablePayload[1].TemplateID)
 	assert.Equal(t, existingProjectVariables[0].Scope, variablePayload[1].Scope)
+
+	assert.Equal(t, existingProjectVariables[1].ID, variablePayload[2].ID)
+	assert.Equal(t, existingProjectVariables[1].Value, variablePayload[2].Value)
+	assert.Equal(t, existingProjectVariables[1].ProjectID, variablePayload[2].ProjectID)
+	assert.Equal(t, existingProjectVariables[1].TemplateID, variablePayload[2].TemplateID)
+	assert.Equal(t, existingProjectVariables[1].Scope, variablePayload[2].Scope)
 	assert.False(t, isSensitive)
 }
 


### PR DESCRIPTION
[SC-104889]

## Before

### Project variables

When updating `project template 1` for project `p2`, values for `p1` `project template 1` and `project template 2` were deleted because they were missing from the POST.
![image](https://github.com/user-attachments/assets/1025cfb1-7ff8-4b47-a5ac-7f83c4a9cf98)

### Common variables

When updating template `common template 2` for variable set `common set 2`, values for `common template 1`, `common set 1` were deleted because they were missing from the POST.
![image](https://github.com/user-attachments/assets/3164f34f-9f61-4582-bc75-90211c852a8b)

## After

No variables are deleted by the CLI.

### Project variables

![image](https://github.com/user-attachments/assets/f6ad77d3-3a9a-49f0-9768-cd9d6f20df63)

### Common variables

![image](https://github.com/user-attachments/assets/79ec3b0a-75c2-4ffb-b6db-3cdc9d0476c8)
