### PR TITLE
Preserve --variable values through interactive runbook run

### DIFF
--- a/pkg/cmd/runbook/run/preview_variables_test.go
+++ b/pkg/cmd/runbook/run/preview_variables_test.go
@@ -1,0 +1,108 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func noPromptAsker(t *testing.T) question.Asker {
+	t.Helper()
+	return func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+		t.Fatalf("unexpected prompt: %T %#v", p, p)
+		return nil
+	}
+}
+
+func cannedAsker(answer interface{}) question.Asker {
+	return func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+		return core.WriteAnswer(response, "", answer)
+	}
+}
+
+// Regression test for issue #582: command-line --variable values that don't
+// match a runbook form preview control were being silently dropped in
+// interactive mode, causing the run to fall back to default values.
+func TestResolveRunbookPreviewVariables_PreservesCmdVarWithoutMatchingControl(t *testing.T) {
+	controls := map[string]*deployments.Control{}
+	values := map[string]string{}
+	cmdVars := map[string]string{
+		"Approver": "John",
+		"Signoff":  "Jane",
+	}
+
+	result, sensitive, err := resolveRunbookPreviewVariables(noPromptAsker(t), controls, values, cmdVars)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Approver": "John", "Signoff": "Jane"}, result)
+	assert.Empty(t, sensitive)
+}
+
+func TestResolveRunbookPreviewVariables_CanonicalisesCasingForMatchedControl(t *testing.T) {
+	approver := deployments.NewControl("VariableValue", "Approver", "", "", false, &resources.DisplaySettings{})
+	controls := map[string]*deployments.Control{"elem-1": approver}
+	values := map[string]string{"elem-1": ""}
+	cmdVars := map[string]string{"APPROVER": "John"}
+
+	result, _, err := resolveRunbookPreviewVariables(noPromptAsker(t), controls, values, cmdVars)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Approver": "John"}, result)
+}
+
+func TestResolveRunbookPreviewVariables_DoesNotPromptWhenCmdVarSuppliedForRequiredControl(t *testing.T) {
+	approver := deployments.NewControl("VariableValue", "Approver", "", "", true, &resources.DisplaySettings{})
+	controls := map[string]*deployments.Control{"elem-1": approver}
+	values := map[string]string{"elem-1": ""}
+	cmdVars := map[string]string{"Approver": "John"}
+
+	result, _, err := resolveRunbookPreviewVariables(noPromptAsker(t), controls, values, cmdVars)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Approver": "John"}, result)
+}
+
+func TestResolveRunbookPreviewVariables_TracksSensitiveControl(t *testing.T) {
+	token := deployments.NewControl("VariableValue", "Token", "", "", true, resources.NewDisplaySettings(resources.ControlTypeSensitive, nil))
+	controls := map[string]*deployments.Control{"elem-1": token}
+	values := map[string]string{"elem-1": ""}
+	cmdVars := map[string]string{"Token": "secret"}
+
+	result, sensitive, err := resolveRunbookPreviewVariables(noPromptAsker(t), controls, values, cmdVars)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Token": "secret"}, result)
+	assert.Equal(t, []string{"Token"}, sensitive)
+}
+
+func TestResolveRunbookPreviewVariables_PromptsForRequiredControlWithoutCmdVar(t *testing.T) {
+	approver := deployments.NewControl("VariableValue", "Approver", "", "", true, &resources.DisplaySettings{})
+	controls := map[string]*deployments.Control{"elem-1": approver}
+	values := map[string]string{"elem-1": ""}
+	cmdVars := map[string]string{}
+
+	result, _, err := resolveRunbookPreviewVariables(cannedAsker("John"), controls, values, cmdVars)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Approver": "John"}, result)
+}
+
+func TestResolveRunbookPreviewVariables_PreservesUnmatchedAndCanonicalisesMatched(t *testing.T) {
+	approver := deployments.NewControl("VariableValue", "Approver", "", "", false, &resources.DisplaySettings{})
+	controls := map[string]*deployments.Control{"elem-1": approver}
+	values := map[string]string{"elem-1": ""}
+	cmdVars := map[string]string{
+		"ApprOVER": "John",
+		"extra":    "passthrough",
+	}
+
+	result, _, err := resolveRunbookPreviewVariables(noPromptAsker(t), controls, values, cmdVars)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Approver": "John", "extra": "passthrough"}, result)
+}

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -1076,8 +1076,24 @@ func askRunbookPreviewVariables(
 		}
 	}
 
