### PR TITLE
chore: avoid updating doc pages when only the moddate changes

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,6 +1,9 @@
 name: 'Generate Docs'
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 env:
   DOCS_TOKEN: ${{ secrets.DOCS_TOKEN }}
 jobs:

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -176,18 +178,39 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, relativeBasePath stri
 	}
 
 	info := NewTemplateInformation(cmd, dir, relativeBasePath, myPosition)
-	f, err := os.Create(info.OutputFile)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
 
 	*pageCollection.Pages = append(*pageCollection.Pages, info)
 
-	if err := GenMarkdownCustom(cmd, f, info); err != nil {
+	// Generate new content to buffer
+	var buf bytes.Buffer
+	if err := GenMarkdownCustom(cmd, &buf, info); err != nil {
 		return err
 	}
-	return nil
+	updatedContent := buf.Bytes()
+
+	// Only write if content actually changed (ignoring modDate line)
+	if existingContent, err := os.ReadFile(info.OutputFile); err == nil {
+		if contentEqualIgnoringModDate(existingContent, updatedContent) {
+			return nil
+		}
+	}
+
+	return os.WriteFile(info.OutputFile, updatedContent, 0644)
+}
+
+var modDatePattern = regexp.MustCompile(`(?m)^modDate: .+$`)
+
+// contentEqualIgnoringModDate compares two file contents, treating the modDate
+// frontmatter line as identical regardless of actual date value.
+// Normalizes CRLF to LF before comparing so existing files with different
+// line endings don't cause false mismatches.
+func contentEqualIgnoringModDate(a, b []byte) bool {
+	placeholder := []byte("modDate: PLACEHOLDER")
+	cr := []byte("\r\n")
+	lf := []byte("\n")
+	normA := bytes.ReplaceAll(modDatePattern.ReplaceAll(a, placeholder), cr, lf)
+	normB := bytes.ReplaceAll(modDatePattern.ReplaceAll(b, placeholder), cr, lf)
+	return bytes.Equal(normA, normB)
 }
 
 const documentationTemplate = `---


### PR DESCRIPTION
Before: 
The modDate property on each doc page would always be updated resulting in a PR with every file touched 

<img width="1331" height="274" alt="image" src="https://github.com/user-attachments/assets/f364dd2a-d986-4b6b-b6ba-79d85237651e" />


After:
I added a new parameter to a command and ran the `gen-docs` command, only that doc page was updated.
```
❯ gst
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   src/pages/docs/octopus-rest-api/cli/octopus-channel-create.mdx
```

```
diff --git a/src/pages/docs/octopus-rest-api/cli/octopus-channel-create.mdx b/src/pages/docs/octopus-rest-api/cli/octopus-channel-create.mdx
index 3fe624430..3b44fae4a 100644
--- a/src/pages/docs/octopus-rest-api/cli/octopus-channel-create.mdx
+++ b/src/pages/docs/octopus-rest-api/cli/octopus-channel-create.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2026-04-19
+modDate: 2026-04-21
 title: octopus channel create
 description: Create a channel
 navOrder: 37
@@ -15,6 +15,7 @@ Usage:
   octopus channel create [flags]

 Flags:
+  -b, --blah string          The lifecycle to use for the channel
       --default              Set this channel as default
   -d, --description string   Description of the channel
   -l, --lifecycle string     The lifecycle to use for the channel
```