### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -776,17 +776,15 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			emptyDeploymentPreviews := fixtures.EmptyDeploymentPreviews()
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/"+release19.ID+"/deployments/previews").RespondWith(&emptyDeploymentPreviews)
 
-			assert.Equal(t, heredoc.Doc(`
-				Project Fire Project
-				Release 1.9
-			`), stdout.String())
-			stdout.Reset()
-
 			q := qa.ExpectQuestion(t, &survey.Select{
 				Message: "Change additional options?",
 				Options: []string{"Proceed to deploy", "Change"},
 			})
-			assert.Regexp(t, "Additional Options", stdout.String()) // actual options tested in PrintAdvancedSummary
+
+			output := stdout.String()
+			assert.Contains(t, output, "Project Fire Project")
+			assert.Contains(t, output, "Release 1.9")
+			assert.Contains(t, output, "Additional Options:") // actual options tested in PrintAdvancedSummary
 			_ = q.AnswerWith("Proceed to deploy")
 
 			err := <-errReceiver


### PR DESCRIPTION
[SC-121396]
Tests in deploy_test.go seem to have been flaky for a while. This appears to be a timing issue in the test. Sometimes "Additional Options" were included in the output prior to the buffer being cleared via `stdout.Reset()`, resulting in a failed equals assertion on project name and release number.

Example failure: https://github.com/OctopusDeploy/cli/actions/runs/17413265554/job/49435474443
<img width="2451" height="876" alt="image" src="https://github.com/user-attachments/assets/4e2d0c9b-db93-4a28-8c4a-e54794914422" />