### PR TITLE
ci: add Dependabot config and scheduled govulncheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Keeps module requirements and workflow actions current, so CVE fixes arrive as
+# routine PRs rather than as inbound issues.
+#
+# This does NOT cover the Go toolchain. Dependabot's gomod ecosystem updates
+# module requirements only -- it raises the `go` directive reactively when a
+# dependency demands a newer one, never proactively for a Go security release
+# (dependabot/dependabot-core#9057 and #13520 are both still open). The toolchain
+# is covered by .github/workflows/vulncheck.yml instead.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    # `fix` so release-please cuts a patch release that actually ships the update.
+    # `chore` would let dependency fixes merge without ever reaching users.
+    commit-message:
+      prefix: fix
+      include: scope
+    groups:
+      # These move together -- x/crypto v0.54.0 requires x/text v0.40.0 -- so
+      # separate PRs would conflict with each other.
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    # `ci` so action bumps do not trigger a release; they do not affect the binary.
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -18,15 +18,30 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: golang/govulncheck-action@v1
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
         with:
-          # Scan the toolchain the release is actually built with: go.mod pins a
-          # full patch version and carries no `toolchain` directive, so goreleaser
-          # builds with exactly this version.
           go-version-file: go.mod
-          # Must be false. The default (true) installs the newest Go, and
-          # govulncheck then reports standard library findings for THAT version
-          # rather than the pinned one. Scanning main (go.mod 1.25.5) under
-          # go1.26.3 reports 3 findings and misses CVE-2025-68121 entirely, versus
-          # 13 findings including it when the pinned toolchain is used.
           check-latest: false
+
+      # govulncheck itself may need a newer toolchain than we ship with, so let
+      # this step switch freely. It only affects the tool, not what gets scanned.
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        env:
+          GOTOOLCHAIN: auto
+
+      # The version govulncheck reports standard library findings against is the
+      # toolchain it runs under, NOT the `go` directive -- so the scan has to be
+      # pinned to what goreleaser actually builds with, or it reports on the
+      # wrong stdlib. Scanning this repo at go.mod 1.25.5 under go1.26.3 finds 3
+      # vulnerabilities and misses CVE-2025-68121; under the pinned go1.25.5 it
+      # finds 13 including it. GOTOOLCHAIN is set from go.mod rather than left to
+      # setup-go because the resolution is easy to get silently wrong.
+      - name: Run govulncheck against the toolchain releases are built with
+        run: |
+          toolchain="go$(awk '/^go [0-9]/ {print $2; exit}' go.mod)"
+          echo "Scanning with $toolchain (from the go directive in go.mod)"
+          GOTOOLCHAIN="$toolchain" go version
+          GOTOOLCHAIN="$toolchain" govulncheck ./...

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -1,0 +1,32 @@
+name: govulncheck
+
+# Dependabot cannot bump the Go toolchain (dependabot/dependabot-core#9057), and
+# 44 of the 47 vulnerabilities reachable from the v2.21.4 release binary were in
+# the standard library. This job is what catches those.
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    # Mondays 02:00 UTC == 12:00 Monday AEST, so a new finding surfaces at the
+    # start of an Australian working day rather than sitting over the weekend.
+    - cron: "0 2 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@v1
+        with:
+          # Scan the toolchain the release is actually built with: go.mod pins a
+          # full patch version and carries no `toolchain` directive, so goreleaser
+          # builds with exactly this version.
+          go-version-file: go.mod
+          # Must be false. The default (true) installs the newest Go, and
+          # govulncheck then reports standard library findings for THAT version
+          # rather than the pinned one. Scanning main (go.mod 1.25.5) under
+          # go1.26.3 reports 3 findings and misses CVE-2025-68121 entirely, versus
+          # 13 findings including it when the pinned toolchain is used.
+          check-latest: false


### PR DESCRIPTION
Follow-up to #619 (now merged), which fixed CVE-2025-68121 (#583) by hand. This PR is the automation that should surface the next one without an inbound issue.

## Why both files

