### PR TITLE
fix: issue release id missing in json output

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -294,6 +294,7 @@ func createRun(cmd *cobra.Command, f factory.Factory, flags *CreateFlags) error 
 				cmd.Printf("%s\n", releaseVersion)
 			case constants.OutputFormatJson:
 				v := &list.ReleaseViewModel{
+					ID:           options.Response.ReleaseID,
 					Version:      releaseVersion,
 					Assembled:    assembled,
 					ReleaseNotes: releaseNotes,

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1394,7 +1394,7 @@ func TestReleaseCreate_AutomationMode(t *testing.T) {
 			_, err := testutil.ReceivePair(cmdReceiver)
 			assert.Nil(t, err)
 
-			assert.Equal(t, "{\"ReleaseNotes\":\"\",\"Assembled\":\"0001-01-01T00:00:00Z\",\"Channel\":\"Alpha channel\",\"Version\":\"1.2.3\"}\n", stdOut.String())
+			assert.Equal(t, "{\"ID\":\"Releases-999\",\"ReleaseNotes\":\"\",\"Assembled\":\"0001-01-01T00:00:00Z\",\"Channel\":\"Alpha channel\",\"Version\":\"1.2.3\"}\n", stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},
 

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -32,6 +32,7 @@ func NewListFlags() *ListFlags {
 }
 
 type ReleaseViewModel struct {
+	ID           string
 	ReleaseNotes string
 	Assembled    time.Time
 	Channel      string
@@ -118,6 +119,7 @@ func listRun(cmd *cobra.Command, f factory.Factory, flags *ListFlags) error {
 		func(item *releases.Release, lookup []string) ReleaseViewModel { // result producer
 			item.Links = nil
 			return ReleaseViewModel{
+				ID:        item.ID,
 				Assembled: item.Assembled,
 				Channel:   lookup[0],
 				Version:   item.Version,

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -72,8 +72,8 @@ func TestReleaseList(t *testing.T) {
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
 					Items: []*releases.Release{
-						releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1"),
-						releases.NewRelease(defaultChannel.ID, fireProjectID, "2.0"),
+						fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID),
+						fixtures.NewRelease(spaceID, "Releases-2", "2.0", fireProjectID, defaultChannel.ID),
 						releases.NewRelease(betaChannel.ID, fireProjectID, "2.0-beta2"),
 						releases.NewRelease(betaChannel.ID, fireProjectID, "2.0-beta1"),
 					},
@@ -116,8 +116,8 @@ func TestReleaseList(t *testing.T) {
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
 					Items: []*releases.Release{
-						releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1"),
-						releases.NewRelease(defaultChannel.ID, fireProjectID, "2.0"),
+						fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID),
+						fixtures.NewRelease(spaceID, "Releases-2", "2.0", fireProjectID, defaultChannel.ID),
 						releases.NewRelease(betaChannel.ID, fireProjectID, "2.0-beta2"),
 						releases.NewRelease(betaChannel.ID, fireProjectID, "2.0-beta1"),
 					},
@@ -158,7 +158,7 @@ func TestReleaseList(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
-					Items: []*releases.Release{releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1")},
+					Items: []*releases.Release{fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID)},
 				})
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels?ids=Channels-1&take=1").
@@ -191,7 +191,7 @@ func TestReleaseList(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
-					Items: []*releases.Release{releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1")},
+					Items: []*releases.Release{fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID)},
 				})
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels?ids=Channels-1&take=1").
@@ -223,7 +223,7 @@ func TestReleaseList(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
-					Items: []*releases.Release{releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1")},
+					Items: []*releases.Release{fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID)},
 				})
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels?ids=Channels-1&take=1").
@@ -233,6 +233,7 @@ func TestReleaseList(t *testing.T) {
 			assert.Nil(t, err)
 
 			type x struct {
+				ID           string
 				Assembled    time.Time
 				Channel      string
 				Version      string
@@ -243,6 +244,7 @@ func TestReleaseList(t *testing.T) {
 
 			expectedTime, _ := time.Parse(time.RFC1123Z, "Mon, 01 Jan 0001 00:00:00")
 			assert.Equal(t, []x{{
+				ID:           "Releases-1",
 				Channel:      defaultChannel.Name,
 				Version:      "2.1",
 				ReleaseNotes: "",
@@ -268,7 +270,7 @@ func TestReleaseList(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
-					Items: []*releases.Release{releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1")},
+					Items: []*releases.Release{fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID)},
 				})
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels?ids=Channels-1&take=1").
@@ -300,7 +302,7 @@ func TestReleaseList(t *testing.T) {
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
 				RespondWith(resources.Resources[*releases.Release]{
-					Items: []*releases.Release{releases.NewRelease(defaultChannel.ID, fireProjectID, "2.1")},
+					Items: []*releases.Release{fixtures.NewRelease(spaceID, "Releases-1", "2.1", fireProjectID, defaultChannel.ID)},
 				})
 
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels?ids=Channels-1&take=1").


### PR DESCRIPTION
## Background
When create a release with output-format json. The output json is missing ReleaseId.

## Result
Fixes #281 
[sc-116437](https://app.shortcut.com/octopusdeploy/story/116437/sev-3-octopus-cli-ignores-f-option-requested-by-nicholas-harvey)
## Before
```
PS D:\Octopus\cli\bin> octopus release create --project 'Project 2' --git-ref 'refs/heads/main' --channel 'Default' --version '0.0.7' -f json --no-prompt
{"ReleaseNotes":"","Assembled":"2025-08-12T11:33:34.712+10:00","Channel":"Default","Version":"0.0.7"}
```
## After
```
PS D:\Octopus\cli\bin> .\octopus.exe release create --project 'Project 2' --git-ref 'refs/heads/main' --channel 'Default' --version '0.0.6' -f json --no-prompt
{"ID":"Releases-102","ReleaseNotes":"","Assembled":"2025-08-12T11:32:15.919+10:00","Channel":"Default","Version":"0.0.6"}
```