### PR TITLE
feat:support project view -f for project view

### DIFF
--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -22,6 +22,13 @@ const (
 	FlagWeb = "web"
 )
 
+// joinURL joins host and path, ensuring there's exactly one slash between them
+func joinURL(host, path string) string {
+	host = strings.TrimSuffix(host, "/")
+	path = strings.TrimPrefix(path, "/")
+	return host + "/" + path
+}
+
 type ViewFlags struct {
 	Web *flag.Flag[bool]
 }
@@ -98,7 +105,7 @@ func viewRun(opts *ViewOptions) error {
 				Description:           p.Description,
 				IsVersionControlled:   p.IsVersionControlled,
 				VersionControlBranch:  cacBranch,
-				WebUrl:               opts.Host + p.Links["Web"],
+				WebUrl:               joinURL(opts.Host, p.Links["Web"]),
 			}
 		},
 		Table: output.TableDefinition[*projects.Project]{
@@ -119,7 +126,7 @@ func viewRun(opts *ViewOptions) error {
 					p.Slug,
 					description,
 					cacBranch,
-					output.Blue(opts.Host + p.Links["Web"]),
+					output.Blue(joinURL(opts.Host, p.Links["Web"])),
 				}
 			},
 		},
@@ -160,7 +167,7 @@ func formatProjectForBasic(opts *ViewOptions, project *projects.Project) string 
 	}
 	
 	// footer with web URL
-	url := opts.Host + project.Links["Web"]
+	url := joinURL(opts.Host, project.Links["Web"])
 	result.WriteString(fmt.Sprintf("View this project in Octopus Deploy: %s\n", output.Blue(url)))
 	
 	if opts.flags.Web.Value {


### PR DESCRIPTION
## Background
Current `octopus project view ` command don't support -f param.
## Result
At support `-f json` , `-f table`, `-f basic`
[fixes-312](https://github.com/OctopusDeploy/cli/issues/312)
[sc-116437](https://app.shortcut.com/octopusdeploy/story/116437/sev-3-octopus-cli-ignores-f-option-requested-by-nicholas-harvey)
## Before
Always return 
```
PS D:\Octopus\cli\bin> octopus project view projects-1 -f json
Project Improve HelpText (project-improve-helptext)
Version control branch: Not version controlled
No description provided
View this project in Octopus Deploy: http://localhost:8066//app#/Spaces-1/projects/Projects-1
```

## After

- json
```
PS D:\Octopus\cli\bin> ./octopus.exe project view projects-1 -f json
{
  "Id": "Projects-1",
  "Name": "Project Improve HelpText",
  "Slug": "project-improve-helptext",
  "Description": "",
  "IsVersionControlled": false,
  "VersionControlBranch": "Not version controlled",
  "WebUrl": "http://localhost:8066//app#/Spaces-1/projects/Projects-1"
}
```

- table
```
PS D:\Octopus\cli\bin> ./octopus.exe project view projects-1 -f table
NAME                      SLUG                      DESCRIPTION              VERSION CONTROL         WEB URL
Project Improve HelpText  project-improve-helptext  No description provided  Not version controlled  http://localhost:8066/app#/Spaces-1/projects/Projects-1
```
- basic
```
PS D:\Octopus\cli\bin> ./octopus.exe project view projects-1 -f basic
Project Improve HelpText (project-improve-helptext)
Version control branch: Not version controlled
No description provided
View this project in Octopus Deploy: http://localhost:8066/app#/Spaces-1/projects/Projects-1
```