### PR TITLE
feat: project-group view command support -f options

### DIFF
--- a/pkg/cmd/buildinformation/view/view.go
+++ b/pkg/cmd/buildinformation/view/view.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/usage"
+	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/buildinformation"
 	"github.com/pkg/browser"
@@ -160,7 +161,7 @@ func viewRun(opts *ViewOptions, cmd *cobra.Command) error {
 				}
 			}
 
-			link := fmt.Sprintf("%s/app#/%s/library/buildinformation/%s", opts.Host, opts.Client.GetSpaceID(), b.GetID())
+			link := util.GenerateWebURL(opts.Host, opts.Client.GetSpaceID(), fmt.Sprintf("library/buildinformation/%s", b.GetID()))
 			s.WriteString(fmt.Sprintf("\nView this build information in Octopus Deploy: %s\n", output.Blue(link)))
 
 			if opts.Web.Value {

--- a/pkg/cmd/projectgroup/view/view.go
+++ b/pkg/cmd/projectgroup/view/view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/usage"
+	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectgroups"
@@ -89,6 +90,11 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
+	// Use basic format as default for project group view when no -f flag is specified
+	if !opts.Command.Flags().Changed(constants.FlagOutputFormat) {
+		opts.Command.Flags().Set(constants.FlagOutputFormat, constants.OutputFormatBasic)
+	}
+
 	return output.PrintResource(projectGroup, opts.Command, output.Mappers[*projectgroups.ProjectGroup]{
 		Json: func(pg *projectgroups.ProjectGroup) any {
 			projectList := make([]ProjectInfo, 0, len(projects))
@@ -105,7 +111,7 @@ func viewRun(opts *ViewOptions) error {
 				Name:        pg.GetName(),
 				Description: pg.Description,
 				Projects:    projectList,
-				WebUrl:      fmt.Sprintf("%s/app#/%s/projects?projectGroupId=%s", opts.Host, pg.SpaceID, pg.GetID()),
+				WebUrl:      util.GenerateWebURL(opts.Host, pg.SpaceID, fmt.Sprintf("projects?projectGroupId=%s", pg.GetID())),
 			}
 		},
 		Table: output.TableDefinition[*projectgroups.ProjectGroup]{
@@ -116,7 +122,7 @@ func viewRun(opts *ViewOptions) error {
 					description = constants.NoDescription
 				}
 				
-				url := fmt.Sprintf("%s/app#/%s/projects?projectGroupId=%s", opts.Host, pg.SpaceID, pg.GetID())
+				url := util.GenerateWebURL(opts.Host, pg.SpaceID, fmt.Sprintf("projects?projectGroupId=%s", pg.GetID()))
 				
 				return []string{
 					output.Bold(pg.GetName()),
@@ -166,7 +172,7 @@ func formatProjectGroupForBasic(opts *ViewOptions, projectGroup *projectgroups.P
 	}
 	
 	// footer with web URL
-	url := fmt.Sprintf("%s/app#/%s/projects?projectGroupId=%s", opts.Host, projectGroup.SpaceID, projectGroup.GetID())
+	url := util.GenerateWebURL(opts.Host, projectGroup.SpaceID, fmt.Sprintf("projects?projectGroupId=%s", projectGroup.GetID()))
 	result.WriteString(fmt.Sprintf("\nView this project group in Octopus Deploy: %s\n", output.Blue(url)))
 	
 	if opts.flags.Web.Value {

--- a/pkg/cmd/space/view/view.go
+++ b/pkg/cmd/space/view/view.go
@@ -59,6 +59,11 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
+	// Use basic format as default for space view when no -f flag is specified
+	if !opts.Command.Flags().Changed(constants.FlagOutputFormat) {
+		opts.Command.Flags().Set(constants.FlagOutputFormat, constants.OutputFormatBasic)
+	}
+
 	host := opts.Host
 	return output.PrintResource(space, opts.Command, output.Mappers[*spaces.Space]{
 		Json: func(item *spaces.Space) any {

--- a/pkg/cmd/tenant/view/view.go
+++ b/pkg/cmd/tenant/view/view.go
@@ -14,6 +14,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/usage"
+	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
@@ -145,7 +146,7 @@ func viewRun(opts *ViewOptions, cmd *cobra.Command) error {
 				s.WriteString(fmt.Sprintln("Tenant is enabled"))
 			}
 
-			link := fmt.Sprintf("%s/app#/%s/tenants/%s/overview", opts.Host, tenant.SpaceID, tenant.ID)
+			link := util.GenerateWebURL(opts.Host, tenant.SpaceID, fmt.Sprintf("tenants/%s/overview", tenant.ID))
 			// footer
 			s.WriteString(fmt.Sprintf("View this tenant in Octopus Deploy: %s\n", output.Blue(link)))
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 )
 
 // SliceContains returns true if it finds an item in the slice that is equal to the target
@@ -292,4 +293,16 @@ func SplitString(s string, delimiters []rune) []string {
 func PrintJSON(obj interface{}) {
 	bytes, _ := json.MarshalIndent(obj, "\t", "\t")
 	fmt.Println(string(bytes))
+}
+
+// GenerateWebURL creates a web URL for Octopus Deploy resources
+// host: base URL (e.g., "http://localhost:8066")
+// spaceID: space identifier (e.g., "Spaces-1")
+// path: resource-specific path (e.g., "projects?projectGroupId=ProjectGroups-1")
+func GenerateWebURL(host, spaceID, path string) string {
+	// Ensure host doesn't end with slash
+	host = strings.TrimSuffix(host, "/")
+	// Ensure path doesn't start with slash
+	path = strings.TrimPrefix(path, "/")
+	return fmt.Sprintf("%s/app#/%s/%s", host, spaceID, path)
 }


### PR DESCRIPTION
## Background
Current `octopus project-group view ` command don't support -f param.
## Result
At support `-f json` , `-f table`, `-f basic`
[fixes-312](https://github.com/OctopusDeploy/cli/issues/312)
[sc-116437](https://app.shortcut.com/octopusdeploy/story/116437/sev-3-octopus-cli-ignores-f-option-requested-by-nicholas-harvey)
## Before
Always return 

```
PS D:\Octopus\cli\bin> octopus project-group view ProjectGroups-1 -f json
Default Project Group (ProjectGroups-1)
No description provided

Projects:
CaC Project (cac-project)
CaC Project  - Another (cac-project-another)
Deployment Target Release (deployment-target-release)
Project Improve HelpText (project-improve-helptext)

View this project group in Octopus Deploy: http://localhost:8066//app#/Spaces-1/projects?projectGroupId=ProjectGroups-1
```

## After

- json
```
PS D:\Octopus\cli\bin> .\octopus.exe project-group view ProjectGroups-1 -f json
{
  "Id": "ProjectGroups-1",
  "Name": "Default Project Group",
  "Description": "",
  "Projects": [
    {
      "Id": "Projects-4",
      "Name": "CaC Project",
      "Slug": "cac-project"
    },
    {
      "Id": "Projects-5",
      "Name": "CaC Project  - Another",
      "Slug": "cac-project-another"
    },
    {
      "Id": "Projects-2",
      "Name": "Deployment Target Release",
      "Slug": "deployment-target-release"
    },
    {
      "Id": "Projects-1",
      "Name": "Project Improve HelpText",
      "Slug": "project-improve-helptext"
    }
  ],
  "WebUrl": "http://localhost:8066//app#/Spaces-1/projects?projectGroupId=ProjectGroups-1"
}
```

- table
```
NAME                   DESCRIPTION              PROJECTS COUNT  WEB URL
Default Project Group  No description provided  4               http://localhost:8066//app#/Spaces-1/projects?projectGroupId=ProjectGroups-1
```
- basic
```
PS D:\Octopus\cli\bin> .\octopus.exe project-group view ProjectGroups-1 -f basic
Default Project Group (ProjectGroups-1)
No description provided

Projects:
CaC Project (cac-project)
CaC Project  - Another (cac-project-another)
Deployment Target Release (deployment-target-release)
Project Improve HelpText (project-improve-helptext)

View this project group in Octopus Deploy: http://localhost:8066//app#/Spaces-1/projects?projectGroupId=ProjectGroups-1
```