### PR TITLE
fix: default output to table as global config

### DIFF
--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -85,11 +85,6 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	// Use basic format as default for project view when no -f flag is specified
-	if !opts.Command.Flags().Changed(constants.FlagOutputFormat) {
-		opts.Command.Flags().Set(constants.FlagOutputFormat, constants.OutputFormatBasic)
-	}
-
 	return output.PrintResource(project, opts.Command, output.Mappers[*projects.Project]{
 		Json: func(p *projects.Project) any {
 			cacBranch := "Not version controlled"

--- a/pkg/cmd/projectgroup/view/view.go
+++ b/pkg/cmd/projectgroup/view/view.go
@@ -90,11 +90,6 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	// Use basic format as default for project group view when no -f flag is specified
-	if !opts.Command.Flags().Changed(constants.FlagOutputFormat) {
-		opts.Command.Flags().Set(constants.FlagOutputFormat, constants.OutputFormatBasic)
-	}
-
 	return output.PrintResource(projectGroup, opts.Command, output.Mappers[*projectgroups.ProjectGroup]{
 		Json: func(pg *projectgroups.ProjectGroup) any {
 			projectList := make([]ProjectInfo, 0, len(projects))

--- a/pkg/cmd/space/view/view.go
+++ b/pkg/cmd/space/view/view.go
@@ -59,11 +59,6 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	// Use basic format as default for space view when no -f flag is specified
-	if !opts.Command.Flags().Changed(constants.FlagOutputFormat) {
-		opts.Command.Flags().Set(constants.FlagOutputFormat, constants.OutputFormatBasic)
-	}
-
 	host := opts.Host
 	return output.PrintResource(space, opts.Command, output.Mappers[*spaces.Space]{
 		Json: func(item *spaces.Space) any {

--- a/pkg/machinescommon/web.go
+++ b/pkg/machinescommon/web.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/workerpools"
@@ -31,17 +32,17 @@ func RegisterWebFlag(cmd *cobra.Command, flags *WebFlags) {
 }
 
 func DoWebForTargets(target *machines.DeploymentTarget, dependencies *cmd.Dependencies, flags *WebFlags, description string) {
-	url := fmt.Sprintf("%s/app#/%s/infrastructure/machines/%s/settings", dependencies.Host, dependencies.Space.GetID(), target.GetID())
+	url := util.GenerateWebURL(dependencies.Host, dependencies.Space.GetID(), fmt.Sprintf("infrastructure/machines/%s/settings", target.GetID()))
 	doWeb(url, description, dependencies.Out, flags)
 }
 
 func DoWebForWorkers(worker *machines.Worker, dependencies *cmd.Dependencies, flags *WebFlags, description string) {
-	url := fmt.Sprintf("%s/app#/%s/infrastructure/workers/%s/settings", dependencies.Host, dependencies.Space.GetID(), worker.GetID())
+	url := util.GenerateWebURL(dependencies.Host, dependencies.Space.GetID(), fmt.Sprintf("infrastructure/workers/%s/settings", worker.GetID()))
 	doWeb(url, description, dependencies.Out, flags)
 }
 
 func DoWebForWorkerPools(workerPool workerpools.IWorkerPool, dependencies *cmd.Dependencies, flags *WebFlags) {
-	url := fmt.Sprintf("%s/app#/%s/infrastructure/workerpools/%s/settings", dependencies.Host, dependencies.Space.GetID(), workerPool.GetID())
+	url := util.GenerateWebURL(dependencies.Host, dependencies.Space.GetID(), fmt.Sprintf("infrastructure/workerpools/%s", workerPool.GetID()))
 	doWeb(url, "Worker Pool", dependencies.Out, flags)
 }
 


### PR DESCRIPTION
The default output format is already configured in [root.go](https://github.com/OctopusDeploy/cli/blob/dcce548ec9c70f0253ff3e529d665b934c109663/pkg/cmd/root/root.go#L90) as "table" for commands that support the -f flag:
```
cmdPFlags.StringP(constants.FlagOutputFormat, "f", constants.OutputFormatTable, `Specify the output format for a command ("json", "table", or "basic")`)
```

This PR removes custom default format overrides from individual commands, ensuring consistent behavior across the CLI by relying on the global default.