### PR TITLE
test: cover empty tag sets when prompting for tenant tags

### DIFF
--- a/pkg/question/selectors/tags_test.go
+++ b/pkg/question/selectors/tags_test.go
@@ -214,3 +214,67 @@ func TestValidateTags_NewTagInExistingTagSet(t *testing.T) {
 
 	assert.Nil(t, err)
 }
+
+// A tag set with no tags in it has nothing to offer, so it must not raise a
+// prompt. Presenting a selector with no options fails with "please provide
+// options to select from", which used to abort `tenant create` on any space
+// that had no usable tag sets. An empty prompt-assertion list means the mock
+// asker fails the test if Tags asks anything at all.
+func TestTags_NoTagSetsDoesNotPrompt(t *testing.T) {
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, []*testutil.PA{})
+
+	result, err := Tags(asker, []string{}, []string{}, []*tagsets.TagSet{})
+
+	checkRemainingPrompts()
+	assert.Nil(t, err)
+	assert.Empty(t, result)
+}
+
+func TestTags_EmptySingleSelectTagSetDoesNotPrompt(t *testing.T) {
+	emptyTagSet := tagsets.NewTagSet("Region")
+	emptyTagSet.Type = tagsets.TagSetTypeSingleSelect
+
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, []*testutil.PA{})
+
+	result, err := Tags(asker, []string{}, []string{}, []*tagsets.TagSet{emptyTagSet})
+
+	checkRemainingPrompts()
+	assert.Nil(t, err)
+	assert.Empty(t, result)
+}
+
+func TestTags_EmptyMultiSelectTagSetDoesNotPrompt(t *testing.T) {
+	emptyTagSet := tagsets.NewTagSet("Environment Type")
+	emptyTagSet.Type = tagsets.TagSetTypeMultiSelect
+
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, []*testutil.PA{})
+
+	result, err := Tags(asker, []string{}, []string{}, []*tagsets.TagSet{emptyTagSet})
+
+	checkRemainingPrompts()
+	assert.Nil(t, err)
+	assert.Empty(t, result)
+}
+
+// An empty tag set alongside a populated one must be skipped without
+// disturbing the prompt for the populated one.
+func TestTags_EmptyTagSetSkippedAlongsidePopulatedTagSet(t *testing.T) {
+	emptyTagSet := tagsets.NewTagSet("Unused")
+	emptyTagSet.Type = tagsets.TagSetTypeSingleSelect
+
+	regionTagSet := tagsets.NewTagSet("Region")
+	regionTagSet.Type = tagsets.TagSetTypeSingleSelect
+	regionTagSet.Tags = []*tagsets.Tag{tagsets.NewTag("US East", "#000000")}
+	regionTagSet.Tags[0].CanonicalTagName = "Region/US East"
+
+	pa := []*testutil.PA{
+		testutil.NewSelectPromptWithDefault("Region (Single Select)", "", []string{"(None)", "Region/US East"}, "(None)", "Region/US East"),
+	}
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
+
+	result, err := Tags(asker, []string{}, []string{}, []*tagsets.TagSet{emptyTagSet, regionTagSet})
+
+	checkRemainingPrompts()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"Region/US East"}, result)
+}


### PR DESCRIPTION
Fixes #529

Adding tests **only**

The reported bug is **already fixed**, incidentally, and this adds only the missing regression coverage. Close #529 without merging if you'd rather not carry the tests.

## What was actually wrong

`tenant create` failed interactively with `please provide options to select from` on any space without usable tag sets. The old `AskTags` helper in `pkg/cmd/tenant/create/create.go` flattened every tag set into one list and **always** raised a `survey.MultiSelect`:

```go
canonicalTagName := []string{}
for _, tagSet := range tagSets {
    for _, tag := range tagSet.Tags {
        canonicalTagName = append(canonicalTagName, tag.CanonicalTagName)
    }
}
err = ask(&survey.MultiSelect{Options: canonicalTagName, ...}, &tags)
```

With no tag sets — or only empty ones — `Options` is empty and `surveyext/select.go` rejects it.

## Why it no longer reproduces

#548 (*feat: Extend tag sets and add environment tags*, Nov 2025) replaced `AskTags` with `selectors.Tags`, which iterates each tag set and skips the empty ones. That landed **after** the versions in the report (2.15.7 and 2.18.0), so the fix has been shipping since ~2.19.0.


🤖 Generated with [Claude Code](https://claude.com/claude-code)