-	// Process variables from command line and prompts
-	result := make(map[string]string)
+	return resolveRunbookPreviewVariables(asker, flattenedControls, flattenedValues, variablesFromCmd)
+}
+
+// resolveRunbookPreviewVariables merges command-line --variable values with the
+// runbook form preview, prompting for any required prompted variables not
+// supplied on the command line. Command-line variables that don't match a
+// preview control are passed through unchanged (issue #582).
+func resolveRunbookPreviewVariables(
+	asker question.Asker,
+	flattenedControls map[string]*deployments.Control,
+	flattenedValues map[string]string,
+	variablesFromCmd map[string]string,
+) (map[string]string, []string, error) {
+	result := make(map[string]string, len(variablesFromCmd))
+	for k, v := range variablesFromCmd {
+		result[k] = v
+	}
+
 	lcaseVarsFromCmd := make(map[string]string, len(variablesFromCmd))
 	for k, v := range variablesFromCmd {
 		lcaseVarsFromCmd[strings.ToLower(k)] = v
@@ -1087,15 +1103,20 @@ func askRunbookPreviewVariables(
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i] > keys[j]
 	})
-
-	// Track sensitive variables
+    // Track sensitive variables
 	sensitiveVars := make([]string, 0)
 
 	for _, key := range keys {
 		control := flattenedControls[key]
 		valueFromCmd, foundValueOnCommandLine := lcaseVarsFromCmd[strings.ToLower(control.Name)]
 		if foundValueOnCommandLine {
-			// implicitly fixes up variable casing
+			// Canonicalise to control.Name when the CLI used a different casing,
+			// so we don't end up with both spellings in the result map.
+			for k := range result {
+				if k != control.Name && strings.EqualFold(k, control.Name) {
+					delete(result, k)
+				}
+			}
 			result[control.Name] = valueFromCmd
 		}
 		if control.Required == true && !foundValueOnCommandLine {
@@ -1114,8 +1135,8 @@ func askRunbookPreviewVariables(
 			result[control.Name] = responseString
 		}
 
-		// Track sensitive variables from the preview
 		if control.DisplaySettings.ControlType == "Sensitive" {
+			// Track sensitive variables from the preview
 			sensitiveVars = append(sensitiveVars, control.Name)
 		}
 	}


### PR DESCRIPTION
Closes #582.

## The bug

`octopus runbook run -v Name:Value` silently drops the variables in interactive mode — both from the printed `Automation Command` and from the actual run, which falls back to default values. `--no-prompt` was the workaround.

Repro from #582:

```
octopus runbook run -p "New Project" -n "Runbook" -s "Kenny" -v "certCommonName:CLI" -v "prompt:CLI" -e "Development"
```

The `Automation Command` comes back missing both `-v` values:

```
Automation Command: octopus runbook run --project 'New Project' --name 'Runbook' --environment 'Development' --no-prompt
```

## cause

__The result map was rebuilt from the controls, not from the caller's inputs.__ Inside `askRunbookPreviewVariables` (`pkg/cmd/runbook/run/run.go`), the `result` map was built fresh by iterating the form preview's `flattenedControls`, only adding entries for controls. Any CLI-supplied variable without a matching control was discarded. The caller then overwrote `options.Variables` with this stripped map.

`--no-prompt` skips this codepath entirely — that's why the workaround works.

## Fix

Extract the variable-resolution into a pure helper `resolveRunbookPreviewVariables`, and seed the result map with the caller's CLI variables _before_ processing controls. Variables matching a control are still canonicalised to the control's name (existing case-fixing behaviour preserved); variables without a matching control pass through unchanged.

## Tests

New `pkg/cmd/runbook/run/preview_variables_test.go` (internal `package run`) with 6 unit tests: passthrough (the fix), casing canonicalisation, no-prompt-when-supplied, sensitive tracking, prompt-fires-for-missing-required, and a combination case.

## Tests

- [x] CI passes `go test ./pkg/cmd/runbook/run/...`
- [x] Manual repro from #582 . `-v` values are in both the `Automation Command` and the actual run.
