### PR TITLE
feat: add --exclude to package create commands

### DIFF
--- a/pkg/cmd/package/nuget/create/create.go
+++ b/pkg/cmd/package/nuget/create/create.go
@@ -76,6 +76,7 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 	flags.StringVar(&packFlags.BasePath.Value, packFlags.BasePath.Name, "", "Root folder containing the contents to zip.")
 	flags.StringVar(&packFlags.OutFolder.Value, packFlags.OutFolder.Name, "", "Folder into which the zip file will be written.")
 	flags.StringSliceVar(&packFlags.Include.Value, packFlags.Include.Name, []string{}, "Add a file pattern to include, relative to the base path e.g. /bin/*.dll; defaults to \"**\".")
+	flags.StringSliceVar(&packFlags.Exclude.Value, packFlags.Exclude.Name, []string{}, "Add a file pattern to exclude, relative to the base path e.g. **/*.config; applied after --include.")
 	flags.BoolVar(&packFlags.Verbose.Value, packFlags.Verbose.Name, false, "Verbose output.")
 	flags.BoolVar(&packFlags.Overwrite.Value, packFlags.Overwrite.Name, false, "Allow an existing package file of the same ID/version to be overwritten.")
 	flags.StringSliceVar(&createFlags.Author.Value, createFlags.Author.Name, []string{}, "Add author/s to the package metadata.")
@@ -144,6 +145,7 @@ func createRun(cmd *cobra.Command, opts *NuPkgCreateOptions) error {
 			opts.BasePath,
 			opts.OutFolder,
 			opts.Include,
+			opts.Exclude,
 			opts.Verbose,
 			opts.Overwrite,
 		)

--- a/pkg/cmd/package/support/pack.go
+++ b/pkg/cmd/package/support/pack.go
@@ -24,6 +24,7 @@ const (
 	FlagBasePath  = "base-path"
 	FlagOutFolder = "out-folder"
 	FlagInclude   = "include"
+	FlagExclude   = "exclude"
 	FlagVerbose   = "verbose"
 	FlagOverwrite = "overwrite"
 )
@@ -34,6 +35,7 @@ type PackageCreateFlags struct {
 	BasePath  *flag.Flag[string]
 	OutFolder *flag.Flag[string]
 	Include   *flag.Flag[[]string]
+	Exclude   *flag.Flag[[]string]
 	Verbose   *flag.Flag[bool]
 	Overwrite *flag.Flag[bool]
 }
@@ -53,6 +55,7 @@ func NewPackageCreateFlags() *PackageCreateFlags {
 		BasePath:  flag.New[string](FlagBasePath, false),
 		OutFolder: flag.New[string](FlagOutFolder, false),
 		Include:   flag.New[[]string](FlagInclude, false),
+		Exclude:   flag.New[[]string](FlagExclude, false),
 		Verbose:   flag.New[bool](FlagVerbose, false),
 		Overwrite: flag.New[bool](FlagOverwrite, false),
 	}
@@ -127,6 +130,22 @@ func PackageCreatePromptMissing(opts *PackageCreateOptions) error {
 		}
 	}
 
