### PR TITLE
Delete winget-pkgs fork before running winget-create

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -215,6 +215,26 @@ step "publish-winget-update-pr" {
         action_type = "Octopus.Script"
         properties = {
             Octopus.Action.Script.ScriptBody = <<-EOT
+                #Headers
+                $headers = @{
+                    'Accept'               = "application/vnd.github+json";
+                    'X-GitHub-Api-Version' = "2022-11-28";
+                }
+                try {
+                    
+                    # Delete the fork of the winget-pkgs repo using the bot's token
+                    $response = Invoke-WebRequest -Method "DELETE" -Uri "https://api.github.com/repos/team-integrations-fnm-bot/winget-pkgs" -Authentication "Bearer" -Token $OctopusParameters["Publish:Winget:GitHubPAT"] -Headers $headers
+                    $statusCode = $Response.StatusCode
+                }
+                catch {
+                    $statusCode = $_.Exception.Response.StatusCode.value__
+                }
+                
+                if (!($statusCode -ge 200 -and $statusCode -le 299 )) {
+                    Write-Warning "Failed to delete fork repo 'team-integrations-fnm-bot/winget-pkgs'. If this fork is too far behind its source, winget-create may fail."
+                }
+                
+                
                 # Install winget-create
                 Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
                 

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -629,12 +629,6 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			assert.Equal(t, heredoc.Doc(`
 				Project Fire Project
 				Release 1.9
-				Additional Options:
-				Deploy Time: Now
-				Skipped Steps: None
-				Guided Failure Mode: Use default setting from the target environment
-				Package Download: Use cached packages (if available)
-				Deployment Targets: All included"
 			`), stdout.String())
 			stdout.Reset()
 

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -629,6 +629,12 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			assert.Equal(t, heredoc.Doc(`
 				Project Fire Project
 				Release 1.9
+				Additional Options:
+				Deploy Time: Now
+				Skipped Steps: None
+				Guided Failure Mode: Use default setting from the target environment
+				Package Download: Use cached packages (if available)
+				Deployment Targets: All included"
 			`), stdout.String())
 			stdout.Reset()
 


### PR DESCRIPTION
We've discovered if the fork repo is too out of sync, the `winget-create update` call can fail.

This change deletes the fork repo before `update` call runs, which will re-fork the repo as part of it's execution