### PR TITLE
Fix: allow completion command to run without an Octopus login

### DIFF
--- a/cmd/octopus/main.go
+++ b/cmd/octopus/main.go
@@ -96,5 +96,5 @@ func commandDoesNotRequireClient(args []string) bool {
 		return true
 	}
 	cmdToRun := args[0]
-	return cmdToRun == "config" || cmdToRun == "version" || cmdToRun == "--version" || cmdToRun == "-v" || cmdToRun == "help" || cmdToRun == "login" || cmdToRun == "logout" || (cmdToRun == "package" && util.SliceContains(args, "create"))
+	return cmdToRun == "config" || cmdToRun == "version" || cmdToRun == "--version" || cmdToRun == "-v" || cmdToRun == "help" || cmdToRun == "login" || cmdToRun == "logout" || cmdToRun == "completion" || cmdToRun == "__complete" || cmdToRun == "__completeNoDesc" || (cmdToRun == "package" && util.SliceContains(args, "create"))
 }

--- a/cmd/octopus/main_test.go
+++ b/cmd/octopus/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandDoesNotRequireClient_CompletionCommandsDoNotRequireClient(t *testing.T) {
+	cases := [][]string{
+		{"completion"},
+		{"completion", "powershell"},
+		{"completion", "bash"},
+		{"__complete", "completion", "powershell", ""},
+		{"__completeNoDesc", "release", "list", ""},
+	}
+
+	for _, args := range cases {
+		assert.True(t, commandDoesNotRequireClient(args), "expected %v to not require a client", args)
+	}
+}
+
+func TestCommandDoesNotRequireClient_ServerCommandsRequireClient(t *testing.T) {
+	cases := [][]string{
+		{"release", "list"},
+		{"deployment", "create"},
+		{"package", "list"},
+	}
+
+	for _, args := range cases {
+		assert.False(t, commandDoesNotRequireClient(args), "expected %v to require a client", args)
+	}
+}


### PR DESCRIPTION
# Background

`octopus completion <shell>` is a local Cobra command that prints a shell completion script; it never contacts the server. But `commandDoesNotRequireClient` in `cmd/octopus/main.go` doesn't include it, so when the user hasn't run `octopus login` the client factory fails to build and the CLI exits with code 3, printing the config banner to stdout instead of the script. Piping that into `Invoke-Expression` then fails with `The term 'Work' is not recognized`. The same gap hits Cobra's hidden `__complete`/`__completeNoDesc` helpers, which the shell calls on every Tab press — so completions stay broken when not logged in even after installing them.

# Results

Adds `completion`, `__complete`, and `__completeNoDesc` to `commandDoesNotRequireClient` so completion works without a login.

Fixes FD-555
Fixes https://github.com/OctopusDeploy/cli/issues/611

## Before

Not logged in:

    $ octopus completion powershell
    Work seamlessly with Octopus Deploy from the command line.
    ... (banner) ...
    # exit code 3, nothing on stderr

`octopus completion powershell | Out-String | Invoke-Expression` → `The term 'Work' is not recognized`.

## After

Not logged in:

    $ octopus completion powershell
    # powershell completion for octopus ...
    Register-ArgumentCompleter -CommandName 'octopus' -ScriptBlock $__octopusCompleterBlock
    # exit code 0

`octopus __complete ""` also returns the command list (exit 0) instead of failing.

# Testing

- Added a unit test covering the completion commands in `commandDoesNotRequireClient`.
- Manually verified against a build: unauthenticated `completion powershell` and `__complete` now exit 0; the `... | Out-String | Invoke-Expression` command runs clean.

> Note: this fixes the not-logged-in failure only. A separate report that tab-completion doesn't fire in Windows PowerShell 5.1 (when logged in) is not addressed here.