### PR TITLE
fix: emit valid JSON from package create commands

### DIFF
--- a/pkg/cmd/package/nuget/create/create.go
+++ b/pkg/cmd/package/nuget/create/create.go
@@ -152,15 +152,7 @@ func createRun(cmd *cobra.Command, opts *NuPkgCreateOptions) error {
 
 	nuget, err := pack.BuildPackage(opts.PackageCreateOptions, outFilePath)
 	if nuget != nil {
-		switch outputFormat {
-		case constants.OutputFormatBasic:
-			cmd.Printf("%s\n", nuget.Name())
-		case constants.OutputFormatJson:
-			cmd.Printf(`{"Path":"%s"}`, nuget.Name())
-			cmd.Println()
-		default: // table
-			cmd.Printf("Successfully created package %s\n", nuget.Name())
-		}
+		pack.PrintPackageCreated(cmd, outputFormat, nuget.Name())
 	}
 	return err
 }

--- a/pkg/cmd/package/support/pack.go
+++ b/pkg/cmd/package/support/pack.go
@@ -2,9 +2,11 @@ package support
 
 import (
 	"archive/zip"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/util"
@@ -153,6 +155,27 @@ func PackageCreatePromptMissing(opts *PackageCreateOptions) error {
 func VerboseOut(out io.Writer, isVerbose bool, messageTemplate string, messageArgs ...any) {
 	if isVerbose {
 		fmt.Fprintf(out, messageTemplate, messageArgs...)
+	}
+}
+
+// PackageCreatedOutput is the JSON shape written after a package is created.
+type PackageCreatedOutput struct {
+	Path string
+}
+
+// PrintPackageCreated writes the path of a newly created package in the
+// requested output format. The JSON form is marshalled rather than assembled by
+// hand so that paths containing backslashes, such as Windows paths, are escaped
+// correctly and the output remains parseable.
+func PrintPackageCreated(cmd *cobra.Command, outputFormat string, path string) {
+	switch outputFormat {
+	case constants.OutputFormatBasic:
+		cmd.Printf("%s\n", path)
+	case constants.OutputFormatJson:
+		data, _ := json.Marshal(PackageCreatedOutput{Path: path})
+		cmd.Println(string(data))
+	default: // table
+		cmd.Printf("Successfully created package %s\n", path)
 	}
 }
 

--- a/pkg/cmd/package/support/pack_test.go
+++ b/pkg/cmd/package/support/pack_test.go
@@ -33,10 +33,13 @@ func TestPrintPackageCreated_JsonEscapesBackslashes(t *testing.T) {
 
 	// The output must be legal JSON; previously the path was interpolated
 	// directly into a string literal, leaving raw backslashes behind.
+	assert.Equal(t, `{"Path":"c:\\temp\\test.package.0.0.1.zip"}`+"\n", output)
+
+	// And it must parse back to the path we were given, not a mangled one:
+	// unescaped, the \t above would have been read as a tab.
 	var result PackageCreatedOutput
 	assert.NoError(t, json.Unmarshal([]byte(output), &result))
 	assert.Equal(t, windowsPackagePath, result.Path)
-	assert.Contains(t, output, `c:\\temp\\test.package.0.0.1.zip`)
 }
 
 func TestPrintPackageCreated_BasicIsUnescaped(t *testing.T) {

--- a/pkg/cmd/package/support/pack_test.go
+++ b/pkg/cmd/package/support/pack_test.go
@@ -2,9 +2,12 @@ package support
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"github.com/OctopusDeploy/cli/pkg/constants"
 	flag "github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
@@ -12,6 +15,41 @@ import (
 	"testing"
 	"time"
 )
+
+const windowsPackagePath = `c:\temp\test.package.0.0.1.zip`
+
+func capturePrintPackageCreated(outputFormat string, path string) string {
+	buf := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetOut(buf)
+
+	PrintPackageCreated(cmd, outputFormat, path)
+
+	return buf.String()
+}
+
+func TestPrintPackageCreated_JsonEscapesBackslashes(t *testing.T) {
+	output := capturePrintPackageCreated(constants.OutputFormatJson, windowsPackagePath)
+
+	// The output must be legal JSON; previously the path was interpolated
+	// directly into a string literal, leaving raw backslashes behind.
+	var result PackageCreatedOutput
+	assert.NoError(t, json.Unmarshal([]byte(output), &result))
+	assert.Equal(t, windowsPackagePath, result.Path)
+	assert.Contains(t, output, `c:\\temp\\test.package.0.0.1.zip`)
+}
+
+func TestPrintPackageCreated_BasicIsUnescaped(t *testing.T) {
+	output := capturePrintPackageCreated(constants.OutputFormatBasic, windowsPackagePath)
+
+	assert.Equal(t, windowsPackagePath+"\n", output)
+}
+
+func TestPrintPackageCreated_TableIsUnescaped(t *testing.T) {
+	output := capturePrintPackageCreated(constants.OutputFormatTable, windowsPackagePath)
+
+	assert.Equal(t, "Successfully created package "+windowsPackagePath+"\n", output)
+}
 
 func TestVerboseOut_WithVerboseEnabled(t *testing.T) {
 	result := testutil.CaptureConsoleOutput(func() {

--- a/pkg/cmd/package/zip/create/create.go
+++ b/pkg/cmd/package/zip/create/create.go
@@ -79,15 +79,7 @@ func createRun(cmd *cobra.Command, opts *pack.PackageCreateOptions) error {
 
 	zip, err := pack.BuildPackage(opts, outFilePath)
 	if zip != nil {
-		switch outputFormat {
-		case constants.OutputFormatBasic:
-			cmd.Printf("%s\n", zip.Name())
-		case constants.OutputFormatJson:
-			cmd.Printf(`{"Path":"%s"}`, zip.Name())
-			cmd.Println()
-		default: // table
-			cmd.Printf("Successfully created package %s\n", zip.Name())
-		}
+		pack.PrintPackageCreated(cmd, outputFormat, zip.Name())
 	}
 	return err
 }


### PR DESCRIPTION
Fixes #518

## Problem

`package zip create` and `package nuget create` built their JSON output with a `Printf` format string:

```go
cmd.Printf(`{"Path":"%s"}`, zip.Name())
```

Any backslash in the path was written through unescaped. On Windows that produces output which is not legal JSON, and which corrupts the path when parsed — `\t` becomes a tab:

```
{"Path":"c:\temp\test.package.0.0.1.zip"}
```

## Change

Marshal with `encoding/json` instead. Both commands now go through a single `pack.PrintPackageCreated` helper — the duplicated inline formatting is precisely what let the same bug exist in two places.

Basic and table output are unchanged.

## Verification

Unit tests assert the JSON round-trips and that basic/table stay unescaped. End-to-end against a directory containing a backslash:

```
$ octopus package zip create ... --output-format json
{"Path":".../packtest/we\\ird/test.package.0.0.1.zip"}

$ python3 -c "import json; print(json.load(open('out.json'))['Path'])"
.../packtest/we\ird/test.package.0.0.1.zip
```

Previously this failed to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)