### PR TITLE
fix: stop commands crashing when an optional identifier is omitted

### DIFF
--- a/pkg/cmd/project/branch/list/list.go
+++ b/pkg/cmd/project/branch/list/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	sharedVariable "github.com/OctopusDeploy/cli/pkg/question/shared/variables"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
@@ -73,13 +74,16 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := NewListOptions(listFlags, cmd.NewDependencies(f, c), c)
 
-			if opts.Project.Value == "" {
+			if opts.Project.Value == "" && len(args) > 0 {
 				opts.Project.Value = args[0]
 			}
 
 			if opts.Project.Value == "" {
-				return fmt.Errorf("must supply project identifier")
+				if err := PromptMissing(opts); err != nil {
+					return err
+				}
 			}
+
 			return listRun(opts)
 		},
 	}
@@ -89,6 +93,28 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&listFlags.Project.Value, listFlags.Project.Name, "p", "", "The project")
 
 	return cmd
+}
+
+// PromptMissing selects a project when none was named on the command line. With
+// prompting disabled there is nothing to fall back on, so the identifier is
+// required.
+func PromptMissing(opts *ListOptions) error {
+	if opts.NoPrompt {
+		return fmt.Errorf("must supply project identifier")
+	}
+
+	selectedProject, err := selectors.Select(
+		opts.Ask,
+		"You have not specified a Project. Please select one:",
+		func() ([]*projects.Project, error) { return shared.GetAllProjects(opts.Client) },
+		func(project *projects.Project) string { return project.GetName() })
+	if err != nil {
+		return err
+	}
+
+	opts.Project.Value = selectedProject.GetName()
+
+	return nil
 }
 
 func listRun(opts *ListOptions) error {

--- a/pkg/cmd/project/variables/list/list.go
+++ b/pkg/cmd/project/variables/list/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	sharedVariable "github.com/OctopusDeploy/cli/pkg/question/shared/variables"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
@@ -71,13 +72,16 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 			opts := NewListOptions(listFlags, cmd.NewDependencies(f, c), c)
 
-			if opts.Project.Value == "" {
+			if opts.Project.Value == "" && len(args) > 0 {
 				opts.Project.Value = args[0]
 			}
 
 			if opts.Project.Value == "" {
-				return fmt.Errorf("must supply project identifier")
+				if err := PromptMissing(opts); err != nil {
+					return err
+				}
 			}
+
 			return listRun(opts)
 		},
 	}
@@ -92,6 +96,28 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 type VariableAsJson struct {
 	*variables.Variable
 	Scope variables.VariableScopeValues
+}
+
+// PromptMissing selects a project when none was named on the command line. With
+// prompting disabled there is nothing to fall back on, so the identifier is
+// required.
+func PromptMissing(opts *ListOptions) error {
+	if opts.NoPrompt {
+		return fmt.Errorf("must supply project identifier")
+	}
+
+	selectedProject, err := selectors.Select(
+		opts.Ask,
+		"You have not specified a Project. Please select one:",
+		func() ([]*projects.Project, error) { return shared.GetAllProjects(opts.Client) },
+		func(project *projects.Project) string { return project.GetName() })
+	if err != nil {
+		return err
+	}
+
+	opts.Project.Value = selectedProject.GetName()
+
+	return nil
 }
 
 func listRun(opts *ListOptions) error {

--- a/pkg/cmd/projectgroup/delete/delete.go
+++ b/pkg/cmd/projectgroup/delete/delete.go
@@ -1,6 +1,8 @@
 package delete
 
 import (
+	"fmt"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
 	"github.com/OctopusDeploy/cli/pkg/constants"
@@ -37,11 +39,17 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 				return err
 			}
 
+			// left empty when no argument is supplied, so PromptMissing selects one
+			idOrName := ""
+			if len(args) > 0 {
+				idOrName = args[0]
+			}
+
 			opts := &DeleteOptions{
 				Client:       client,
 				Ask:          f.Ask,
 				NoPrompt:     !f.IsPromptEnabled(),
-				IdOrName:     args[0],
+				IdOrName:     idOrName,
 				ConfirmFlags: confirmFlags,
 			}
 
@@ -59,6 +67,12 @@ func deleteRun(opts *DeleteOptions) error {
 		if err := PromptMissing(opts); err != nil {
 			return err
 		}
+	}
+
+	// with prompting disabled there is nothing to select from, and looking up an
+	// empty identifier reports an unhelpful error from the API client
+	if opts.IdOrName == "" {
+		return fmt.Errorf("must supply project group identifier")
 	}
 
 	itemToDelete, err := opts.Client.ProjectGroups.GetByIDOrName(opts.IdOrName)


### PR DESCRIPTION
Fixes #627

## Problem

Three commands index `args[0]` with neither a `len(args)` guard nor an `Args` constraint, so omitting the identifier panics:

```
$ octopus project variables list
panic: runtime error: index out of range [0] with length 0
	pkg/cmd/project/variables/list/list.go:75
```

## Change

**Guard the argument**.

**Prompt instead of failing**, now that the crash no longer pre-empts it:

- `project-group delete` **already had the selector** in `PromptMissing` at `delete.go:78` — it was simply unreachable behind the panic. It now also reports a clear error under `--no-prompt`.
- The two list commands select a project rather than erroring with `must supply project identifier`, matching `tenant variables update`.

## Verification

Run on a live instance. 

Interactive paths driven through a real pty:

```
? You have not specified a Project. Please select one:  [Use arrows to move, type to filter]
> cli-tests
  NJ Todo List Build
  ...
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)