### PR TITLE
test: read stdout only while the asker goroutine is parked

### DIFF
--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -47,10 +47,6 @@ var now = func() time.Time {
 }
 var ctxWithFakeNow = context.WithValue(context.TODO(), constants.ContextKeyTimeNow, now)
 
-// AskQuestions runs in a goroutine here, so the stdout buffer is only stable
-// while that goroutine is parked on a question. Read it directly after an
-// ExpectQuestion returns; answering releases the goroutine to write more into
-// the same buffer, and a read taken after that races it.
 func TestDeployCreate_AskQuestions(t *testing.T) {
 	const spaceID = "Spaces-1"
 	const fireProjectID = "Projects-22"

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -47,6 +47,10 @@ var now = func() time.Time {
 }
 var ctxWithFakeNow = context.WithValue(context.TODO(), constants.ContextKeyTimeNow, now)
 
+// AskQuestions runs in a goroutine here, so the stdout buffer is only stable
+// while that goroutine is parked on a question. Read it directly after an
+// ExpectQuestion returns; answering releases the goroutine to write more into
+// the same buffer, and a read taken after that races it.
 func TestDeployCreate_AskQuestions(t *testing.T) {
 	const spaceID = "Spaces-1"
 	const fireProjectID = "Projects-22"
@@ -569,16 +573,15 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			validationErr = q.AnswerWith("John")
 			assert.Nil(t, validationErr)
 
-			assert.Contains(t, stdout.String(), heredoc.Doc(`
-				Project Fire Project
-				Release 2.0
-				Environments dev
-			`), stdout.String())
-
 			q = qa.ExpectQuestion(t, &survey.Select{
 				Message: "Change additional options?",
 				Options: []string{"Proceed to deploy", "Change"},
 			})
+			assert.Contains(t, stdout.String(), heredoc.Doc(`
+				Project Fire Project
+				Release 2.0
+				Environments dev
+			`))
 			assert.Regexp(t, "Additional Options", stdout.String()) // actual options tested in PrintAdvancedSummary
 			_ = q.AnswerWith("Proceed to deploy")
 
@@ -647,15 +650,15 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 				Message: "Scoped Sensitive",
 				Help:    "",
 			})
-			assert.Regexp(t, "", stdout.String()) // actual options tested in PrintAdvancedSummary
-			_ = promptQuestion.AnswerWith("Secret Value")
-
+			// Exact contents, so this has to precede the answer below.
 			assert.Equal(t, heredoc.Doc(`
 				Project Fire Project
 				Release 2.0
 				Environments dev
 			`), stdout.String())
 			stdout.Reset()
+
+			_ = promptQuestion.AnswerWith("Secret Value")
 
 			q := qa.ExpectQuestion(t, &survey.Select{
 				Message: "Change additional options?",
@@ -758,15 +761,14 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			emptyDeploymentPreviews := fixtures.EmptyDeploymentPreviews()
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/"+release19.ID+"/deployments/previews").RespondWith(&emptyDeploymentPreviews)
 
-			assert.Contains(t, heredoc.Doc(`
-				Project Fire Project
-				Release 1.9
-			`), stdout.String())
-
 			q = qa.ExpectQuestion(t, &survey.Select{
 				Message: "Change additional options?",
 				Options: []string{"Proceed to deploy", "Change"},
 			})
+			assert.Contains(t, stdout.String(), heredoc.Doc(`
+				Project Fire Project
+				Release 1.9
+			`))
 			assert.Regexp(t, "Additional Options", stdout.String()) // actual options tested in PrintAdvancedSummary
 			_ = q.AnswerWith("Proceed to deploy")
 
@@ -869,15 +871,14 @@ func TestDeployCreate_AskQuestions(t *testing.T) {
 			emptyDeploymentPreviews := fixtures.EmptyDeploymentPreviews()
 			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/"+release19.ID+"/deployments/previews").RespondWith(&emptyDeploymentPreviews)
 
-			assert.Contains(t, stdout.String(), heredoc.Doc(`
-				Project Fire Project
-				Release 1.9
-			`))
-
 			q = qa.ExpectQuestion(t, &survey.Select{
 				Message: "Change additional options?",
 				Options: []string{"Proceed to deploy", "Change"},
 			})
+			assert.Contains(t, stdout.String(), heredoc.Doc(`
+				Project Fire Project
+				Release 1.9
+			`))
 			assert.Regexp(t, "Additional Options", stdout.String()) // actual options tested in PrintAdvancedSummary
 			_ = q.AnswerWith("Proceed to deploy")
 

--- a/test/testutil/fakesurvey.go
+++ b/test/testutil/fakesurvey.go
@@ -298,6 +298,12 @@ func (m *AskMocker) ReceiveQuestion() *QuestionWrapper {
 }
 
 // ExpectQuestion calls ReceiveQuestion and asserts that the received survey prompt matches `question`
+//
+// It returns once the code under test has asked the question and is blocked waiting for an answer.
+// If that code runs in a goroutine and writes to a buffer the test also reads — captured stdout,
+// typically — this is the only point at which the buffer is stable. Assert on it between here and
+// AnswerWith. AnswerWith releases the code under test to write more into the same buffer, so an
+// assertion made after it races that goroutine and will fail intermittently.
 func (m *AskMocker) ExpectQuestion(t *testing.T, question survey.Prompt) *QuestionWrapper {
 	q := m.ReceiveQuestion()
 	assert.Equal(t, question, q.Question)
@@ -325,6 +331,9 @@ type QuestionWrapper struct {
 //	err := q.AnswerWith("5")
 //	assert.EqualError(t, err, nil)
 //	test sequence should proceed now
+//
+// Sending the answer resumes the code under test, so assert on any captured output before calling
+// this rather than after. A failed validator sends nothing and leaves it blocked.
 func (q *QuestionWrapper) AnswerWith(answer any) error {
 	// run validators, otherwise we won't be able to test them
 	if q.Options != nil && len(q.Options.Validators) > 0 {


### PR DESCRIPTION
## Problem

`TestDeployCreate_AskQuestions` runs `AskQuestions` in a goroutine and asserts on the buffer it writes to. Four subtests read that buffer straight after answering a question. Answering lets the goroutine run on and append the advanced-options summary, so the read races it.

Both outcomes turn up in CI: the buffer holds more than expected, or `stdout.Reset()` has already run and it holds nothing.

One of the four also had its arguments reversed, checking that a two-line heredoc contained the whole of stdout. That fails as soon as anything else is written.

## Change

Read the buffer only while the goroutine is parked on a question. Three assertions move below the next `ExpectQuestion`. The fourth compares exact contents, so it moves above the `AnswerWith` instead.

Corrected the reversed arguments. Dropped an `assert.Regexp(t, "", ...)`, which matched anything.

Forcing the race with a sleep in each window reproduces the CI failures on the old code, and none on the new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
