### PR TITLE
fix: make delete commands usable with --no-prompt

### DIFF
--- a/pkg/cmd/package/delete/delete.go
+++ b/pkg/cmd/package/delete/delete.go
@@ -82,10 +82,13 @@ func NewCmdDelete(f factory.Factory) *cobra.Command {
 }
 
 func deleteRun(opts *DeleteOptions) error {
-	if !opts.NoPrompt {
-		if err := PromptMissing(opts); err != nil {
-			return err
-		}
+	// Resolve regardless of whether prompting is enabled. --package-id and
+	// --version identify the package just as well as the positional ID does,
+	// and running this only in interactive mode left them ignored under
+	// --no-prompt, which then rejected the command for want of an identifier.
+	// Nothing here prompts while both flags are supplied.
+	if err := PromptMissing(opts); err != nil {
+		return err
 	}
 
 	if opts.ID == "" {
@@ -154,11 +157,15 @@ func selectPackage(opts *DeleteOptions) (*packages.Package, error) {
 			return nil, fmt.Errorf("unable to find a package matching the specifed ID: '%s'", opts.DeleteFlags.PackageId.Value)
 		}
 		return allExistingPackages[idx], nil
-	} else {
-		return question.SelectMap(opts.Ask, "Select the package you wish to delete:", allExistingPackages, func(item *packages.Package) string {
-			return item.PackageID
-		})
 	}
+
+	if opts.NoPrompt {
+		return nil, fmt.Errorf("package identifier is required but was not provided; supply it as an argument, or use --%s together with --%s", FlagPackageId, FlagVersion)
+	}
+
+	return question.SelectMap(opts.Ask, "Select the package you wish to delete:", allExistingPackages, func(item *packages.Package) string {
+		return item.PackageID
+	})
 }
 
 func selectVersion(opts *DeleteOptions, packageID string) (*packages.Package, error) {
@@ -181,6 +188,10 @@ func selectVersion(opts *DeleteOptions, packageID string) (*packages.Package, er
 		}
 		packageVersionToDelete = allPackageVersions[idx]
 	} else {
+		if opts.NoPrompt {
+			return nil, fmt.Errorf("--%s is required alongside --%s while prompting is disabled", FlagVersion, FlagPackageId)
+		}
+
 		packageVersionToDelete, err = question.SelectMap(opts.Ask, "Select the version you wish to delete:", allPackageVersions, func(item *packages.Package) string { return item.Version })
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/package/delete/delete.go
+++ b/pkg/cmd/package/delete/delete.go
@@ -84,8 +84,7 @@ func NewCmdDelete(f factory.Factory) *cobra.Command {
 func deleteRun(opts *DeleteOptions) error {
 	// --package-id and --version identify the package just as well as the
 	// positional ID does, so they are resolved whether or not prompting is
-	// enabled. Doing this inside PromptMissing left them ignored under
-	// --no-prompt, which then rejected the command for want of an identifier.
+	// enabled.
 	if err := resolveIdentifier(opts); err != nil {
 		return err
 	}

--- a/pkg/cmd/package/delete/delete.go
+++ b/pkg/cmd/package/delete/delete.go
@@ -82,17 +82,22 @@ func NewCmdDelete(f factory.Factory) *cobra.Command {
 }
 
 func deleteRun(opts *DeleteOptions) error {
-	// Resolve regardless of whether prompting is enabled. --package-id and
-	// --version identify the package just as well as the positional ID does,
-	// and running this only in interactive mode left them ignored under
+	// --package-id and --version identify the package just as well as the
+	// positional ID does, so they are resolved whether or not prompting is
+	// enabled. Doing this inside PromptMissing left them ignored under
 	// --no-prompt, which then rejected the command for want of an identifier.
-	// Nothing here prompts while both flags are supplied.
-	if err := PromptMissing(opts); err != nil {
+	if err := resolveIdentifier(opts); err != nil {
 		return err
 	}
 
+	if !opts.NoPrompt {
+		if err := PromptMissing(opts); err != nil {
+			return err
+		}
+	}
+
 	if opts.ID == "" {
-		return fmt.Errorf("package identifier is required but was not provided")
+		return fmt.Errorf("package identifier is required but was not provided; supply it as an argument, or use --%s together with --%s", FlagPackageId, FlagVersion)
 	}
 
 	packageToDelete, err := packages.GetByID(opts.Client, opts.Client.GetSpaceID(), opts.ID)
@@ -127,6 +132,29 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 }
 
+// resolveIdentifier turns --package-id and --version into the ID of the package
+// to delete. It never prompts, so it is safe to run with prompting disabled.
+// Either flag on its own does not identify a package, so those are left to
+// PromptMissing to finish off.
+func resolveIdentifier(opts *DeleteOptions) error {
+	if opts.ID != "" || opts.DeleteFlags.PackageId.Value == "" || opts.DeleteFlags.Version.Value == "" {
+		return nil
+	}
+
+	packageToDelete, err := findPackage(opts, opts.DeleteFlags.PackageId.Value)
+	if err != nil {
+		return err
+	}
+
+	packageVersionToDelete, err := findVersion(opts, packageToDelete.PackageID, opts.DeleteFlags.Version.Value)
+	if err != nil {
+		return err
+	}
+
+	opts.ID = packageVersionToDelete.GetID()
+	return nil
+}
+
 func PromptMissing(opts *DeleteOptions) error {
 	if opts.ID == "" {
 		packageToDelete, err := selectPackage(opts)
@@ -146,21 +174,13 @@ func PromptMissing(opts *DeleteOptions) error {
 }
 
 func selectPackage(opts *DeleteOptions) (*packages.Package, error) {
+	if opts.DeleteFlags.PackageId.Value != "" {
+		return findPackage(opts, opts.DeleteFlags.PackageId.Value)
+	}
+
 	allExistingPackages, err := packages.GetAll(opts.Client, opts.Client.GetSpaceID())
 	if err != nil {
 		return nil, err
-	}
-
-	if opts.DeleteFlags.PackageId.Value != "" {
-		idx := slices.IndexFunc(allExistingPackages, func(p *packages.Package) bool { return p.PackageID == opts.DeleteFlags.PackageId.Value })
-		if idx == -1 {
-			return nil, fmt.Errorf("unable to find a package matching the specifed ID: '%s'", opts.DeleteFlags.PackageId.Value)
-		}
-		return allExistingPackages[idx], nil
-	}
-
-	if opts.NoPrompt {
-		return nil, fmt.Errorf("package identifier is required but was not provided; supply it as an argument, or use --%s together with --%s", FlagPackageId, FlagVersion)
 	}
 
 	return question.SelectMap(opts.Ask, "Select the package you wish to delete:", allExistingPackages, func(item *packages.Package) string {
@@ -169,36 +189,55 @@ func selectPackage(opts *DeleteOptions) (*packages.Package, error) {
 }
 
 func selectVersion(opts *DeleteOptions, packageID string) (*packages.Package, error) {
+	if opts.DeleteFlags.Version.Value != "" {
+		return findVersion(opts, packageID, opts.DeleteFlags.Version.Value)
+	}
+
+	allPackageVersions, err := allVersions(opts, packageID)
+	if err != nil {
+		return nil, err
+	}
+
+	return question.SelectMap(opts.Ask, "Select the version you wish to delete:", allPackageVersions, func(item *packages.Package) string { return item.Version })
+}
+
+func findPackage(opts *DeleteOptions, packageID string) (*packages.Package, error) {
+	allExistingPackages, err := packages.GetAll(opts.Client, opts.Client.GetSpaceID())
+	if err != nil {
+		return nil, err
+	}
+
+	idx := slices.IndexFunc(allExistingPackages, func(p *packages.Package) bool { return p.PackageID == packageID })
+	if idx == -1 {
+		return nil, fmt.Errorf("unable to find a package matching the specifed ID: '%s'", packageID)
+	}
+
+	return allExistingPackages[idx], nil
+}
+
+func findVersion(opts *DeleteOptions, packageID string, version string) (*packages.Package, error) {
+	allPackageVersions, err := allVersions(opts, packageID)
+	if err != nil {
+		return nil, err
+	}
+
+	idx := slices.IndexFunc(allPackageVersions, func(p *packages.Package) bool { return p.Version == version })
+	if idx == -1 {
+		return nil, fmt.Errorf("unable to find a version matching the specified version: '%s", version)
+	}
+
+	return allPackageVersions[idx], nil
+}
+
+func allVersions(opts *DeleteOptions, packageID string) ([]*packages.Package, error) {
 	packageVersions, err := packages.Get(opts.Client, opts.Client.GetSpaceID(), packages.PackagesQuery{
 		NuGetPackageID: packageID,
 	})
 	if err != nil {
 		return nil, err
 	}
-	allPackageVersions, err := packageVersions.GetAllPages(opts.Client.Sling())
-	if err != nil {
-		return nil, err
-	}
 
-	var packageVersionToDelete *packages.Package
-	if opts.DeleteFlags.Version.Value != "" {
-		idx := slices.IndexFunc(allPackageVersions, func(p *packages.Package) bool { return p.Version == opts.DeleteFlags.Version.Value })
-		if idx == -1 {
-			return nil, fmt.Errorf("unable to find a version matching the specified version: '%s", opts.DeleteFlags.Version.Value)
-		}
-		packageVersionToDelete = allPackageVersions[idx]
-	} else {
-		if opts.NoPrompt {
-			return nil, fmt.Errorf("--%s is required alongside --%s while prompting is disabled", FlagVersion, FlagPackageId)
-		}
-
-		packageVersionToDelete, err = question.SelectMap(opts.Ask, "Select the version you wish to delete:", allPackageVersions, func(item *packages.Package) string { return item.Version })
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return packageVersionToDelete, nil
+	return packageVersions.GetAllPages(opts.Client.Sling())
 }
 
 func delete(client *client.Client, packageToDelete *packages.Package) error {

--- a/pkg/question/input.go
+++ b/pkg/question/input.go
@@ -1,8 +1,11 @@
 package question
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
+	cliErrors "github.com/OctopusDeploy/cli/pkg/errors"
 	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/spf13/cobra"
@@ -24,6 +27,23 @@ func RegisterConfirmDeletionFlag(cmd *cobra.Command, value *bool, resourceDescri
 	cmd.Flags().BoolVarP(value, FlagConfirm, "y", false, fmt.Sprintf("Don't ask for confirmation before deleting the %s.", resourceDescription))
 }
 
+// describeConfirmationFailure turns the internal "prompt disabled" error into
+// something a caller can act on. Deletion asks the user to type the item's name
+// to confirm, which cannot happen with prompting turned off, so --no-prompt on
+// its own reports only "prompt disabled" and deletes nothing. Point at the flag
+// that actually skips the confirmation rather than deleting unasked, since that
+// is not something to infer from --no-prompt.
+func describeConfirmationFailure(err error, itemType string) error {
+	var promptDisabled *cliErrors.PromptDisabledError
+	if errors.As(err, &promptDisabled) {
+		return fmt.Errorf(
+			"cannot confirm deletion of the %s while prompting is disabled; pass --%s to delete it without confirmation",
+			itemType, FlagConfirm)
+	}
+
+	return err
+}
+
 func DeleteWithConfirmation(ask Asker, itemType string, itemName string, itemID string, doDelete func() error) error {
 	var enteredName string
 	if err := ask(&survey.Input{
@@ -31,7 +51,7 @@ func DeleteWithConfirmation(ask Asker, itemType string, itemName string, itemID 
 			`You are about to delete the %s "%s" %s. This action cannot be reversed. To confirm, type the %s name:`,
 			itemType, itemName, output.Dimf("(%s)", itemID), itemType),
 	}, &enteredName); err != nil {
-		return err
+		return describeConfirmationFailure(err, itemType)
 	}
 
 	if enteredName != itemName {

--- a/pkg/question/input_test.go
+++ b/pkg/question/input_test.go
@@ -1,38 +1,115 @@
-package question
+package question_test
 
 import (
 	"errors"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
 	"testing"
 
+	"github.com/OctopusDeploy/cli/test/testutil"
+
 	cliErrors "github.com/OctopusDeploy/cli/pkg/errors"
+	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/stretchr/testify/assert"
 )
 
-// Deletion asks the user to retype the item's name, which cannot happen with
+func TestQuestion_DeleteWithConfirmation_Success(t *testing.T) {
+	qa := testutil.NewAskMocker()
+	errReceiver := testutil.GoBegin(func() error {
+		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
+	})
+
+	qa.ExpectQuestion(t, &survey.Input{
+		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
+	}).AnswerWith("dog")
+
+	err := <-errReceiver
+	assert.Nil(t, err)
+}
+
+func TestQuestion_DeleteWithConfirmation_invalidResponse(t *testing.T) {
+	qa := testutil.NewAskMocker()
+	errReceiver := testutil.GoBegin(func() error {
+		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
+	})
+
+	qa.ExpectQuestion(t, &survey.Input{
+		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
+	}).AnswerWith("cat")
+
+	err := <-errReceiver
+	assert.Equal(t, err, fmt.Errorf("input value %s does match expected value %s", "cat", "dog"))
+}
+
+func TestQuestion_DeleteWithConfirmation_error(t *testing.T) {
+	qa := testutil.NewAskMocker()
+	errReceiver := testutil.GoBegin(func() error {
+		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
+	})
+
+	qa.ExpectQuestion(t, &survey.Input{
+		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
+	}).AnswerWithError(errors.New("ouch"))
+
+	err := <-errReceiver
+	assert.Equal(t, errors.New("ouch"), err)
+}
+
+// Confirming a deletion means retyping the item's name, which cannot happen with
 // prompting disabled. On its own that surfaced only "prompt disabled", with no
 // hint that --confirm is the way to delete without being asked.
-func TestDescribeConfirmationFailure_ExplainsPromptDisabled(t *testing.T) {
-	err := describeConfirmationFailure(&cliErrors.PromptDisabledError{}, "deployment target")
+func TestQuestion_DeleteWithConfirmation_promptDisabled(t *testing.T) {
+	qa := testutil.NewAskMocker()
+	errReceiver := testutil.GoBegin(func() error {
+		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
+	})
 
+	qa.ExpectQuestion(t, &survey.Input{
+		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
+	}).AnswerWithError(&cliErrors.PromptDisabledError{})
+
+	err := <-errReceiver
 	assert.EqualError(t, err,
-		"cannot confirm deletion of the deployment target while prompting is disabled; pass --confirm to delete it without confirmation")
+		"cannot confirm deletion of the animal while prompting is disabled; pass --confirm to delete it without confirmation")
 }
 
-func TestDescribeConfirmationFailure_ExplainsWrappedPromptDisabled(t *testing.T) {
-	wrapped := errors.Join(errors.New("while deleting"), &cliErrors.PromptDisabledError{})
+func TestQuestion_DeleteWithConfirmation_wrappedPromptDisabled(t *testing.T) {
+	qa := testutil.NewAskMocker()
+	errReceiver := testutil.GoBegin(func() error {
+		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
+	})
 
-	err := describeConfirmationFailure(wrapped, "package")
+	qa.ExpectQuestion(t, &survey.Input{
+		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
+	}).AnswerWithError(errors.Join(errors.New("while deleting"), &cliErrors.PromptDisabledError{}))
 
+	err := <-errReceiver
 	assert.EqualError(t, err,
-		"cannot confirm deletion of the package while prompting is disabled; pass --confirm to delete it without confirmation")
+		"cannot confirm deletion of the animal while prompting is disabled; pass --confirm to delete it without confirmation")
 }
 
-func TestDescribeConfirmationFailure_LeavesOtherErrorsAlone(t *testing.T) {
-	original := errors.New("interrupted")
+func TestQuestion_DeleteWithConfirmation_deleteError(t *testing.T) {
+	qa := testutil.NewAskMocker()
+	errReceiver := testutil.GoBegin(func() error {
+		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return errors.New("ouch") })
+	})
 
-	assert.Same(t, original, describeConfirmationFailure(original, "package"))
+	qa.ExpectQuestion(t, &survey.Input{
+		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
+	}).AnswerWith("dog")
+
+	err := <-errReceiver
+	assert.Equal(t, errors.New("ouch"), err)
 }
 
-func TestDescribeConfirmationFailure_NoError(t *testing.T) {
-	assert.NoError(t, describeConfirmationFailure(nil, "package"))
+func TestAskName(t *testing.T) {
+	pa := []*testutil.PA{
+		testutil.NewInputPrompt("prefix Name", "A short, memorable, unique name for this resource.", "answer"),
+	}
+	qa, _ := testutil.NewMockAsker(t, pa)
+
+	var value string
+	err := question.AskName(qa, "prefix ", "resource", &value)
+	assert.NoError(t, err)
+	assert.Equal(t, value, "answer")
 }

--- a/pkg/question/input_test.go
+++ b/pkg/question/input_test.go
@@ -1,81 +1,38 @@
-package question_test
+package question
 
 import (
 	"errors"
-	"fmt"
-	"github.com/AlecAivazis/survey/v2"
 	"testing"
 
-	"github.com/OctopusDeploy/cli/test/testutil"
-
-	"github.com/OctopusDeploy/cli/pkg/question"
+	cliErrors "github.com/OctopusDeploy/cli/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestQuestion_DeleteWithConfirmation_Success(t *testing.T) {
-	qa := testutil.NewAskMocker()
-	errReceiver := testutil.GoBegin(func() error {
-		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
-	})
+// Deletion asks the user to retype the item's name, which cannot happen with
+// prompting disabled. On its own that surfaced only "prompt disabled", with no
+// hint that --confirm is the way to delete without being asked.
+func TestDescribeConfirmationFailure_ExplainsPromptDisabled(t *testing.T) {
+	err := describeConfirmationFailure(&cliErrors.PromptDisabledError{}, "deployment target")
 
-	qa.ExpectQuestion(t, &survey.Input{
-		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
-	}).AnswerWith("dog")
-
-	err := <-errReceiver
-	assert.Nil(t, err)
+	assert.EqualError(t, err,
+		"cannot confirm deletion of the deployment target while prompting is disabled; pass --confirm to delete it without confirmation")
 }
 
-func TestQuestion_DeleteWithConfirmation_invalidResponse(t *testing.T) {
-	qa := testutil.NewAskMocker()
-	errReceiver := testutil.GoBegin(func() error {
-		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
-	})
+func TestDescribeConfirmationFailure_ExplainsWrappedPromptDisabled(t *testing.T) {
+	wrapped := errors.Join(errors.New("while deleting"), &cliErrors.PromptDisabledError{})
 
-	qa.ExpectQuestion(t, &survey.Input{
-		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
-	}).AnswerWith("cat")
+	err := describeConfirmationFailure(wrapped, "package")
 
-	err := <-errReceiver
-	assert.Equal(t, err, fmt.Errorf("input value %s does match expected value %s", "cat", "dog"))
+	assert.EqualError(t, err,
+		"cannot confirm deletion of the package while prompting is disabled; pass --confirm to delete it without confirmation")
 }
 
-func TestQuestion_DeleteWithConfirmation_error(t *testing.T) {
-	qa := testutil.NewAskMocker()
-	errReceiver := testutil.GoBegin(func() error {
-		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return nil })
-	})
+func TestDescribeConfirmationFailure_LeavesOtherErrorsAlone(t *testing.T) {
+	original := errors.New("interrupted")
 
-	qa.ExpectQuestion(t, &survey.Input{
-		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
-	}).AnswerWithError(errors.New("ouch"))
-
-	err := <-errReceiver
-	assert.Equal(t, errors.New("ouch"), err)
+	assert.Same(t, original, describeConfirmationFailure(original, "package"))
 }
 
-func TestQuestion_DeleteWithConfirmation_deleteError(t *testing.T) {
-	qa := testutil.NewAskMocker()
-	errReceiver := testutil.GoBegin(func() error {
-		return question.DeleteWithConfirmation(qa.AsAsker(), "animal", "dog", "1", func() error { return errors.New("ouch") })
-	})
-
-	qa.ExpectQuestion(t, &survey.Input{
-		Message: `You are about to delete the animal "dog" (1). This action cannot be reversed. To confirm, type the animal name:`,
-	}).AnswerWith("dog")
-
-	err := <-errReceiver
-	assert.Equal(t, errors.New("ouch"), err)
-}
-
-func TestAskName(t *testing.T) {
-	pa := []*testutil.PA{
-		testutil.NewInputPrompt("prefix Name", "A short, memorable, unique name for this resource.", "answer"),
-	}
-	qa, _ := testutil.NewMockAsker(t, pa)
-
-	var value string
-	err := question.AskName(qa, "prefix ", "resource", &value)
-	assert.NoError(t, err)
-	assert.Equal(t, value, "answer")
+func TestDescribeConfirmationFailure_NoError(t *testing.T) {
+	assert.NoError(t, describeConfirmationFailure(nil, "package"))
 }


### PR DESCRIPTION
Fixes #490
Fixes #530

Two reports about `--no-prompt` on delete commands. Same symptom, different causes.

## #490 — `prompt disabled`, nothing deleted, no explanation

Deleting asks the user to retype the item's name, which cannot happen once prompting is off. `deployment-target delete <name> --no-prompt` therefore printed "prompt disabled" didn't work no hints

**Fix:** report which flag skips the confirmation.

```
before  prompt disabled
after   cannot confirm deletion of the deployment target while prompting is disabled;
        pass --confirm to delete it without confirmation
```

Handled in `DeleteWithConfirmation`, all delete commands covered.

*not* making `--no-prompt` imply confirmation of delete, don't want to silently destroy things. `-y --no-prompt` is the scripting path, and it works:

## #530 — `--package-id` and `--version` ignored under `--no-prompt`

Different mechanism. Those flags were consumed only inside `PromptMissing`, which `--no-prompt` skips entirely, so `deleteRun` fell through to demanding the positional ID:

```
$ octopus package delete -p "Package" -v "1.0.0" -y --no-prompt
package identifier is required but was not provided     # identical to omitting -p
```


**Fix:** resolve them regardless of prompting — nothing prompts while both are present. if value missing, say which flag is needed


## Testing

 
| What | Outcome |
|---|---|
| `target delete <name> --no-prompt` | actionable message, nothing deleted |
| `target delete <name> -y --no-prompt` | deleted |
| `package delete -p X -v Y -y --no-prompt` | deleted |
| `package delete --no-prompt` | names both flags |
| interactive `target delete <name>` | still prompts to retype the name |


🤖 Generated with [Claude Code](https://claude.com/claude-code)