+	if len(opts.Exclude.Value) == 0 {
+		for {
+			var pattern string
+			if err := opts.Ask(&survey.Input{
+				Message: "Exclude patterns",
+				Help:    "Add a file pattern to exclude, relative to the base path e.g. **/*.config; leave blank to exclude nothing.",
+			}, &pattern); err != nil {
+				return err
+			}
+			if pattern == "" {
+				break
+			}
+			opts.Exclude.Value = append(opts.Exclude.Value, pattern)
+		}
+	}
+
 	if !opts.Verbose.Value {
 		err := opts.Ask(&survey.Confirm{
 			Message: "Verbose",
@@ -178,8 +197,11 @@ func BuildPackage(opts *PackageCreateOptions, outFileName string) (*os.File, err
 	}
 
 	VerboseOut(opts.Writer, opts.Verbose.Value, "Saving \"%s\" to \"%s\"...\nAdding files from \"%s\" matching pattern/s \"%s\"\n", outFileName, outPath, opts.BasePath.Value, strings.Join(opts.Include.Value, ", "))
+	if len(opts.Exclude.Value) > 0 {
+		VerboseOut(opts.Writer, opts.Verbose.Value, "Excluding files matching pattern/s \"%s\"\n", strings.Join(opts.Exclude.Value, ", "))
+	}
 
-	filePaths, err := getDistinctPatternMatches(opts.BasePath.Value, opts.Include.Value)
+	filePaths, err := getDistinctPatternMatches(opts.BasePath.Value, opts.Include.Value, opts.Exclude.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -254,11 +276,11 @@ func buildArchive(out io.Writer, outFilePath string, basePath string, filesToArc
 	return zipFile, nil
 }
 
-func getDistinctPatternMatches(basePath string, patterns []string) ([]string, error) {
+func getDistinctPatternMatches(basePath string, includePatterns []string, excludePatterns []string) ([]string, error) {
 	fileSys := os.DirFS(filepath.Clean(basePath))
 	var filePaths []string
 
-	for _, pattern := range patterns {
+	for _, pattern := range includePatterns {
 		paths, err := doublestar.Glob(fileSys, filepath.ToSlash(pattern))
 		if err != nil {
 			return nil, err
@@ -266,5 +288,52 @@ func getDistinctPatternMatches(basePath string, patterns []string) ([]string, er
 		filePaths = append(filePaths, paths...)
 	}
 
-	return util.SliceDistinct(filePaths), nil
+	filePaths = util.SliceDistinct(filePaths)
+
+	if len(excludePatterns) == 0 {
+		return filePaths, nil
+	}
+
+	var keptPaths []string
+	for _, path := range filePaths {
+		excluded, err := matchesAnyPattern(path, excludePatterns)
+		if err != nil {
+			return nil, err
+		}
+		if !excluded {
+			keptPaths = append(keptPaths, path)
+		}
+	}
+
+	return keptPaths, nil
+}
+
+// matchesAnyPattern reports whether path matches any of the supplied glob
+// patterns. A directory matches when the pattern targets its contents (e.g.
+// "AppData/**" excludes the AppData directory as well as everything inside it)
+// so that excluded directories are not added to the archive as empty entries.
+func matchesAnyPattern(path string, patterns []string) (bool, error) {
+	for _, pattern := range patterns {
+		pattern = filepath.ToSlash(pattern)
+
+		matched, err := doublestar.Match(pattern, path)
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
+		}
+
+		if directoryPrefix, found := strings.CutSuffix(pattern, "/**"); found {
+			matched, err = doublestar.Match(directoryPrefix, path)
+			if err != nil {
+				return false, err
+			}
+			if matched {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/cmd/package/support/pack_test.go
+++ b/pkg/cmd/package/support/pack_test.go
@@ -70,6 +70,101 @@ func cleanUpTemp(tempDir string) {
 	}
 }
 
+func setupForExclude(t *testing.T) string {
+	dir := filepath.ToSlash(t.TempDir())
+	for _, relativePath := range []string{
+		"test.txt",
+		"app.config",
+		"sub/nested.config",
+		"sub/keep.dll",
+		"AppData/data.bin",
+		"AppData/deep/more.bin",
+		"conf/settings.local.env",
+	} {
+		fullPath := filepath.Join(dir, relativePath)
+		assert.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		assert.NoError(t, os.WriteFile(fullPath, []byte("x"), 0644))
+	}
+
+	return dir
+}
+
+func TestGetDistinctPatternMatches_NoExcludeKeepsEverything(t *testing.T) {
+	basePath := setupForExclude(t)
+
+	result, err := getDistinctPatternMatches(basePath, []string{"**"}, nil)
+
+	assert.NoError(t, err)
+	assert.Contains(t, result, "app.config")
+	assert.Contains(t, result, "sub/nested.config")
+	assert.Contains(t, result, "AppData/data.bin")
+	assert.Contains(t, result, "conf/settings.local.env")
+}
+
+// The three scenarios called out in the original request for --exclude.
+func TestGetDistinctPatternMatches_ExcludeByExtension(t *testing.T) {
+	basePath := setupForExclude(t)
+
+	result, err := getDistinctPatternMatches(basePath, []string{"**"}, []string{"**/*.config"})
+
+	assert.NoError(t, err)
+	// matched at the root as well as in a subdirectory
+	assert.NotContains(t, result, "app.config")
+	assert.NotContains(t, result, "sub/nested.config")
+	assert.Contains(t, result, "sub/keep.dll")
+	assert.Contains(t, result, "test.txt")
+}
+
+func TestGetDistinctPatternMatches_ExcludeDirectoryAndContents(t *testing.T) {
+	basePath := setupForExclude(t)
+
+	result, err := getDistinctPatternMatches(basePath, []string{"**"}, []string{"AppData/**"})
+
+	assert.NoError(t, err)
+	// the directory entries go too, otherwise they are archived as empty folders
+	assert.NotContains(t, result, "AppData")
+	assert.NotContains(t, result, "AppData/deep")
+	assert.NotContains(t, result, "AppData/data.bin")
+	assert.NotContains(t, result, "AppData/deep/more.bin")
+	assert.Contains(t, result, "test.txt")
+}
+
+func TestGetDistinctPatternMatches_ExcludeCompoundExtension(t *testing.T) {
+	basePath := setupForExclude(t)
+
+	result, err := getDistinctPatternMatches(basePath, []string{"**"}, []string{"**/*.local.env"})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, result, "conf/settings.local.env")
+	assert.Contains(t, result, "conf")
+	assert.Contains(t, result, "test.txt")
+}
+
+func TestGetDistinctPatternMatches_MultipleExcludePatterns(t *testing.T) {
+	basePath := setupForExclude(t)
+
+	result, err := getDistinctPatternMatches(basePath, []string{"**"}, []string{"**/*.config", "AppData/**"})
+
+	assert.NoError(t, err)
+	assert.NotContains(t, result, "app.config")
+	assert.NotContains(t, result, "sub/nested.config")
+	assert.NotContains(t, result, "AppData/data.bin")
+	assert.Contains(t, result, "sub/keep.dll")
+	assert.Contains(t, result, "conf/settings.local.env")
+}
+
+// --exclude narrows whatever --include selected, rather than widening it.
+func TestGetDistinctPatternMatches_ExcludeAppliesAfterInclude(t *testing.T) {
+	basePath := setupForExclude(t)
+
+	result, err := getDistinctPatternMatches(basePath, []string{"sub/**"}, []string{"**/*.config"})
+
+	assert.NoError(t, err)
+	assert.Contains(t, result, "sub/keep.dll")
+	assert.NotContains(t, result, "sub/nested.config")
+	assert.NotContains(t, result, "test.txt")
+}
+
 func TestBuildPackage_VerboseOutput(t *testing.T) {
 	basePath := setupForArchive(t)
 	if runtime.GOOS == "windows" {
@@ -90,6 +185,7 @@ func TestBuildPackage_VerboseOutput(t *testing.T) {
 			BasePath:  &flag.Flag[string]{Value: basePath},
 			OutFolder: &flag.Flag[string]{Value: outFolder},
 			Include:   &flag.Flag[[]string]{Value: []string{"**"}},
+			Exclude:   &flag.Flag[[]string]{Value: []string{}},
 			Verbose:   &flag.Flag[bool]{Value: true},
 			Overwrite: &flag.Flag[bool]{Value: true},
 		},

--- a/pkg/cmd/package/zip/create/create.go
+++ b/pkg/cmd/package/zip/create/create.go
@@ -35,6 +35,7 @@ func NewCmdCreate(f factory.Factory) *cobra.Command {
 	flags.StringVar(&createFlags.BasePath.Value, createFlags.BasePath.Name, "", "Root folder containing the contents to zip.")
 	flags.StringVar(&createFlags.OutFolder.Value, createFlags.OutFolder.Name, "", "Folder into which the zip file will be written.")
 	flags.StringSliceVar(&createFlags.Include.Value, createFlags.Include.Name, []string{}, "Add a file pattern to include, relative to the base path e.g. /bin/*.dll; defaults to \"**\".")
+	flags.StringSliceVar(&createFlags.Exclude.Value, createFlags.Exclude.Name, []string{}, "Add a file pattern to exclude, relative to the base path e.g. **/*.config; applied after --include.")
 	flags.BoolVar(&createFlags.Verbose.Value, createFlags.Verbose.Name, false, "Verbose output.")
 	flags.BoolVar(&createFlags.Overwrite.Value, createFlags.Overwrite.Name, false, "Allow an existing package file of the same ID/version to be overwritten.")
 	flags.SortFlags = false
@@ -69,6 +70,7 @@ func createRun(cmd *cobra.Command, opts *pack.PackageCreateOptions) error {
 			opts.BasePath,
 			opts.OutFolder,
 			opts.Include,
+			opts.Exclude,
 			opts.Verbose,
 			opts.Overwrite,
 		)


### PR DESCRIPTION
Fixes #214

## Problem

`package zip create` and `package nuget create` could only select files with `--include`. Trimming a handful of files out of an otherwise wholesale `**` meant enumerating every wanted pattern by hand.

## Change

Adds a matching `--exclude`, applied **after** `--include` so it narrows the selected set rather than widening it. Patterns use the same `doublestar` globbing as `--include`.

The three scenarios from the issue all work:

| Pattern | Effect |
|---|---|
| `**/*.config` | removes `app.config` at the root *and* `sub/nested.config` |
| `**/*.local.env` | removes `conf/settings.local.env` |
| `AppData/**` | removes the `AppData` directory and everything under it |

A trailing `/**` also matches the directory itself. Without that, an excluded folder would still be archived as an empty entry, since `doublestar.Glob("**")` returns directory entries as well as files.

## Reviewer note

Interactive mode now prompts for exclude patterns, mirroring the existing include prompt. That's one extra Enter press on every interactive `package zip create`. Happy to drop it and keep the flag automation-only if you'd prefer.

## Verification

Six unit tests over `getDistinctPatternMatches` covering each scenario above, multiple patterns, and exclude-narrows-include. End-to-end:

```
$ octopus package zip create --include '**' \
    --exclude '**/*.config' --exclude 'AppData/**' ...
$ unzip -l exc.test.1.0.0.zip
  keep.txt
  sub/
  sub/keep.dll
```

`app.config`, `sub/nested.config` and all of `AppData/` correctly absent.

Also fixes `TestBuildPackage_VerboseOutput`, which builds `PackageCreateFlags` as a literal rather than via the constructor and so panicked on the new nil field. It's the only place outside `NewPackageCreateFlags` doing that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)