### PR TITLE
Use package version for Winget publish

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -242,7 +242,7 @@ step "publish-winget-update-pr" {
                 # Install winget-create
                 Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
                 
-                $version = $OctopusParameters["Octopus.Release.Number"]
+                $version = $OctopusParameters["Octopus.Action.Package[cli].PackageVersion"]
                 
                 $packageUrls = "https://github.com/OctopusDeploy/cli/releases/download/v$version/octopus_$($version)_windows_amd64.msi|x64"
                 
@@ -267,6 +267,16 @@ step "publish-winget-update-pr" {
         container {
             feed = "docker-hub"
             image = "octopusdeploy/worker-tools:6.4-windows.ltsc2022"
+        }
+
+        packages "cli" {
+            acquisition_location = "Server"
+            feed = "octopus-server-built-in"
+            package_id = "octopus-cli"
+            properties = {
+                Extract = "False"
+                SelectionMode = "immediate"
+            }
         }
     }
 }

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -270,7 +270,7 @@ step "publish-winget-update-pr" {
         }
 
         packages "cli" {
-            acquisition_location = "Server"
+            acquisition_location = "NotAcquired"
             feed = "octopus-server-built-in"
             package_id = "octopus-cli"
             properties = {


### PR DESCRIPTION
Don't use `Octopus.Release.Number` for the Winget push as it means if there is an error deploying the release we can't easily create a new release to try again and need to delete the old release first.

This brings it inline with the other external repositories we are deploying the CLI to