### PR TITLE
fix: open a pull request when publishing the homebrew formula

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -74,7 +74,11 @@ step "push-homebrew-formula-updates-to-the-homebrew-taps-repo" {
                     [String]$githubtoken
                 )
                 
-                $origin="https://github.com/OctopusDeploy/homebrew-taps"
+                $ErrorActionPreference = "Stop"
+                
+                $repo = "OctopusDeploy/homebrew-taps"
+                $defaultBranch = "master"
+                $origin = "https://github.com/$repo"
                 
                 if ($OctopusParameters) {
                     $packageVersion = $OctopusParameters["Octopus.Action.Package[cli].PackageVersion"]
@@ -83,18 +87,19 @@ step "push-homebrew-formula-updates-to-the-homebrew-taps-repo" {
                     $gitUserEmail = $OctopusParameters["Publish:HomeBrew:UserEmail"]
                 
                     $githubtoken = $OctopusParameters["Publish:HomeBrew:ApiKey"]
-                    $origin="https://$($gitUserName):$($githubtoken)@github.com/OctopusDeploy/homebrew-taps"
+                    $origin = "https://$($gitUserName):$($githubtoken)@github.com/$repo"
                 
                 }
                 
-                if (!$packageVersion || !$extractedPath) {
+                if ([string]::IsNullOrWhiteSpace($packageVersion) -or [string]::IsNullOrWhiteSpace($extractedPath)) {
                     throw "Error: packageVersion or extractedPath are not set"
-                    exit
-                } else {
-                    write-host "Using: packageVersion $packageVersion from $extractedPath"
                 }
+                
+                Write-Host "Using: packageVersion $packageVersion from $extractedPath"
                 
                 git clone --depth 1 $origin octopus-homebrew-taps
+                if ($LASTEXITCODE -ne 0) { throw "Failed to clone $repo" }
+                
                 Set-Location octopus-homebrew-taps
                 
                 if ($gitUserName) {
@@ -104,12 +109,59 @@ step "push-homebrew-formula-updates-to-the-homebrew-taps-repo" {
                 
                 $branchName = "releases/$packageVersion"
                 git checkout -b $branchName
+                if ($LASTEXITCODE -ne 0) { throw "Failed to create branch $branchName" }
                 
                 Copy-Item -Path "$extractedPath/homebrew/*" -Filter "*.rb" -Destination "." -Force
                 
-                git diff-index --quiet HEAD || (git commit -a -m "Update for release $packageVersion" `
-                    && git push --repo $origin --set-upstream origin $branchName `
-                )
+                git diff-index --quiet HEAD
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "Formula already matches $packageVersion; nothing to publish."
+                    Set-Location ..
+                    exit 0
+                }
+                
+                git commit -a -m "Update for release $packageVersion"
+                if ($LASTEXITCODE -ne 0) { throw "Failed to commit the formula update" }
+                
+                git push --repo $origin --set-upstream origin $branchName
+                if ($LASTEXITCODE -ne 0) { throw "Failed to push $branchName" }
+                
+                # Pushing the branch on its own leaves the tap untouched, so open a
+                # pull request for it. Without this the formula is never updated and
+                # `brew install octopus-cli` keeps serving the previous release.
+                $headers = @{
+                    "Accept"               = "application/vnd.github+json"
+                    "X-GitHub-Api-Version" = "2022-11-28"
+                    "Authorization"        = "Bearer $githubtoken"
+                }
+                
+                $pullRequest = @{
+                    title = "Update for release $packageVersion"
+                    head  = $branchName
+                    base  = $defaultBranch
+                    body  = "Automated formula update for octopus-cli $packageVersion."
+                } | ConvertTo-Json
+                
+                try {
+                    $response = Invoke-RestMethod -Method Post -Headers $headers `
+                        -Uri "https://api.github.com/repos/$repo/pulls" `
+                        -Body $pullRequest -ContentType "application/json"
+                
+                    Write-Host "Opened pull request $($response.html_url)"
+                }
+                catch {
+                    # A re-run of the same release finds its pull request already open,
+                    # which is not a failure worth stopping the deployment for.
+                    $statusCode = $_.Exception.Response.StatusCode.value__
+                    $alreadyExists = $statusCode -eq 422 -and $_.ErrorDetails.Message -match "already exists"
+                
+                    if ($alreadyExists) {
+                        Write-Host "A pull request for $branchName is already open."
+                    }
+                    else {
+                        throw "Failed to open a pull request against $repo`: $($_.Exception.Message)"
+                    }
+                }
                 
                 Set-Location ..
                 EOT

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -123,7 +123,10 @@ step "push-homebrew-formula-updates-to-the-homebrew-taps-repo" {
                 git commit -a -m "Update for release $packageVersion"
                 if ($LASTEXITCODE -ne 0) { throw "Failed to commit the formula update" }
                 
-                git push --repo $origin --set-upstream origin $branchName
+                # Force, because a re-run branches from master again and so its commit is a
+                # sibling of any existing releases/$packageVersion, not a descendant of it.
+                # A plain push is rejected as non-fast-forward and the release fails.
+                git push --force --repo $origin --set-upstream origin $branchName
                 if ($LASTEXITCODE -ne 0) { throw "Failed to push $branchName" }
                 
                 # Pushing the branch on its own leaves the tap untouched, so open a
@@ -159,7 +162,10 @@ step "push-homebrew-formula-updates-to-the-homebrew-taps-repo" {
                         Write-Host "A pull request for $branchName is already open."
                     }
                     else {
-                        throw "Failed to open a pull request against $repo`: $($_.Exception.Message)"
+                        # Exception.Message is only ever "Response status code does not indicate
+                        # success"; the response body is what says which field GitHub rejected.
+                        $detail = if ($_.ErrorDetails.Message) { $_.ErrorDetails.Message } else { $_.Exception.Message }
+                        throw "Failed to open a pull request against $repo`: $detail"
                     }
                 }
                 


### PR DESCRIPTION
Fixes #541

## Root cause

The publish step clones the tap, commits the regenerated formula, pushes a `releases/<version>` branch, no pr and merge happens.

Confirmed against the tap: branches exist for **every release from `0.3.2` through `2.21.4`**, `master` is still on **2.20.0**, and the only pull request ever opened is [#69](https://github.com/OctopusDeploy/homebrew-taps/pull/69) — raised by hand by an external user, @jnv, in June.

## Change

- **Open the pull request** via GitHub API after push
- **Force-push the release branch.** The step does shallow clone, branches each run, so a re-run's commit is a *sibling* of any existing `releases/<version>`. Forcing also makes a re-run update the open PR instead of failing.
- **Treat a 422 mentioning *already exists* as success**, so re-running a release is harmless.
- **Fail loudly.** `$ErrorActionPreference = "Stop"`, `$LASTEXITCODE` checked after each `git` call API errors. A clone or push failure previously left the step green.
- **Fix the argument guard.** `if (!$packageVersion || !$extractedPath)` used `||`, PowerShell's pipeline chain operator, where `-or` was meant, so the guard never evaluated as a boolean.
- **Exit early when the formula is unchanged**, rather than relying on the `||` chain.

## Testing

Ran on **pwsh 7 on Unix** like the `hosted-ubuntu`container, against a scratch tap seeded with the real formula at 2.20.0.

| Case | Result |
|---|---|
| First release | PR opened, base `master`, correct one-line version diff, exit 0 |
| Re-run of the same version | Force-push updates the branch, existing PR is detected, exit 0 |
| Unrelated API failure (invalid `base`) | Throws with GitHub's validation body, exit 1 |

The first two rows are what caught the force-push bug: before it, a re-run died at the push and never reached the already-exists handling.


🤖 Generated with [Claude Code](https://claude.com/claude-code)