### PR TITLE
Add wait, timeout, and cancellation options for the release deploy command

### DIFF
--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -86,10 +86,12 @@ const (
 	FlagDeploymentFreezeName           = "deployment-freeze-name"
 	FlagDeploymentFreezeOverrideReason = "deployment-freeze-override-reason"
 
-	FlagWaitForDeployment = "wait-for-deployment"
-	FlagTimeout           = "timeout"
-	FlagCancelOnTimeout   = "cancel-on-timeout"
-	DefaultTimeout        = 600
+	FlagWaitForDeployment  = "wait-for-deployment"
+	FlagTimeout            = "timeout"
+	FlagPollingInterval    = "polling-interval"
+	FlagCancelOnTimeout    = "cancel-on-timeout"
+	DefaultTimeout         = 600
+	DefaultPollingInterval = 10
 )
 
 // executions API stops here.
@@ -116,6 +118,7 @@ type DeployFlags struct {
 	DeploymentFreezeOverrideReason *flag.Flag[string]
 	WaitForDeployment              *flag.Flag[bool]
 	Timeout                        *flag.Flag[int]
+	PollingInterval                *flag.Flag[int]
 	CancelOnTimeout                *flag.Flag[bool]
 }
 
@@ -139,6 +142,7 @@ func NewDeployFlags() *DeployFlags {
 		DeploymentFreezeOverrideReason: flag.New[string](FlagDeploymentFreezeOverrideReason, false),
 		WaitForDeployment:              flag.New[bool](FlagWaitForDeployment, false),
 		Timeout:                        flag.New[int](FlagTimeout, false),
+		PollingInterval:                flag.New[int](FlagPollingInterval, false),
 		CancelOnTimeout:                flag.New[bool](FlagCancelOnTimeout, false),
 	}
 }
@@ -183,7 +187,8 @@ func NewCmdDeploy(f factory.Factory) *cobra.Command {
 	flags.StringArrayVarP(&deployFlags.DeploymentFreezeNames.Value, deployFlags.DeploymentFreezeNames.Name, "", nil, "Override this deployment freeze (can be specified multiple times)")
 	flags.StringVarP(&deployFlags.DeploymentFreezeOverrideReason.Value, deployFlags.DeploymentFreezeOverrideReason.Name, "", "", "Reason for overriding a deployment freeze")
 	flags.BoolVarP(&deployFlags.WaitForDeployment.Value, deployFlags.WaitForDeployment.Name, "", false, "Wait for the deployment to complete")
-	flags.IntVarP(&deployFlags.Timeout.Value, deployFlags.Timeout.Name, "", DefaultTimeout, "Seconds to wait for the deployment to complete. Requires --wait-for-deployment")
+	flags.IntVarP(&deployFlags.Timeout.Value, deployFlags.Timeout.Name, "", DefaultTimeout, "Time in seconds to wait for deployment to complete. Requires --wait-for-deployment")
+	flags.IntVarP(&deployFlags.PollingInterval.Value, deployFlags.PollingInterval.Name, "", DefaultPollingInterval, "Polling interval in seconds to check deployment status during wait. Requires --wait-for-deployment")
 	flags.BoolVarP(&deployFlags.CancelOnTimeout.Value, deployFlags.CancelOnTimeout.Name, "", false, "Cancel the deployment if the wait timeout is reached. Requires --wait-for-deployment")
 
 	flags.SortFlags = false

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -85,6 +85,11 @@ const (
 
 	FlagDeploymentFreezeName           = "deployment-freeze-name"
 	FlagDeploymentFreezeOverrideReason = "deployment-freeze-override-reason"
+
+	FlagWaitForDeployment = "wait-for-deployment"
+	FlagTimeout           = "timeout"
+	FlagCancelOnTimeout   = "cancel-on-timeout"
+	DefaultTimeout        = 600
 )
 
 // executions API stops here.
@@ -109,6 +114,9 @@ type DeployFlags struct {
 	ExcludeTargets                 *flag.Flag[[]string]
 	DeploymentFreezeNames          *flag.Flag[[]string]
 	DeploymentFreezeOverrideReason *flag.Flag[string]
+	WaitForDeployment              *flag.Flag[bool]
+	Timeout                        *flag.Flag[int]
+	CancelOnTimeout                *flag.Flag[bool]
 }
 
 func NewDeployFlags() *DeployFlags {
@@ -129,6 +137,9 @@ func NewDeployFlags() *DeployFlags {
 		ExcludeTargets:                 flag.New[[]string](FlagExcludeDeploymentTarget, false),
 		DeploymentFreezeNames:          flag.New[[]string](FlagDeploymentFreezeName, false),
 		DeploymentFreezeOverrideReason: flag.New[string](FlagDeploymentFreezeOverrideReason, false),
+		WaitForDeployment:              flag.New[bool](FlagWaitForDeployment, false),
+		Timeout:                        flag.New[int](FlagTimeout, false),
+		CancelOnTimeout:                flag.New[bool](FlagCancelOnTimeout, false),
 	}
 }
 
@@ -171,6 +182,9 @@ func NewCmdDeploy(f factory.Factory) *cobra.Command {
 	flags.StringArrayVarP(&deployFlags.ExcludeTargets.Value, deployFlags.ExcludeTargets.Name, "", nil, "Deploy to targets except for this (can be specified multiple times)")
 	flags.StringArrayVarP(&deployFlags.DeploymentFreezeNames.Value, deployFlags.DeploymentFreezeNames.Name, "", nil, "Override this deployment freeze (can be specified multiple times)")
 	flags.StringVarP(&deployFlags.DeploymentFreezeOverrideReason.Value, deployFlags.DeploymentFreezeOverrideReason.Name, "", "", "Reason for overriding a deployment freeze")
+	flags.BoolVarP(&deployFlags.WaitForDeployment.Value, deployFlags.WaitForDeployment.Name, "", false, "Wait for the deployment to complete")
+	flags.IntVarP(&deployFlags.Timeout.Value, deployFlags.Timeout.Name, "", DefaultTimeout, "Seconds to wait for the deployment to complete. Requires --wait-for-deployment")
+	flags.BoolVarP(&deployFlags.CancelOnTimeout.Value, deployFlags.CancelOnTimeout.Name, "", false, "Cancel the deployment if the wait timeout is reached. Requires --wait-for-deployment")
 
 	flags.SortFlags = false
 

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	surveyCore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"github.com/OctopusDeploy/cli/pkg/cmd/release/deploy"
 	cmdRoot "github.com/OctopusDeploy/cli/pkg/cmd/root"
 	"github.com/OctopusDeploy/cli/pkg/constants"
@@ -28,6 +29,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tasks"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/spf13/cobra"
@@ -1872,4 +1874,235 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			test.run(t, new(bytes.Buffer))
 		})
 	}
