### PR TITLE
Add missing title property to nuspec

### DIFF
--- a/pkg/cmd/package/nuget/create/create.go
+++ b/pkg/cmd/package/nuget/create/create.go
@@ -305,6 +305,9 @@ func GenerateNuSpec(opts *NuPkgCreateOptions) (string, error) {
 	sb.WriteString("  <metadata>\n")
 	sb.WriteString("    <id>" + opts.Id.Value + "</id>\n")
 	sb.WriteString("    <version>" + opts.Version.Value + "</version>\n")
+	if opts.Title.Value != "" {
+		sb.WriteString("    <title>" + opts.Title.Value + "</title>\n")
+	}
 	sb.WriteString("    <description>" + opts.Description.Value + "</description>\n")
 	sb.WriteString("    <authors>" + strings.Join(opts.Author.Value, ",") + "</authors>\n")
 	if releaseNotes != "" {


### PR DESCRIPTION
Fixes #510 

Tested that nuspec outputs the expected title property

```
# MyPackage.nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
  <metadata>
    <id>MyPackage</id>
    <version>1.2.34</version>
    <title>My title</title>
    <description>A deployment package created from files on disk.</description>
    <authors>Me</authors>
  </metadata>
</package>
```