Three of the last four bumps to the `go` directive in this repo were reactive CVE remediation (#570, #543, `9c9ae09`), each landing on whatever patch happened to be current that week — so the exposure re-accrues within a few weeks.

**Dependabot alone would not have caught #583.** Its `gomod` ecosystem updates module requirements only. It raises the `go` directive *reactively*, when an upgraded dependency demands a newer one, never proactively for a Go security release — [dependabot-core#9057](https://github.com/dependabot/dependabot-core/issues/9057) (open since Feb 2024) and [dependabot-core#13520](https://github.com/dependabot/dependabot-core/issues/13520) (open since Nov 2025) track exactly this. **44 of the 47** vulnerabilities reachable from the v2.21.4 binary were standard library, so Dependabot would have raised the `golang.org/x/text` and `golang.org/x/net` PRs and been silent on the rest.

So: Dependabot for the modules, govulncheck for the toolchain.

## `.github/dependabot.yml`

- **`gomod`, weekly.** `golang.org/x/*` is grouped into one PR because those versions are interdependent — `x/crypto v0.54.0` requires `x/text v0.40.0`, so ungrouped PRs would conflict with each other (exactly what happened while preparing #619).
- **`github-actions`, monthly**, all grouped.
- **Commit prefixes matter here.** With `release-type: simple`, release-please cuts a patch release for `fix:` and nothing for `chore:`/`ci:`. `gomod` therefore uses `fix` so a dependency fix actually ships to users; `github-actions` uses `ci` because action bumps don't affect the binary. Without this, dependency fixes would merge and sit unreleased.
- No `labels` key, so Dependabot's default labels are used rather than referencing labels that don't exist in this repo.

## `.github/workflows/vulncheck.yml`

The subtlety this workflow exists to handle: **govulncheck reports standard library findings against the toolchain it runs under, not against the `go` directive.** Since `go.mod` pins a full patch version with no `toolchain` directive, goreleaser builds with exactly that version — so a scan under any other Go version is measuring something we don't ship. Verified against the pre-#619 tree:

| Scan of the pre-#619 tree (`go.mod` = 1.25.5) | Reachable vulns | stdlib reported as | CVE-2025-68121 |
|---|---|---|---|
| Under `go1.26.3` | 3 | `crypto/tls@go1.26.3` | **missed** |
| Under the pinned `go1.25.5` | **13** | `crypto/tls@go1.25.5` | **caught**, exit 3 |

### Why this doesn't use `golang/govulncheck-action`

The first version of this workflow did, with `go-version-file: go.mod` and `check-latest: false`. That does not work. The action wires setup-go as:

```yaml
go-version: ${{ inputs.go-version-input }}   # defaults to 'stable'
go-version-file: ${{ inputs.go-version-file }}
```

setup-go prioritises `go-version` when both are set, so `go-version-file` is silently ignored and the scan always runs on `stable`. The run logged it plainly:

```
##[warning]Both go-version and go-version-file inputs are specified, only go-version will be used
Setup go version spec stable
```

`check-latest: false` doesn't help, because the version spec never came from `go.mod` in the first place. It would have been possible to force it with `go-version-input: ""`, but that's an easy detail to lose in a later edit of a security control, so this uses explicit steps that set `GOTOOLCHAIN` from the `go` directive. The toolchain in use is echoed before the scan, so the log always shows what was actually measured.

`GOTOOLCHAIN: auto` is scoped to the install step only — govulncheck may itself require a newer toolchain than we ship, and that must not constrain what gets scanned.

Triggers: `schedule` (Mondays 02:00 UTC = 12:00 Monday AEST, so findings surface at the start of an Australian working day rather than over the weekend), `pull_request`, and `workflow_dispatch`.

## Verification

- **Goes red on a vulnerable tree.** Running the workflow's exact commands against the pre-#619 tree selects `go1.25.5`, reports 13 vulnerabilities including `crypto/tls@go1.25.5`, and exits 3 — so the step fails.
- **Goes green on current `main`.** The `govulncheck` check on this PR passes, scanning `go1.26.5` (visible in the log), which is what `go.mod` now pins.
- **No false failures from the one unfixable advisory.** GO-2026-5932 (`golang.org/x/crypto/openpgp`, `Fixed in: N/A`) is module-level and uncalled, and govulncheck exits 0 on it — so no suppression or allowlist is needed.
- Both files parse as valid YAML; `awk` extraction of the `go` directive verified against both the 1.25.5 and 1.26.5 forms of `go.mod`.
- Confirmed this repo has no existing `dependabot.yml` or Renovate config to conflict with.

## Two things to decide

1. **`pull_request` trigger.** An upstream Go security release can turn unrelated PRs red until the toolchain is bumped. That's arguably the point — it blocks merging known-vulnerable code — but if it proves disruptive, dropping the `pull_request` line leaves the weekly scan intact.
2. **Scheduled failure visibility.** A failing scheduled run notifies via GitHub's usual workflow-failure path, which is easy to miss. If this should page someone or open an issue automatically, that's worth adding as a follow-up.

Note this reports but does not fix; a human still edits `go.mod`. Renovate does bump the `go` directive automatically if you'd rather trade an extra tool for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
