### PR TITLE
feat: runbook snapshot create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.4
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.70.1
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -46,10 +46,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.3 h1:qZfyylXCIXPKRwUwG3fsyhubQblKZBfxphQDJg5Uf/k=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.3/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.4 h1:2y0wbmPT5D1MD2Xvyme0GZXkGF41Y9J84HP5PKkUEQI=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.4/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.70.1 h1:aW1K0utvdDPSRElTnvp40Xs9oPmJR6IyPAT6PBvPSJs=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.70.1/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/runbook/delete/delete.go
+++ b/pkg/cmd/runbook/delete/delete.go
@@ -95,13 +95,7 @@ func DeleteRun(opts *DeleteOptions) error {
 		return err
 	}
 
-	runbooksAreInGit := false
-
-	if project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
-		runbooksAreInGit = project.PersistenceSettings.(projects.GitPersistenceSettings).RunbooksAreInGit()
-	}
-
-	if runbooksAreInGit {
+	if shared.AreRunbooksInGit(project) {
 		gitReference, err := getGitReference(opts, project)
 		if err != nil {
 			return err

--- a/pkg/cmd/runbook/list/list.go
+++ b/pkg/cmd/runbook/list/list.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"errors"
+	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/shared"
 	"math"
 
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
@@ -120,17 +121,11 @@ func listRun(cmd *cobra.Command, f factory.Factory, flags *ListFlags) error {
 	}
 
 	var foundRunbooks *resources.Resources[*runbooks.Runbook]
-	runbooksAreInGit := false
-
-	if selectedProject.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
-		runbooksAreInGit = selectedProject.PersistenceSettings.(projects.GitPersistenceSettings).RunbooksAreInGit()
-	}
-
 	if limit <= 0 {
 		limit = math.MaxInt32
 	}
 
-	if runbooksAreInGit {
+	if shared.AreRunbooksInGit(selectedProject) {
 		if f.IsPromptEnabled() {
 			if gitReference == "" { // we need a git ref; ask for one
 				gitRef, err := selectors.GitReference("Select the Git reference to list runbooks for", octopus, f.Ask, selectedProject)

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/shared"
 	"github.com/OctopusDeploy/cli/pkg/packages"
 	"golang.org/x/exp/maps"
 	"io"
@@ -216,13 +217,7 @@ func runbookRun(cmd *cobra.Command, f factory.Factory, flags *RunFlags) error {
 	}
 
 	flags.Project.Value = project.Name
-	runbooksAreInGit := false
-
-	if project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
-		runbooksAreInGit = project.PersistenceSettings.(projects.GitPersistenceSettings).RunbooksAreInGit()
-	}
-
-	if runbooksAreInGit {
+	if shared.AreRunbooksInGit(project) {
 		return runGitRunbook(cmd, f, flags, octopus, project, parsedVariables, outputFormat)
 	} else {
 		return runDbRunbook(cmd, f, flags, octopus, project, parsedVariables, outputFormat)

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -141,7 +141,7 @@ func NewCmdRun(f factory.Factory) *cobra.Command {
 		Long:  "Run runbooks in Octopus Deploy",
 		Example: heredoc.Docf(`
 			$ %[1]s runbook run  # fully interactive
-			$ %[1]s runbook run --project MyProject ... TODO
+			$ %[1]s runbook run --project MyProject --runbook "Rebuild DB indexes"
 		`, constants.ExecutableName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && runFlags.Project.Value == "" {

--- a/pkg/cmd/runbook/shared/shared.go
+++ b/pkg/cmd/runbook/shared/shared.go
@@ -164,3 +164,13 @@ func GetProject(octopus *client.Client, projectIdentifier string) (*projects.Pro
 
 	return project, nil
 }
+
+func AreRunbooksInGit(project *projects.Project) bool {
+	inGit := false
+
+	if project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
+		inGit = project.PersistenceSettings.(projects.GitPersistenceSettings).RunbooksAreInGit()
+	}
+
+	return inGit
+}

--- a/pkg/cmd/runbook/snapshot/create/create.go
+++ b/pkg/cmd/runbook/snapshot/create/create.go
@@ -141,7 +141,7 @@ func createRun(opts *CreateOptions) error {
 		return errors.New("unable to find project")
 	}
 
-	runbooksInGit := areRunbooksInGit(project)
+	runbooksInGit := shared.AreRunbooksInGit(project)
 	if runbooksInGit {
 		return errors.New("creating independent Runbook snapshots is not supported for Runbooks stored in Git")
 	}
@@ -286,7 +286,7 @@ func PromptMissing(opts *CreateOptions) error {
 	}
 	opts.Project.Value = project.GetName()
 
-	runbooksInGit := areRunbooksInGit(project)
+	runbooksInGit := shared.AreRunbooksInGit(project)
 	if runbooksInGit {
 		return errors.New("creating independent Runbook snapshots is not supported for Runbooks stored in Git")
 	}
@@ -400,14 +400,4 @@ func getRunbook(opts *CreateOptions, project *projects.Project) (*runbooks.Runbo
 	}
 
 	return runbook, err
-}
-
-func areRunbooksInGit(project *projects.Project) bool {
-	inGit := false
-
-	if project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
-		inGit = project.PersistenceSettings.(projects.GitPersistenceSettings).RunbooksAreInGit()
-	}
-
-	return inGit
 }

--- a/pkg/cmd/runbook/snapshot/create/create.go
+++ b/pkg/cmd/runbook/snapshot/create/create.go
@@ -1,0 +1,413 @@
+package create
+
+import (
+	"errors"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/gitresources"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/packages"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	clientGit "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
+	clientPackages "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+const (
+	FlagProject            = "project"
+	FlagRunbook            = "runbook"
+	FlagName               = "name"
+	FlagPublish            = "publish"
+	FlagSnapshotNotes      = "snapshot-notes"
+	FlagSnapshotNotesFile  = "snapshot-notes-file"
+	FlagPackageVersionSpec = "package"
+	FlagPackageVersion     = "package-version"
+	FlagGitResourceRefSpec = "git-resource"
+)
+
+type CreateFlags struct {
+	Runbook             *flag.Flag[string]
+	Project             *flag.Flag[string]
+	Name                *flag.Flag[string]
+	Publish             *flag.Flag[bool]
+	SnapshotNotes       *flag.Flag[string]
+	SnapshotNotesFile   *flag.Flag[string]
+	PackageVersion      *flag.Flag[string]
+	PackageVersionSpec  *flag.Flag[[]string]
+	GitResourceRefsSpec *flag.Flag[[]string]
+}
+
+func NewCreateFlags() *CreateFlags {
+	return &CreateFlags{
+		Project:             flag.New[string](FlagProject, false),
+		Runbook:             flag.New[string](FlagRunbook, false),
+		Name:                flag.New[string](FlagName, false),
+		Publish:             flag.New[bool](FlagPublish, false),
+		SnapshotNotes:       flag.New[string](FlagSnapshotNotes, false),
+		SnapshotNotesFile:   flag.New[string](FlagSnapshotNotesFile, false),
+		PackageVersion:      flag.New[string](FlagPackageVersion, false),
+		PackageVersionSpec:  flag.New[[]string](FlagPackageVersionSpec, false),
+		GitResourceRefsSpec: flag.New[[]string](FlagGitResourceRefSpec, false),
+	}
+}
+
+type CreateOptions struct {
+	*CreateFlags
+	PackageVersionOverrides []string
+	*shared.RunbooksOptions
+	GetAllProjectsCallback shared.GetAllProjectsCallback
+	*cmd.Dependencies
+}
+
+func NewCreateOptions(createFlags *CreateFlags, dependencies *cmd.Dependencies) *CreateOptions {
+	return &CreateOptions{
+		CreateFlags:            createFlags,
+		RunbooksOptions:        shared.NewGetRunbooksOptions(dependencies),
+		GetAllProjectsCallback: func() ([]*projects.Project, error) { return shared.GetAllProjects(dependencies.Client) },
+		Dependencies:           dependencies,
+	}
+}
+
+func NewCmdCreate(f factory.Factory) *cobra.Command {
+	createFlags := NewCreateFlags()
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a runbook snapshot",
+		Long:    "Create a runbook snapshot in Octopus Deploy",
+		Aliases: []string{"new"},
+		Example: heredoc.Docf(`
+			$ %[1]s runbook snapshot create --project MyProject --runbook "Rebuild DB Indexes"
+			$ %[1]s runbook snapshot create --project MyProject --runbook "Rebuild DB Indexes" --name "My cool snapshot"
+			$ %[1]s runbook snapshot create -p MyProject -r "Restart App" --package "azure-cli:1.2.3" --no-prompt
+			$ %[1]s runbook snapshot create -p MyProject -r "Restart App" --git-resource "Script step from Git:refs/heads/dev-branch" --publish --no-prompt
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := NewCreateOptions(createFlags, cmd.NewDependencies(f, c))
+			return createRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&createFlags.Project.Value, createFlags.Project.Name, "p", "", "Name or ID of the project where the runbook is")
+	flags.StringVarP(&createFlags.Runbook.Value, createFlags.Runbook.Name, "r", "", "Name or ID of the runbook to create the snapshot for")
+	flags.StringVarP(&createFlags.Name.Value, createFlags.Name.Name, "n", "", "Override the snapshot name")
+	flags.StringVarP(&createFlags.PackageVersion.Value, createFlags.PackageVersion.Name, "", "", "Default version to use for all packages. Only relevant for config-as-code projects where runbooks are stored in Git.")
+	flags.StringArrayVarP(&createFlags.PackageVersionSpec.Value, createFlags.PackageVersionSpec.Name, "", []string{}, "Version specification a specific packages.\nFormat as {package}:{version}, {step}:{version} or {package-ref-name}:{packageOrStep}:{version}\nYou may specify this multiple times")
+	flags.StringVar(&createFlags.SnapshotNotes.Value, createFlags.SnapshotNotes.Name, "", "Release notes to attach")
+	flags.StringVar(&createFlags.SnapshotNotesFile.Value, createFlags.SnapshotNotesFile.Name, "", "Release notes to attach (from file)")
+	flags.BoolVar(&createFlags.Publish.Value, createFlags.Publish.Name, false, "Publish the snapshot immediately")
+	flags.StringArrayVarP(&createFlags.GitResourceRefsSpec.Value, createFlags.GitResourceRefsSpec.Name, "", nil, "Git reference for a specific Git resource.\nFormat as {step}:{git-ref}, {step}:{git-resource-name}:{git-ref}\nYou may specify this multiple times.\nOnly relevant for config-as-code projects where runbooks are stored in Git.")
+
+	return cmd
+}
+
+func createRun(opts *CreateOptions) error {
+	if opts.SnapshotNotes.Value != "" && opts.SnapshotNotesFile.Value != "" {
+		return errors.New("cannot specify both --snapshot-notes and --snapshot-notes-file at the same time")
+	}
+
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	if opts.SnapshotNotesFile.Value != "" {
+		fileContents, err := os.ReadFile(opts.SnapshotNotesFile.Value)
+		if err != nil {
+			return err
+		}
+		opts.SnapshotNotes.Value = string(fileContents)
+	}
+
+	project, err := selectors.FindProject(opts.Client, opts.Project.Value)
+	if err != nil {
+		return err
+	}
+	if project == nil {
+		return errors.New("unable to find project")
+	}
+
+	runbooksInGit := areRunbooksInGit(project)
+	if runbooksInGit {
+		return errors.New("Creating independent Runbook snapshots is not supported for Runbooks stored in Git.")
+	}
+
+	runbook, err := selectors.FindRunbook(opts.Client, project, opts.Runbook.Value)
+
+	if err != nil {
+		return err
+	}
+	if runbook == nil {
+		return errors.New("unable to find runbook")
+	}
+
+	runbookTemplate, err := opts.Client.Runbooks.GetRunbookSnapshotTemplate(runbook)
+	if err != nil {
+		return err
+	}
+
+	snapshotName := getSnapshotName(opts, runbookTemplate)
+	if err != nil {
+		return err
+	}
+
+	packageVersionOverrides := make([]*packages.PackageVersionOverride, 0)
+	packageVersionBaseline := buildPackageVersionBaseline(opts, runbookTemplate)
+	for _, s := range opts.PackageVersionSpec.Value {
+		ambOverride, err := packages.ParsePackageOverrideString(s)
+		if err != nil {
+			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
+		}
+		resolvedOverride, err := packages.ResolvePackageOverride(ambOverride, packageVersionBaseline)
+		if err != nil {
+			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
+		}
+		packageVersionOverrides = append(packageVersionOverrides, resolvedOverride)
+	}
+
+	selectedPackages := packages.ApplyPackageOverrides(packageVersionBaseline, packageVersionOverrides)
+
+	snapshot := runbooks.NewRunbookSnapshot(snapshotName, project.GetID(), runbook.ID)
+	if opts.SnapshotNotes.Value != "" {
+		snapshot.Notes = opts.SnapshotNotes.Value
+	}
+	snapshot.SelectedPackages = util.SliceTransform(selectedPackages, func(p *packages.StepPackageVersion) *clientPackages.SelectedPackage {
+		return &clientPackages.SelectedPackage{
+			ActionName:           p.ActionName,
+			StepName:             p.ActionName,
+			PackageReferenceName: p.PackageReferenceName,
+			Version:              p.Version,
+		}
+	})
+
+	gitRefOverrides := make([]*gitresources.GitResourceGitRef, 0)
+	gitResourceBaseline := gitresources.BuildGitResourcesBaseline(runbookTemplate.GitResources)
+	for _, s := range opts.GitResourceRefsSpec.Value {
+		ambOverride, err := gitresources.ParseGitResourceGitRefString(s)
+		if err != nil {
+			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
+		}
+		resolvedOverride, err := gitresources.ResolveGitResourceOverride(ambOverride, gitResourceBaseline)
+		if err != nil {
+			continue // silently ignore anything that wasn't parseable (should we emit a warning?)
+		}
+		gitRefOverrides = append(gitRefOverrides, resolvedOverride)
+	}
+
+	selectedGitRefs := gitresources.ApplyGitResourceOverrides(gitResourceBaseline, gitRefOverrides)
+	snapshot.SelectedGitResources = util.SliceTransform(selectedGitRefs, func(g *gitresources.GitResourceGitRef) *clientGit.SelectedGitResources {
+		return &clientGit.SelectedGitResources{
+			ActionName: g.ActionName,
+			GitReference: &clientGit.GitReference{
+				GitRef: g.GitRef,
+			},
+			GitResourceReferenceName: g.GitResourceName,
+		}
+	})
+
+	if opts.Publish.Value {
+		snapshot, err = opts.Client.RunbookSnapshots.Publish(snapshot)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(opts.Out, "\nSuccessfully created and published runbook snapshot '%s' (%s) for runbook '%s'\n", snapshot.Name, snapshot.GetID(), runbook.Name)
+	} else {
+		snapshot, err = opts.Client.RunbookSnapshots.Add(snapshot)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(opts.Out, "\nSuccessfully created runbook snapshot '%s' (%s) for runbook '%s'\n", snapshot.Name, snapshot.GetID(), runbook.Name)
+	}
+
+	link := output.Bluef("%s/app#/%s/projects/%s/operations/runbooks/%s/snapshots/%s", opts.Host, opts.Space.GetID(), project.GetID(), runbook.GetID(), snapshot.GetID())
+	fmt.Fprintf(opts.Out, "View this snapshot on Octopus Deploy: %s\n", link)
+
+	return nil
+}
+
+func buildPackageVersionBaseline(opts *CreateOptions, runbookTemplate *runbooks.RunbookSnapshotTemplate) []*packages.StepPackageVersion {
+	feedPackageVersions := make(map[string]string)
+	pkgs := make([]*packages.StepPackageVersion, 0, len(runbookTemplate.Packages))
+	for _, p := range runbookTemplate.Packages {
+		{
+			key := fmt.Sprintf("%s/%s", p.FeedID, p.PackageID)
+			if _, ok := feedPackageVersions[key]; !ok {
+				packageVersion, err := feeds.SearchPackageVersions(opts.Client, opts.Client.GetSpaceID(), p.FeedID, p.PackageID, "", 1)
+				if err == nil && packageVersion != nil && !util.Empty(packageVersion.Items) {
+					feedPackageVersions[key] = packageVersion.Items[0].Version
+				}
+			}
+		}
+	}
+
+	for _, p := range runbookTemplate.Packages {
+		pkg := &packages.StepPackageVersion{
+			PackageID:            p.PackageID,
+			ActionName:           p.ActionName,
+			PackageReferenceName: p.PackageReferenceName}
+		if !p.IsResolvable {
+			pkg.Version = ""
+		} else {
+			key := fmt.Sprintf("%s/%s", p.FeedID, p.PackageID)
+			pkg.Version = feedPackageVersions[key]
+		}
+		pkgs = append(pkgs, pkg)
+	}
+
+	return pkgs
+}
+
+func getSnapshotName(opts *CreateOptions, template *runbooks.RunbookSnapshotTemplate) string {
+	if opts.Name.Value != "" {
+		return opts.Name.Value
+	}
+
+	return template.NextNameIncrement
+}
+
+func PromptMissing(opts *CreateOptions) error {
+	project, err := getProject(opts)
+	if err != nil {
+		return err
+	}
+	opts.Project.Value = project.GetName()
+
+	runbooksInGit := areRunbooksInGit(project)
+	if runbooksInGit {
+		return errors.New("Creating independent Runbook snapshots is not supported for Runbooks stored in Git.")
+	}
+
+	selectedRunbook, err := getRunbook(opts, project)
+	if err != nil {
+		return err
+	}
+	opts.Runbook.Value = selectedRunbook.Name
+
+	template, err := opts.Client.Runbooks.GetRunbookSnapshotTemplate(selectedRunbook)
+
+	if err != nil {
+		return err
+	}
+
+	if opts.Name.Value == "" {
+		if err := opts.Ask(&survey.Input{
+			Message: "Snapshot name",
+			Help:    "A short, memorable, name for this snapshot.",
+			Default: template.NextNameIncrement,
+		}, &opts.Name.Value); err != nil {
+			return err
+		}
+	}
+
+	packageVersionBaseline, err := packages.BuildPackageVersionBaseline(opts.Client, util.SliceTransform(template.Packages, func(pkg *releases.ReleaseTemplatePackage) releases.ReleaseTemplatePackage { return *pkg }), nil)
+	if err != nil {
+		return err
+	}
+
+	if len(packageVersionBaseline) > 0 { // if we have packages, run the package flow
+		_, packageVersionOverrides, err := packages.AskPackageOverrideLoop(
+			packageVersionBaseline,
+			opts.PackageVersion.Value,
+			opts.PackageVersionOverrides,
+			opts.Ask,
+			opts.Out)
+
+		if err != nil {
+			return err
+		}
+
+		if len(packageVersionOverrides) > 0 {
+			opts.PackageVersionOverrides = make([]string, 0, len(packageVersionOverrides))
+			for _, ov := range packageVersionOverrides {
+				opts.PackageVersionOverrides = append(opts.PackageVersionOverrides, ov.ToPackageOverrideString())
+			}
+		}
+	}
+
+	gitResourcesBaseline := gitresources.BuildGitResourcesBaseline(template.GitResources)
+	if len(gitResourcesBaseline) > 0 {
+		overriddenGitResources, err := gitresources.AskGitResourceOverrideLoop(
+			gitResourcesBaseline,
+			opts.GitResourceRefsSpec.Value,
+			opts.Ask,
+			opts.Out)
+
+		if err != nil {
+			return err
+		}
+
+		if len(overriddenGitResources) > 0 {
+			opts.GitResourceRefsSpec.Value = make([]string, 0, len(overriddenGitResources))
+			for _, ov := range overriddenGitResources {
+				opts.GitResourceRefsSpec.Value = append(opts.GitResourceRefsSpec.Value, ov.ToGitResourceGitRefString())
+			}
+		}
+	}
+
+	if !opts.Publish.Value {
+		if err = opts.Ask(&survey.Confirm{
+			Message: "Would you like to publish this snapshot immediately?",
+			Default: false,
+		}, &opts.Publish.Value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getProject(opts *CreateOptions) (*projects.Project, error) {
+	var project *projects.Project
+	var err error
+	if opts.Project.Value == "" {
+		project, err = selectors.Select(opts.Ask, "Select the project containing the runbook you wish to snapshot:", opts.GetAllProjectsCallback, func(project *projects.Project) string { return project.GetName() })
+	} else {
+		project, err = opts.GetProjectCallback(opts.Project.Value)
+	}
+
+	if project == nil {
+		return nil, errors.New("unable to find project")
+	}
+
+	return project, err
+}
+
+func getRunbook(opts *CreateOptions, project *projects.Project) (*runbooks.Runbook, error) {
+	var runbook *runbooks.Runbook
+	var err error
+	if opts.Runbook.Value == "" {
+		runbook, err = selectors.Select(opts.Ask, "Select the runbook you wish to delete:", func() ([]*runbooks.Runbook, error) { return opts.GetDbRunbooksCallback(project.GetID()) }, func(runbook *runbooks.Runbook) string { return runbook.Name })
+	} else {
+		runbook, err = opts.GetDbRunbookCallback(project.GetID(), opts.Runbook.Value)
+	}
+
+	if runbook == nil {
+		return nil, errors.New("unable to find runbook")
+	}
+
+	return runbook, err
+}
+
+func areRunbooksInGit(project *projects.Project) bool {
+	inGit := false
+
+	if project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
+		inGit = project.PersistenceSettings.(projects.GitPersistenceSettings).RunbooksAreInGit()
+	}
+
+	return inGit
+}

--- a/pkg/cmd/runbook/snapshot/create/create.go
+++ b/pkg/cmd/runbook/snapshot/create/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/shared"
+	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/list"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/gitresources"
@@ -242,7 +243,13 @@ func createRun(opts *CreateOptions, outputFormat string) error {
 	case constants.OutputFormatBasic:
 		fmt.Fprintf(opts.Out, "%s\n", snapshot.GetID())
 	case constants.OutputFormatJson:
-		data, err := json.MarshalIndent(snapshot, "", "\t")
+		outputJson := list.SnapshotsAsJson{
+			Id:        snapshot.GetID(),
+			Name:      snapshotName,
+			Assembled: snapshot.Assembled,
+			Published: opts.Publish.Value,
+		}
+		data, _ := json.MarshalIndent(outputJson, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/runbook/snapshot/create/create.go
+++ b/pkg/cmd/runbook/snapshot/create/create.go
@@ -143,7 +143,7 @@ func createRun(opts *CreateOptions) error {
 
 	runbooksInGit := areRunbooksInGit(project)
 	if runbooksInGit {
-		return errors.New("Creating independent Runbook snapshots is not supported for Runbooks stored in Git.")
+		return errors.New("creating independent Runbook snapshots is not supported for Runbooks stored in Git")
 	}
 
 	runbook, err := selectors.FindRunbook(opts.Client, project, opts.Runbook.Value)
@@ -288,7 +288,7 @@ func PromptMissing(opts *CreateOptions) error {
 
 	runbooksInGit := areRunbooksInGit(project)
 	if runbooksInGit {
-		return errors.New("Creating independent Runbook snapshots is not supported for Runbooks stored in Git.")
+		return errors.New("creating independent Runbook snapshots is not supported for Runbooks stored in Git")
 	}
 
 	selectedRunbook, err := getRunbook(opts, project)
@@ -390,7 +390,7 @@ func getRunbook(opts *CreateOptions, project *projects.Project) (*runbooks.Runbo
 	var runbook *runbooks.Runbook
 	var err error
 	if opts.Runbook.Value == "" {
-		runbook, err = selectors.Select(opts.Ask, "Select the runbook you wish to delete:", func() ([]*runbooks.Runbook, error) { return opts.GetDbRunbooksCallback(project.GetID()) }, func(runbook *runbooks.Runbook) string { return runbook.Name })
+		runbook, err = selectors.Select(opts.Ask, "Select the runbook you wish to to snapshot:", func() ([]*runbooks.Runbook, error) { return opts.GetDbRunbooksCallback(project.GetID()) }, func(runbook *runbooks.Runbook) string { return runbook.Name })
 	} else {
 		runbook, err = opts.GetDbRunbookCallback(project.GetID(), opts.Runbook.Value)
 	}

--- a/pkg/cmd/runbook/snapshot/list/list.go
+++ b/pkg/cmd/runbook/snapshot/list/list.go
@@ -40,6 +40,7 @@ type SnapshotsAsJson struct {
 	Id        string     `json:"Id"`
 	Name      string     `json:"Name"`
 	Assembled *time.Time `json:"Assembled"`
+	Published bool       `json:"Published"`
 }
 
 func NewCmdList(f factory.Factory) *cobra.Command {
@@ -141,12 +142,17 @@ func listRun(cmd *cobra.Command, f factory.Factory, flags *ListFlags) error {
 				Id:        s.GetID(),
 				Name:      s.Name,
 				Assembled: s.Assembled,
+				Published: s.GetID() == selectedRunbook.PublishedRunbookSnapshotID,
 			}
 		},
 		Table: output.TableDefinition[*runbooks.RunbookSnapshot]{
-			Header: []string{"ID", "NAME", "ASSEMBLED"},
+			Header: []string{"ID", "NAME", "PUBLISHED", "ASSEMBLED"},
 			Row: func(s *runbooks.RunbookSnapshot) []string {
-				return []string{s.GetID(), output.Bold(s.Name), s.Assembled.Format(time.RFC1123Z)}
+				published := ""
+				if selectedRunbook.PublishedRunbookSnapshotID == s.GetID() {
+					published = "Yes"
+				}
+				return []string{s.GetID(), output.Bold(s.Name), output.Green(published), s.Assembled.Format(time.RFC1123Z)}
 			},
 		},
 		Basic: func(s *runbooks.RunbookSnapshot) string {

--- a/pkg/cmd/runbook/snapshot/publish/publish.go
+++ b/pkg/cmd/runbook/snapshot/publish/publish.go
@@ -57,10 +57,9 @@ func NewPublishOptions(publishFlags *PublishFlags, dependencies *cmd.Dependencie
 func NewCmdPublish(f factory.Factory) *cobra.Command {
 	publishFlags := NewPublishFlags()
 	cmd := &cobra.Command{
-		Use:     "publish",
-		Short:   "Publish a runbook snapshot",
-		Long:    "Publish a runbook snapshot in Octopus Deploy",
-		Aliases: []string{"new", "publish"},
+		Use:   "publish",
+		Short: "Publish a runbook snapshot",
+		Long:  "Publish a runbook snapshot in Octopus Deploy",
 		Example: heredoc.Docf(`
 			$ %[1]s runbook snapshot publish --project MyProject --runbook "Rebuild DB Indexes" --snapshot "Snapshot 40C9ENM"
 		`, constants.ExecutableName),

--- a/pkg/cmd/runbook/snapshot/publish/publish.go
+++ b/pkg/cmd/runbook/snapshot/publish/publish.go
@@ -165,6 +165,8 @@ func getSnapshot(opts *PublishOptions, runbook *runbooks.Runbook) (*runbooks.Run
 		if snapshot == nil {
 			return nil, errors.New("unable to find snapshot")
 		}
+
+		return snapshot, nil
 	}
 
 	snapshot, err := selectors.Select(opts.Ask, "Select the snapshot to publish:", func() ([]*runbooks.RunbookSnapshot, error) {

--- a/pkg/cmd/runbook/snapshot/publish/publish.go
+++ b/pkg/cmd/runbook/snapshot/publish/publish.go
@@ -1,0 +1,236 @@
+package publish
+
+import (
+	"errors"
+	"fmt"
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
+	"github.com/OctopusDeploy/cli/pkg/cmd/runbook/shared"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/pkg/factory"
+	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
+	"github.com/OctopusDeploy/cli/pkg/util/flag"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/spf13/cobra"
+	"math"
+	"time"
+)
+
+const (
+	FlagProject  = "project"
+	FlagRunbook  = "runbook"
+	FlagSnapshot = "snapshot"
+)
+
+type PublishFlags struct {
+	Runbook  *flag.Flag[string]
+	Project  *flag.Flag[string]
+	Snapshot *flag.Flag[string]
+}
+
+func NewPublishFlags() *PublishFlags {
+	return &PublishFlags{
+		Runbook:  flag.New[string](FlagRunbook, false),
+		Project:  flag.New[string](FlagProject, false),
+		Snapshot: flag.New[string](FlagSnapshot, false),
+	}
+}
+
+type PublishOptions struct {
+	*PublishFlags
+	*shared.RunbooksOptions
+	GetAllProjectsCallback shared.GetAllProjectsCallback
+	*cmd.Dependencies
+}
+
+func NewPublishOptions(publishFlags *PublishFlags, dependencies *cmd.Dependencies) *PublishOptions {
+	return &PublishOptions{
+		PublishFlags:           publishFlags,
+		RunbooksOptions:        shared.NewGetRunbooksOptions(dependencies),
+		GetAllProjectsCallback: func() ([]*projects.Project, error) { return shared.GetAllProjects(dependencies.Client) },
+		Dependencies:           dependencies,
+	}
+}
+
+func NewCmdPublish(f factory.Factory) *cobra.Command {
+	publishFlags := NewPublishFlags()
+	cmd := &cobra.Command{
+		Use:     "publish",
+		Short:   "Publish a runbook snapshot",
+		Long:    "Publish a runbook snapshot in Octopus Deploy",
+		Aliases: []string{"new", "publish"},
+		Example: heredoc.Docf(`
+			$ %[1]s runbook snapshot publish --project MyProject --runbook "Rebuild DB Indexes" --snapshot "Snapshot 40C9ENM"
+		`, constants.ExecutableName),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts := NewPublishOptions(publishFlags, cmd.NewDependencies(f, c))
+			return publishRun(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&publishFlags.Project.Value, publishFlags.Project.Name, "p", "", "Name or ID of the project where the runbook is")
+	flags.StringVarP(&publishFlags.Runbook.Value, publishFlags.Runbook.Name, "r", "", "Name or ID of the runbook to publish an existing snapshot")
+	flags.StringVarP(&publishFlags.Snapshot.Value, publishFlags.Snapshot.Name, "", "", "Name or ID of the snapshot to publish")
+
+	return cmd
+}
+
+func publishRun(opts *PublishOptions) error {
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
+	project, err := selectors.FindProject(opts.Client, opts.Project.Value)
+	if err != nil {
+		return err
+	}
+	if project == nil {
+		return errors.New("unable to find project")
+	}
+
+	runbooksInGit := shared.AreRunbooksInGit(project)
+	if runbooksInGit {
+		return errors.New("independent Runbook snapshots is not supported for Runbooks stored in Git")
+	}
+
+	runbook, err := selectors.FindRunbook(opts.Client, project, opts.Runbook.Value)
+
+	if err != nil {
+		return err
+	}
+	if runbook == nil {
+		return errors.New("unable to find runbook")
+	}
+
+	snapshot, err := findSnapshot(opts, runbook)
+	if err != nil {
+		return err
+	}
+
+	runbook.PublishedRunbookSnapshotID = snapshot.ID
+	runbook, err = runbooks.Update(opts.Client, runbook)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(opts.Out, "Runbook snapshot %s has been published\n", output.Greenf("%s", snapshot.Name))
+	link := output.Bluef("%s/app#/%s/projects/%s/operations/runbooks/%s/snapshots/%s", opts.Host, opts.Space.GetID(), project.GetID(), runbook.GetID(), snapshot.GetID())
+	fmt.Fprintf(opts.Out, "View this snapshot on Octopus Deploy: %s\n", link)
+
+	if !opts.NoPrompt {
+		autoCmd := flag.GenerateAutomationCmd(opts.CmdPath, opts.Project, opts.Runbook, opts.Snapshot)
+		fmt.Fprintf(opts.Out, "\nAutomation Command: %s\n", autoCmd)
+	}
+	return nil
+}
+
+func PromptMissing(opts *PublishOptions) error {
+	project, err := getProject(opts)
+	if err != nil {
+		return err
+	}
+	opts.Project.Value = project.GetName()
+
+	runbooksInGit := shared.AreRunbooksInGit(project)
+	if runbooksInGit {
+		return errors.New("independent Runbook snapshots is not supported for Runbooks stored in Git")
+	}
+
+	selectedRunbook, err := getRunbook(opts, project)
+	if err != nil {
+		return err
+	}
+	opts.Runbook.Value = selectedRunbook.Name
+
+	selectedSnapshot, err := getSnapshot(opts, selectedRunbook)
+	if err != nil {
+		return err
+	}
+	opts.Snapshot.Value = selectedSnapshot.Name
+
+	return nil
+}
+
+func getSnapshot(opts *PublishOptions, runbook *runbooks.Runbook) (*runbooks.RunbookSnapshot, error) {
+	if opts.Snapshot.Value != "" {
+		snapshot, err := runbooks.GetSnapshot(opts.Client, opts.Space.GetID(), runbook.ProjectID, opts.Snapshot.Value)
+		if err != nil {
+			return nil, err
+		}
+		if snapshot == nil {
+			return nil, errors.New("unable to find snapshot")
+		}
+	}
+
+	snapshot, err := selectors.Select(opts.Ask, "Select the snapshot to publish:", func() ([]*runbooks.RunbookSnapshot, error) {
+		allSnapshots, err := runbooks.ListSnapshots(opts.Client, opts.Space.GetID(), runbook.ProjectID, runbook.GetID(), math.MaxInt16)
+		if err != nil {
+			return nil, err
+		}
+
+		var availableSnapshots = make([]*runbooks.RunbookSnapshot, 0)
+		for _, s := range allSnapshots.Items {
+			if s.GetID() != runbook.PublishedRunbookSnapshotID {
+				availableSnapshots = append(availableSnapshots, s)
+			}
+		}
+		return availableSnapshots, nil
+	}, func(s *runbooks.RunbookSnapshot) string {
+		return fmt.Sprintf("%s (Assembled: %s)", s.Name, s.Assembled.Format(time.RFC1123Z))
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+func getProject(opts *PublishOptions) (*projects.Project, error) {
+	var project *projects.Project
+	var err error
+	if opts.Project.Value == "" {
+		project, err = selectors.Select(opts.Ask, "Select the project containing the runbook you wish update the snapshot:", opts.GetAllProjectsCallback, func(project *projects.Project) string { return project.GetName() })
+	} else {
+		project, err = opts.GetProjectCallback(opts.Project.Value)
+	}
+
+	if project == nil {
+		return nil, errors.New("unable to find project")
+	}
+
+	return project, err
+}
+
+func getRunbook(opts *PublishOptions, project *projects.Project) (*runbooks.Runbook, error) {
+	var runbook *runbooks.Runbook
+	var err error
+	if opts.Runbook.Value == "" {
+		runbook, err = selectors.Select(opts.Ask, "Select the runbook you wish to you wish to update the snapshot:", func() ([]*runbooks.Runbook, error) { return opts.GetDbRunbooksCallback(project.GetID()) }, func(runbook *runbooks.Runbook) string { return runbook.Name })
+	} else {
+		runbook, err = opts.GetDbRunbookCallback(project.GetID(), opts.Runbook.Value)
+	}
+
+	if runbook == nil {
+		return nil, errors.New("unable to find runbook")
+	}
+
+	return runbook, err
+}
+
+func findSnapshot(opts *PublishOptions, runbook *runbooks.Runbook) (*runbooks.RunbookSnapshot, error) {
+	snapshot, err := runbooks.GetSnapshot(opts.Client, opts.Space.GetID(), runbook.ProjectID, opts.Snapshot.Value)
+
+	if err != nil {
+		return nil, err
+	}
+	if snapshot == nil {
+		return nil, errors.New("unable to find snapshot")
+	}
+
+	return snapshot, nil
+}

--- a/pkg/cmd/runbook/snapshot/snapshot.go
+++ b/pkg/cmd/runbook/snapshot/snapshot.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	cmdCreate "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/create"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/list"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
@@ -20,5 +21,6 @@ func NewCmdSnapshot(f factory.Factory) *cobra.Command {
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f))
 	return cmd
 }

--- a/pkg/cmd/runbook/snapshot/snapshot.go
+++ b/pkg/cmd/runbook/snapshot/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	cmdCreate "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/create"
 	cmdList "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/list"
+	cmdPublish "github.com/OctopusDeploy/cli/pkg/cmd/runbook/snapshot/publish"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/spf13/cobra"
@@ -22,5 +23,6 @@ func NewCmdSnapshot(f factory.Factory) *cobra.Command {
 
 	cmd.AddCommand(cmdList.NewCmdList(f))
 	cmd.AddCommand(cmdCreate.NewCmdCreate(f))
+	cmd.AddCommand(cmdPublish.NewCmdPublish(f))
 	return cmd
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -285,4 +286,10 @@ func SplitString(s string, delimiters []rune) []string {
 		a[i] = s[span.start:span.end]
 	}
 	return a
+}
+
+// helpful for debugging
+func PrintJSON(obj interface{}) {
+	bytes, _ := json.MarshalIndent(obj, "\t", "\t")
+	fmt.Println(string(bytes))
 }


### PR DESCRIPTION
feat: runbook snapshot publish
fix: runbook snapshot list now shows which snapshot is published

replaces #343 

fixes #110 

## runbook snapshot list

Now specifies which snapshot is the current published snapshot
```
ID                    NAME              PUBLISHED  ASSEMBLED
RunbookSnapshots-381  Snapshot 4E6TUYP             Wed, 30 Apr 2025 06:17:16 +0000
RunbookSnapshots-379  Snapshot K8MM6GD             Wed, 30 Apr 2025 01:20:53 +0000
RunbookSnapshots-378  Snapshot 2BRT8ZF             Wed, 30 Apr 2025 01:19:53 +0000
RunbookSnapshots-377  Snapshot 8EKKDY9             Wed, 30 Apr 2025 01:11:29 +0000
RunbookSnapshots-376  Snapshot 3JDLKHP             Wed, 30 Apr 2025 01:11:13 +0000
RunbookSnapshots-375  Snapshot BRYFKMB             Wed, 30 Apr 2025 01:10:10 +0000
RunbookSnapshots-374  Snapshot 40C9ENM             Wed, 30 Apr 2025 01:06:20 +0000
RunbookSnapshots-373  Snapshot XBNF77G             Wed, 30 Apr 2025 01:05:56 +0000
RunbookSnapshots-372  Snapshot SR0YKVH             Wed, 30 Apr 2025 01:00:07 +0000
RunbookSnapshots-371  Snapshot 0UVWXRJ             Wed, 30 Apr 2025 00:53:48 +0000
RunbookSnapshots-370  Snapshot SB5J0SH             Wed, 30 Apr 2025 00:30:10 +0000
RunbookSnapshots-369  Snapshot 6NL4C58             Wed, 30 Apr 2025 00:09:17 +0000
RunbookSnapshots-365  Snapshot 7Z0QBSZ             Tue, 29 Apr 2025 05:56:40 +0000
RunbookSnapshots-364  Snapshot HQBBGBY  Yes        Tue, 29 Apr 2025 05:44:52 +0000
RunbookSnapshots-363  Snapshot NEY7G68             Tue, 29 Apr 2025 05:44:09 +0000
RunbookSnapshots-362  Snapshot 0H8VQRR             Tue, 29 Apr 2025 05:43:06 +0000
```

```json
  {
    "Id": "RunbookSnapshots-365",
    "Name": "Snapshot 7Z0QBSZ",
    "Assembled": "2025-04-29T05:56:40.729Z",
    "Published": false
  },
  {
    "Id": "RunbookSnapshots-364",
    "Name": "Snapshot HQBBGBY",
    "Assembled": "2025-04-29T05:44:52.66Z",
    "Published": true
  },
  {
    "Id": "RunbookSnapshots-363",
    "Name": "Snapshot NEY7G68",
    "Assembled": "2025-04-29T05:44:09.321Z",
    "Published": false
  },
```

## runbook snapshot publish

`octopus runbook snapshot publish -s Default -p runbooks -r "runbook 3" --snapshot "Snapshot 2BRT8ZF"`

```
Runbook snapshot Snapshot 2BRT8ZF has been published
View this snapshot on Octopus Deploy: http://localhost:8066/app#/Spaces-1/projects/Projects-22/operations/runbooks/Runbooks-161/snapshots/RunbookSnapshots-378

Automation Command: octopus runbook snapshot publish --project 'runbooks' --runbook 'runbook 3' --snapshot 'Snapshot 2BRT8ZF' --no-prompt
```

`octopus runbook snapshot publish -s Default -p runbooks -r "runbook 3"`

prompts for snapshot, with assembled date shown
![image](https://github.com/user-attachments/assets/a6679750-4001-4e08-8890-47af58ca4b78)


## runbook snapshot create

`octopus runbook snapshot create`

prompts for space, project and runbook
Default snapshot name comes from the template

```
? You have not specified a Space. Please select one: Default
? Select the project containing the runbook you wish to snapshot: runbooks
? Select the runbook you wish to to snapshot: runbook 3
? Snapshot name [? for help] (Snapshot NF2M098)
```

Git references, and package are prompted in the same manner as releases and runbook run
Supports publishing at creation time too
```
? You have not specified a Space. Please select one: Default
? Select the project containing the runbook you wish to snapshot: runbooks
? Select the runbook you wish to to snapshot: runbook 3
? Snapshot name Snapshot NF2M098
PACKAGE     VERSION  STEP NAME/PACKAGE REFERENCE
TestWebApp  1.0.2    Run a Script with package ref/
? Package override string (y to accept, u to undo, ? for help): y
STEP NAME              GIT RESOURCE  GIT REF
Run a Script from git  <primary>     main
? Git resource git reference override string (y to accept, u to undo, r to reset, ? for help): y
X Sorry, your reply was invalid: "t" is not a valid answer, please try again.
? Would you like to publish this snapshot immediately? Yes

Successfully created and published runbook snapshot 'Snapshot NF2M098' (RunbookSnapshots-382) for runbook 'runbook 3'
View this snapshot on Octopus Deploy: http://localhost:8066/app#/Spaces-1/projects/Projects-22/operations/runbooks/Runbooks-161/snapshots/RunbookSnapshots-382
```

![image](https://github.com/user-attachments/assets/18f8f712-b8de-4d62-af73-1d3108e9406d)


### Create but with no snapshot name

`octopus runbook snapshot create -s Default -p runbooks -r "runbook 3" --no-prompt`

```
Successfully created runbook snapshot 'Snapshot N28WZ7C' (RunbookSnapshots-383) for runbook 'runbook 3'
View this snapshot on Octopus Deploy: http://localhost:8066/app#/Spaces-1/projects/Projects-22/operations/runbooks/Runbooks-161/snapshots/RunbookSnapshots-383
```

support for additional output formats:
```
octopus runbook snapshot create -s Default -p runbooks -r "runbook 3" --no-prompt --output-format json
{
  "Id": "RunbookSnapshots-401",
  "Name": "Snapshot M6CXSCV",
  "Assembled": "2025-05-01T05:56:29.424Z",
  "Published": false
}

octopus runbook snapshot create -s Default -p runbooks -r "runbook 3" --no-prompt --output-format basic
RunbookSnapshots-387
```