### PR TITLE
fix: set default worker pool correctly on azure web app target create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.103.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.108.0
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -46,10 +46,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.99.0 h1:0HzgNBPiOGY7ekP+uoRbX1DeMs0Y2JpJ3ecmUxFtC1o=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.99.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.103.0 h1:yGQxxqm3lXgEFITtdhXC7FQPufTwdPgy0+aXMKw4uOw=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.103.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.108.0 h1:hUnkq49u3gRiZSisRF9L86gPygKK4qS9LMoO5ADTGKI=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.108.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
 github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=

--- a/pkg/cmd/target/azure-web-app/create/create.go
+++ b/pkg/cmd/target/azure-web-app/create/create.go
@@ -159,6 +159,14 @@ func createRun(opts *CreateOptions) error {
 	endpoint.WebAppName = opts.WebApp.Value
 	endpoint.ResourceGroupName = opts.ResourceGroup.Value
 	endpoint.WebAppSlotName = opts.Slot.Value
+	if opts.WorkerPool.Value != "" {
+		workerPoolId, err := shared.FindWorkerPoolId(opts.GetAllWorkerPoolsCallback, opts.WorkerPool.Value)
+		if err != nil {
+			return err
+		}
+		endpoint.DefaultWorkerPoolID = workerPoolId
+	}
+
 	deploymentTarget := machines.NewDeploymentTarget(opts.Name.Value, endpoint, environmentIds, util.SliceDistinct(combinedRoles))
 
 	err = shared.ConfigureTenant(deploymentTarget, opts.CreateTargetTenantFlags, opts.CreateTargetTenantOptions)


### PR DESCRIPTION
Fixes #595 

```
octopus deployment-target azure-web-app create --name 'az target 5' --account 'azure fnm sandbox' --web-app 'testappforfd-339' --resource-group 'testappforfd-339_group' --environment 'Dev' --tag 'Default Target Tags/pi' --tenanted-mode 'Untenanted' --no-prompt --worker-pool "second" -s Default
Successfully created Azure web app 'az target 5'.
View this Azure web app on Octopus Deploy: http://localhost:8066/app#/Spaces-1/infrastructure/machines/Machines-406/settings
```

<img width="696" height="693" alt="image" src="https://github.com/user-attachments/assets/682f10a4-318a-4039-bc66-61533e338f74" />
