### PR TITLE
feat: accept --tenant on tenant view

### DIFF
--- a/pkg/cmd/tenant/view/view.go
+++ b/pkg/cmd/tenant/view/view.go
@@ -119,12 +119,12 @@ func resolveTenant(f factory.Factory, octopus *client.Client, idOrName string) (
 		return nil, fmt.Errorf("must supply tenant identifier")
 	}
 
-	return selectTenant(f.Ask, func() ([]*tenants.Tenant, error) { return shared.GetAllTenants(octopus) })
+	return promptMissing(f.Ask, func() ([]*tenants.Tenant, error) { return shared.GetAllTenants(octopus) })
 }
 
-// selectTenant prompts for a tenant. The getter is a parameter so the prompt can
+// promptMissing prompts for a tenant. The getter is a parameter so the prompt can
 // be driven from tests, as connect and update do.
-func selectTenant(ask question.Asker, getAllTenants shared.GetAllTenantsCallback) (*tenants.Tenant, error) {
+func promptMissing(ask question.Asker, getAllTenants shared.GetAllTenantsCallback) (*tenants.Tenant, error) {
 	return selectors.Select(
 		ask,
 		"You have not specified a Tenant. Please select one:",

--- a/pkg/cmd/tenant/view/view.go
+++ b/pkg/cmd/tenant/view/view.go
@@ -13,6 +13,8 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/usage"
 	"github.com/OctopusDeploy/cli/pkg/util"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
@@ -23,37 +25,41 @@ import (
 )
 
 const (
-	FlagWeb = "web"
+	FlagTenant = "tenant"
+	FlagWeb    = "web"
 )
 
 type ViewFlags struct {
-	Web *flag.Flag[bool]
+	Tenant *flag.Flag[string]
+	Web    *flag.Flag[bool]
 }
 
 func NewViewFlags() *ViewFlags {
 	return &ViewFlags{
-		Web: flag.New[bool](FlagWeb, false),
+		Tenant: flag.New[string](FlagTenant, false),
+		Web:    flag.New[bool](FlagWeb, false),
 	}
 }
 
 type ViewOptions struct {
-	Client   *client.Client
-	Host     string
-	out      io.Writer
-	idOrName string
-	flags    *ViewFlags
+	Client *client.Client
+	Host   string
+	out    io.Writer
+	tenant *tenants.Tenant
+	flags  *ViewFlags
 }
 
 func NewCmdView(f factory.Factory) *cobra.Command {
 	viewFlags := NewViewFlags()
 	cmd := &cobra.Command{
-		Args:  usage.ExactArgs(1),
-		Use:   "view {<name> | <id>}",
+		Args:  usage.MaximumNArgs(1),
+		Use:   "view [<name> | <id>]",
 		Short: "View a tenant",
 		Long:  "View a tenant in Octopus Deploy",
 		Example: heredoc.Docf(`
 			%[1]s tenant view Tenants-1
 			%[1]s tenant view 'Tenant'
+			%[1]s tenant view --tenant 'Tenant'
 		`, constants.ExecutableName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
@@ -61,15 +67,16 @@ func NewCmdView(f factory.Factory) *cobra.Command {
 				return err
 			}
 
-			if len(args) == 0 {
-				return fmt.Errorf("tenant identifier is required")
+			tenant, err := resolveTenant(f, client, resolveTenantIdentifier(viewFlags.Tenant.Value, args))
+			if err != nil {
+				return err
 			}
 
 			opts := &ViewOptions{
 				client,
 				f.GetCurrentHost(),
 				cmd.OutOrStdout(),
-				args[0],
+				tenant,
 				viewFlags,
 			}
 
@@ -78,16 +85,55 @@ func NewCmdView(f factory.Factory) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
+	flags.StringVarP(&viewFlags.Tenant.Value, viewFlags.Tenant.Name, "t", "", "The tenant")
 	flags.BoolVarP(&viewFlags.Web.Value, viewFlags.Web.Name, "w", false, "Open in web browser")
 
 	return cmd
 }
 
-func viewRun(opts *ViewOptions, cmd *cobra.Command) error {
-	tenant, err := opts.Client.Tenants.GetByIdentifier(opts.idOrName)
-	if err != nil {
-		return err
+// resolveTenantIdentifier prefers --tenant and falls back to the positional
+// argument, matching how the other commands accepting both forms behave.
+//
+// An empty result means no tenant was named; the caller prompts for one.
+func resolveTenantIdentifier(tenant string, args []string) string {
+	if tenant != "" {
+		return tenant
 	}
+
+	if len(args) > 0 {
+		return args[0]
+	}
+
+	return ""
+}
+
+// resolveTenant looks up the named tenant, or prompts for one when the command
+// line did not name any. With prompting disabled there is nothing to select
+// from, so the identifier is required.
+func resolveTenant(f factory.Factory, octopus *client.Client, idOrName string) (*tenants.Tenant, error) {
+	if idOrName != "" {
+		return octopus.Tenants.GetByIdentifier(idOrName)
+	}
+
+	if !f.IsPromptEnabled() {
+		return nil, fmt.Errorf("must supply tenant identifier")
+	}
+
+	return selectTenant(f.Ask, func() ([]*tenants.Tenant, error) { return shared.GetAllTenants(octopus) })
+}
+
+// selectTenant prompts for a tenant. The getter is a parameter so the prompt can
+// be driven from tests, as connect and update do.
+func selectTenant(ask question.Asker, getAllTenants shared.GetAllTenantsCallback) (*tenants.Tenant, error) {
+	return selectors.Select(
+		ask,
+		"You have not specified a Tenant. Please select one:",
+		getAllTenants,
+		func(tenant *tenants.Tenant) string { return tenant.Name })
+}
+
+func viewRun(opts *ViewOptions, cmd *cobra.Command) error {
+	tenant := opts.tenant
 
 	environmentMap, err := shared.GetEnvironmentMapForTenants(opts.Client, []*tenants.Tenant{tenant})
 	if err != nil {

--- a/pkg/cmd/tenant/view/view_test.go
+++ b/pkg/cmd/tenant/view/view_test.go
@@ -64,13 +64,13 @@ func testTenants() []*tenants.Tenant {
 	}
 }
 
-func TestSelectTenant_PromptsAndReturnsSelection(t *testing.T) {
+func TestPromptMissing_PromptsAndReturnsSelection(t *testing.T) {
 	pa := []*testutil.PA{
 		testutil.NewSelectPrompt("You have not specified a Tenant. Please select one:", "", []string{"Tenant 1", "Tenant 2"}, "Tenant 2"),
 	}
 	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
 
-	result, err := selectTenant(asker, func() ([]*tenants.Tenant, error) { return testTenants(), nil })
+	result, err := promptMissing(asker, func() ([]*tenants.Tenant, error) { return testTenants(), nil })
 
 	checkRemainingPrompts()
 	assert.NoError(t, err)
@@ -78,10 +78,10 @@ func TestSelectTenant_PromptsAndReturnsSelection(t *testing.T) {
 	assert.Equal(t, "Tenant 2", result.Name)
 }
 
-func TestSelectTenant_PropagatesLookupFailure(t *testing.T) {
+func TestPromptMissing_PropagatesLookupFailure(t *testing.T) {
 	asker, checkRemainingPrompts := testutil.NewMockAsker(t, []*testutil.PA{})
 
-	result, err := selectTenant(asker, func() ([]*tenants.Tenant, error) { return nil, errors.New("no tenants for you") })
+	result, err := promptMissing(asker, func() ([]*tenants.Tenant, error) { return nil, errors.New("no tenants for you") })
 
 	checkRemainingPrompts()
 	assert.EqualError(t, err, "no tenants for you")

--- a/pkg/cmd/tenant/view/view_test.go
+++ b/pkg/cmd/tenant/view/view_test.go
@@ -1,0 +1,89 @@
+package view
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveTenantIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		tenant   string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "positional argument",
+			args:     []string{"Bobs Wood Shop"},
+			expected: "Bobs Wood Shop",
+		},
+		{
+			name:     "tenant flag",
+			tenant:   "Bobs Wood Shop",
+			expected: "Bobs Wood Shop",
+		},
+		{
+			name:     "tenant flag with an id",
+			tenant:   "Tenants-123",
+			expected: "Tenants-123",
+		},
+		{
+			// consistent with the other commands accepting both forms
+			name:     "flag wins when both are supplied",
+			tenant:   "Bobs Wood Shop",
+			args:     []string{"Sallys Tackle Truck"},
+			expected: "Bobs Wood Shop",
+		},
+		{
+			// nothing named, so the caller prompts for a tenant
+			name:     "neither supplied",
+			expected: "",
+		},
+		{
+			name:     "no arguments does not panic",
+			args:     []string{},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, resolveTenantIdentifier(test.tenant, test.args))
+		})
+	}
+}
+
+func testTenants() []*tenants.Tenant {
+	return []*tenants.Tenant{
+		tenants.NewTenant("Tenant 1"),
+		tenants.NewTenant("Tenant 2"),
+	}
+}
+
+func TestSelectTenant_PromptsAndReturnsSelection(t *testing.T) {
+	pa := []*testutil.PA{
+		testutil.NewSelectPrompt("You have not specified a Tenant. Please select one:", "", []string{"Tenant 1", "Tenant 2"}, "Tenant 2"),
+	}
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, pa)
+
+	result, err := selectTenant(asker, func() ([]*tenants.Tenant, error) { return testTenants(), nil })
+
+	checkRemainingPrompts()
+	assert.NoError(t, err)
+	// the selected tenant is returned whole, so viewRun need not look it up again
+	assert.Equal(t, "Tenant 2", result.Name)
+}
+
+func TestSelectTenant_PropagatesLookupFailure(t *testing.T) {
+	asker, checkRemainingPrompts := testutil.NewMockAsker(t, []*testutil.PA{})
+
+	result, err := selectTenant(asker, func() ([]*tenants.Tenant, error) { return nil, errors.New("no tenants for you") })
+
+	checkRemainingPrompts()
+	assert.EqualError(t, err, "no tenants for you")
+	assert.Nil(t, result)
+}

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -37,3 +37,17 @@ func ExactArgs(n int) cobra.PositionalArgs {
 		return nil
 	}
 }
+
+// Argument validation helper for commands whose positional argument is optional,
+// typically because the same value can also be supplied by a flag. Emits a
+// UsageError rather than a plain string error, so the root handler prints usage.
+func MaximumNArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) > n {
+			return NewUsageError(
+				fmt.Sprintf("accepts at most %d arg(s), received %d", n, len(args)),
+				cmd)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
## Support Tenant View

Picks up the second half of **#299**, originally submitted by **@thampton** who raised #297 , years ago 😓 had #299 covering `tenant variables list` and `tenant view`. Thank you for the report and fix.

`tenant variables list` was rewritten around `CommonVariableScopingFeatureToggle` in #548, so #299 no original proposal no longer merges. 

## Problem

`tenant view` identified its tenant only through a positional argument:

```
$ octopus tenant view --tenant 'Tenant'
unknown flag: --tenant
```

`tenant variables update` has used `--tenant`/`-t` all along, so the two behaved differently for no reason.

## Change

**Adds `--tenant`/`-t`.** The positional still works, and the flag wins if both are given — consistent with `release list`, `runbook run`, `project variables list` and the rest.

**Prompts when neither is supplied**, instead of `tenant identifier is required`:

```
? You have not specified a Tenant. Please select one:  [Use arrows to move, type to filter]
> Contoso NA
  Fabrikam NA
  Globex EU
  Initech NA
```


**`ViewOptions` now carries the resolved `*tenants.Tenant`** rather than an identifier string, because the selector already has the whole record and re-fetching it by name was a wasted round trip. The struct itself is kept, unlike in #299 where it was removed.


Fixes #297

Closes #299 — needs closing by hand, since GitHub's closing keywords only act on issues, not pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
