### PR TITLE
Fix: interactive runbook snapshot create drops --package overrides

### DIFF
--- a/pkg/cmd/runbook/snapshot/create/create.go
+++ b/pkg/cmd/runbook/snapshot/create/create.go
@@ -68,7 +68,6 @@ func NewCreateFlags() *CreateFlags {
 
 type CreateOptions struct {
 	*CreateFlags
-	PackageVersionOverrides []string
 	*shared.RunbooksOptions
 	GetAllProjectsCallback shared.GetAllProjectsCallback
 	*cmd.Dependencies
@@ -351,7 +350,7 @@ func PromptMissing(opts *CreateOptions) error {
 		_, packageVersionOverrides, err := packages.AskPackageOverrideLoop(
 			packageVersionBaseline,
 			opts.PackageVersion.Value,
-			opts.PackageVersionOverrides,
+			opts.PackageVersionSpec.Value,
 			opts.Ask,
 			opts.Out)
 
@@ -360,9 +359,9 @@ func PromptMissing(opts *CreateOptions) error {
 		}
 
 		if len(packageVersionOverrides) > 0 {
-			opts.PackageVersionOverrides = make([]string, 0, len(packageVersionOverrides))
+			opts.PackageVersionSpec.Value = make([]string, 0, len(packageVersionOverrides))
 			for _, ov := range packageVersionOverrides {
-				opts.PackageVersionOverrides = append(opts.PackageVersionOverrides, ov.ToPackageOverrideString())
+				opts.PackageVersionSpec.Value = append(opts.PackageVersionSpec.Value, ov.ToPackageOverrideString())
 			}
 		}
 	}


### PR DESCRIPTION
## What

Fixes a pre-existing bug where `octopus runbook snapshot create` in interactive mode silently drops package version overrides typed at the wizard's package prompt.

## Symptom

Running `octopus runbook snapshot create --project=X --runbook=Y` interactively:

1. CLI shows the package table with baseline versions
2. User types an override at the `Package override string` prompt
3. CLI's local table updates and shows the new version — user thinks the override took effect
4. User presses `y` to accept
5. Snapshot is created on the server with the **baseline** versions, **not** the typed overrides

No error, no warning, exit code 0. The user only discovers the silent drop by inspecting the snapshot afterwards.

## Root cause

In `pkg/cmd/runbook/snapshot/create/create.go`:

- The non-interactive build loop reads from `opts.PackageVersionSpec.Value` (line 178)
- The interactive `AskPackageOverrideLoop` was writing its resolved results to `opts.PackageVersionOverrides` — a **separate field** on `CreateOptions` that is never read by the build phase and never seeded from `PackageVersionSpec`

So overrides typed interactively flowed into a dead-end field. Compare with the git-resource block in the same file (`opts.GitResourceRefsSpec.Value` is read at build time and written by the interactive loop — same field, no bug). Compare with `release create` which initialises `options.PackageVersionOverrides = flags.PackageVersionSpec.Value` and uses one field consistently.

## Fix

Remove the duplicate `PackageVersionOverrides` field from `CreateOptions` and use `opts.PackageVersionSpec.Value` throughout — matching the git-resource pattern in the same file. Three lines change.

## Scope

This bug is **not** related to FD-135 — verified by diffing the affected code against `v2.19.1`, where the bug is identical. Splitting it out so cli#584 stays focused on the escape-syntax change.

## Test plan

- [ ] Manual: interactive `runbook snapshot create` with an override, verify resulting snapshot has the typed version (not baseline) via API
- [ ] Manual: non-interactive `runbook snapshot create --package ... --no-prompt` still works (regression check on the path that already worked)

No unit-test addition — `pkg/cmd/runbook/snapshot/create/` has no existing test file and adding the mock infrastructure for `IClient`, `Asker`, etc. is significant scope beyond the fix.