+}
+
+func TestWaitForDeployments(t *testing.T) {
+	out := bytes.Buffer{}
+	defaultTaskIDs := []string{
+		"TaskID1",
+		"TaskID2",
+	}
+
+	taskList := []*tasks.Task{
+		tasks.NewTask(),
+		tasks.NewTask(),
+	}
+
+	// bool vars as bool constants can't be used as pointers for IsCompleted
+	boolFalse := false
+	boolTrue := true
+
+	taskList[0].ID = defaultTaskIDs[0]
+	taskList[0].IsCompleted = &boolFalse
+	taskList[0].FinishedSuccessfully = &boolFalse
+	taskList[0].Description = "Deploy Bar 1 release 0.0.2 to Foo"
+	taskList[0].State = "Executing"
+
+	taskList[1].ID = defaultTaskIDs[1]
+	taskList[1].IsCompleted = &boolTrue
+	taskList[1].FinishedSuccessfully = &boolTrue
+	taskList[1].Description = "Deploy Bar 2 release 0.0.2 to Foo"
+	taskList[1].State = "Success"
+
+	timesCalled := 0
+
+	getServerTaskCallback := func(taskIDs []string) ([]*tasks.Task, error) {
+		timesCalled += 1
+		switch timesCalled {
+		case 1:
+			assert.Len(t, taskIDs, 2)
+			assert.Equal(t, defaultTaskIDs[0], taskIDs[0])
+			assert.Equal(t, defaultTaskIDs[1], taskIDs[1])
+			return taskList, nil
+		case 2:
+			assert.Len(t, taskIDs, 1)
+			assert.Equal(t, defaultTaskIDs[0], taskIDs[0])
+			taskList[0].IsCompleted = &boolTrue
+			taskList[0].FinishedSuccessfully = &boolTrue
+			taskList[0].State = "Success"
+			taskList = taskList[:len(taskList)-1]
+			return taskList, nil
+		}
+		return nil, fmt.Errorf("getServerTaskCallback was called more then the expected amount of times")
+	}
+
+	opts := &deploy.WaitOptions{
+		Dependencies: &cmd.Dependencies{
+			Out: &out,
+		},
+		TaskIDs:                defaultTaskIDs,
+		GetServerTasksCallback: getServerTaskCallback,
+		Timeout:                60,
+		PollInterval:           1,
+		CancelOnTimeout:        false,
+	}
+
+	err := deploy.WaitForDeployments(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, timesCalled)
+	expectedOutput := heredoc.Doc(`
+  Waiting for 1 deployment(s) to complete...
+  Deployment(s) completed successfully
+  `)
+	assert.Equal(t, expectedOutput, out.String())
+}
+
+func TestWaitForDeployments_FailedTask(t *testing.T) {
+	out := bytes.Buffer{}
+	defaultTaskIDs := []string{
+		"TaskID1",
+	}
+
+	taskList := []*tasks.Task{
+		tasks.NewTask(),
+	}
+
+	// bool vars as bool constants can't be used as pointers for IsCompleted
+	boolFalse := false
+	boolTrue := true
+
+	taskList[0].ID = defaultTaskIDs[0]
+	taskList[0].IsCompleted = &boolTrue
+	taskList[0].FinishedSuccessfully = &boolFalse
+	taskList[0].Description = "Deploy Bar 1 release 0.0.2 to Foo"
+	taskList[0].State = "Failed"
+
+	getServerTaskCallback := func(taskIDs []string) ([]*tasks.Task, error) {
+		return taskList, nil
+	}
+
+	opts := &deploy.WaitOptions{
+		Dependencies: &cmd.Dependencies{
+			Out: &out,
+		},
+		TaskIDs:                defaultTaskIDs,
+		GetServerTasksCallback: getServerTaskCallback,
+		Timeout:                60,
+		PollInterval:           1,
+		CancelOnTimeout:        false,
+	}
+
+	err := deploy.WaitForDeployments(opts)
+	assert.EqualError(t, err, "one or more deployment tasks failed: TaskID1")
+	assert.Empty(t, out.String())
+}
+
+func TestWaitForDeployments_FailedPendingTask(t *testing.T) {
+	out := bytes.Buffer{}
+	defaultTaskIDs := []string{
+		"TaskID1",
+	}
+
+	taskList := []*tasks.Task{
+		tasks.NewTask(),
+	}
+
+	// bool vars as bool constants can't be used as pointers for IsCompleted
+	boolFalse := false
+	boolTrue := true
+
+	taskList[0].ID = defaultTaskIDs[0]
+	taskList[0].IsCompleted = &boolFalse
+	taskList[0].FinishedSuccessfully = &boolFalse
+	taskList[0].Description = "Deploy Bar 1 release 0.0.2 to Foo"
+	taskList[0].State = "Executing"
+
+	timesCalled := 0
+
+	getServerTaskCallback := func(taskIDs []string) ([]*tasks.Task, error) {
+		timesCalled += 1
+		switch timesCalled {
+		case 1:
+			return taskList, nil
+		case 2:
+			taskList[0].IsCompleted = &boolTrue
+			taskList[0].FinishedSuccessfully = &boolFalse
+			taskList[0].State = "Failed"
+			return taskList, nil
+		}
+		return nil, fmt.Errorf("getServerTaskCallback was called more then the expected amount of times")
+	}
+
+	opts := &deploy.WaitOptions{
+		Dependencies: &cmd.Dependencies{
+			Out: &out,
+		},
+		TaskIDs:                defaultTaskIDs,
+		GetServerTasksCallback: getServerTaskCallback,
+		Timeout:                60,
+		PollInterval:           1,
+		CancelOnTimeout:        false,
+	}
+
+	err := deploy.WaitForDeployments(opts)
+	assert.EqualError(t, err, "one or more deployment tasks failed: TaskID1")
+	assert.Equal(t, 2, timesCalled)
+	expectedOutput := heredoc.Doc(`
+  Waiting for 1 deployment(s) to complete...
+  `)
+	assert.Equal(t, expectedOutput, out.String())
+}
+
+func TestWaitForDeployments_CancelOnTimeout(t *testing.T) {
+	out := bytes.Buffer{}
+	defaultTaskIDs := []string{
+		"TaskID1",
+		"TaskID2",
+	}
+
+	taskList := []*tasks.Task{
+		tasks.NewTask(),
+		tasks.NewTask(),
+	}
+
+	// bool vars as bool constants can't be used as pointers for IsCompleted
+	boolFalse := false
+	boolTrue := true
+
+	taskList[0].ID = defaultTaskIDs[0]
+	taskList[0].IsCompleted = &boolFalse
+	taskList[0].FinishedSuccessfully = &boolFalse
+	taskList[0].Description = "Deploy Bar 1 release 0.0.2 to Foo"
+	taskList[0].State = "Executing"
+
+	taskList[1].ID = defaultTaskIDs[1]
+	taskList[1].IsCompleted = &boolTrue
+	taskList[1].FinishedSuccessfully = &boolTrue
+	taskList[1].Description = "Deploy Bar 2 release 0.0.2 to Foo"
+	taskList[1].State = "Success"
+
+	getServerTaskCallback := func(taskIDs []string) ([]*tasks.Task, error) {
+		time.Sleep(1 * time.Second)
+		assert.Len(t, taskIDs, 2)
+		assert.Equal(t, defaultTaskIDs[0], taskIDs[0])
+		assert.Equal(t, defaultTaskIDs[1], taskIDs[1])
+		return taskList, nil
+	}
+
+	cancelCalled := false
+	cancelServerTaskCallback := func(taskIDs []string) error {
+		cancelCalled = true
+		return nil
+	}
+
+	opts := &deploy.WaitOptions{
+		Dependencies: &cmd.Dependencies{
+			Out: &out,
+		},
+		TaskIDs:                   defaultTaskIDs,
+		GetServerTasksCallback:    getServerTaskCallback,
+		CancelServerTasksCallback: cancelServerTaskCallback,
+		Timeout:                   1,
+		PollInterval:              1,
+		CancelOnTimeout:           true,
+	}
+
+	err := deploy.WaitForDeployments(opts)
+	assert.True(t, cancelCalled)
+	assert.EqualError(t, err, "timeout while waiting for deployment(s) to complete")
+	expectedOutput := heredoc.Doc(`
+  Waiting for 1 deployment(s) to complete...
+  Cancelling remaining deployment tasks: TaskID1
+  `)
+	assert.Equal(t, expectedOutput, out.String())
 }

--- a/pkg/cmd/task/wait/wait.go
+++ b/pkg/cmd/task/wait/wait.go
@@ -26,8 +26,8 @@ type WaitOptions struct {
 	TaskIDs                []string
 	GetServerTasksCallback ServerTasksCallback
 	GetTaskDetailsCallback TaskDetailsCallback
-	Timeout               int
-	ShowProgress         bool
+	Timeout                int
+	ShowProgress           bool
 }
 
 type ServerTasksCallback func([]string) ([]*tasks.Task, error)
@@ -36,11 +36,11 @@ type TaskDetailsCallback func(string) (*tasks.TaskDetailsResource, error)
 func NewWaitOps(dependencies *cmd.Dependencies, taskIDs []string) *WaitOptions {
 	return &WaitOptions{
 		Dependencies:           dependencies,
-		TaskIDs:               taskIDs,
+		TaskIDs:                taskIDs,
 		GetServerTasksCallback: GetServerTasksCallback(dependencies.Client),
 		GetTaskDetailsCallback: GetTaskDetailsCallback(dependencies.Client),
-		Timeout:               DefaultTimeout,
-		ShowProgress:         false,
+		Timeout:                DefaultTimeout,
+		ShowProgress:           false,
 	}
 }
 
@@ -68,7 +68,7 @@ func NewCmdWait(f factory.Factory) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.IntVar(&timeout, FlagTimeout, DefaultTimeout, "Duration to wait (in seconds) before stopping execution")
+	flags.IntVar(&timeout, FlagTimeout, DefaultTimeout, "Duration to wait (in seconds) before the CLI exits. Does not cancel the task in progress.")
 	flags.BoolVar(&showProgress, FlagProgress, false, "Show detailed progress of the tasks")
 
 	return cmd


### PR DESCRIPTION
Depends on https://github.com/OctopusDeploy/go-octopusdeploy/pull/333

## Background
There has been a request to add support for deployment waiting flags in the new Octopus CLI to improve automation workflows. These flags were previously available in the [old Octopus CLI](https://github.com/OctopusDeploy/OctopusCLI/blob/main/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs#L57-L59). This PR ports those capabilities into the new CLI.

[sc-108942]

## Result
- Added support for the following flags in the deploy-release step:
  - `--wait-for-deployment`
  - `--timeout`
  - `--polling-interval`
  - `--cancel-on-timeout`

- Updated the help description of the `task wait` command as there was confusion about whether this command cancelled the task on timeout.