### PR TITLE
fix: always write a nuspec into generated NuGet packages

### DIFF
--- a/pkg/cmd/package/nuget/create/create.go
+++ b/pkg/cmd/package/nuget/create/create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
@@ -26,6 +27,11 @@ const (
 	FlagReleaseNotes     = "releaseNotes"
 	FlagReleaseNotesFile = "releaseNotesFile"
 )
+
+// DefaultDescription is used when the caller supplies no description. The nuspec
+// schema requires the element, and this is what the flag help has always
+// promised.
+const DefaultDescription = "A deployment package created from files on disk."
 
 type NuPkgCreateFlags struct {
 	Author           *flag.Flag[[]string] // this need to be multiple and default to current user
@@ -112,22 +118,32 @@ func createRun(cmd *cobra.Command, opts *NuPkgCreateOptions) error {
 		return err
 	}
 
-	nuspecFilePath := ""
-	if shouldGenerateNuSpec(opts) {
-		defer func() {
-			if nuspecFilePath != "" {
-				err := os.Remove(nuspecFilePath)
-				if err != nil {
-					panic(err)
-				}
-			}
-		}()
-		nuspecFilePath, err = GenerateNuSpec(opts)
+	// Every .nupkg needs a manifest: readers locate it by looking for a single
+	// .nuspec in the archive root, so a package without one is not a valid NuGet
+	// package even though it is a perfectly good zip. Generate one unless the
+	// base path already supplies it, in which case that file is authoritative and
+	// must not be touched.
+	nuspecFileName := opts.Id.Value + ".nuspec"
+	suppliedNuSpec, err := hasSuppliedNuSpec(opts.BasePath.Value, nuspecFileName)
+	if err != nil {
+		return err
+	}
+
+	if suppliedNuSpec {
+		pack.VerboseOut(opts.Writer, opts.Verbose.Value, "Using existing nuspec file \"%s\"\n", nuspecFileName)
+	} else {
+		nuspecFilePath, err := GenerateNuSpec(opts)
 		if err != nil {
 			return err
 		}
-		opts.Include.Value = append(opts.Include.Value, opts.Id.Value+".nuspec")
+		defer func() {
+			if err := os.Remove(nuspecFilePath); err != nil {
+				pack.VerboseOut(opts.Writer, opts.Verbose.Value, "Could not remove generated nuspec file \"%s\": %v\n", nuspecFilePath, err)
+			}
+		}()
 	}
+
+	opts.Include.Value = append(opts.Include.Value, nuspecFileName)
 
 	pack.VerboseOut(opts.Writer, opts.Verbose.Value, "Packing \"%s\" version \"%s\"...\n", opts.Id.Value, opts.Version.Value)
 	outFilePath := pack.BuildOutFileName("nupkg", opts.Id.Value, opts.Version.Value)
@@ -198,7 +214,7 @@ func PromptMissing(opts *NuPkgCreateOptions) error {
 			if err := opts.Ask(&survey.Input{
 				Message: "Nuspec description",
 				Help:    "The description to include in the Nuspec file.",
-				Default: "A deployment package created from files on disk.",
+				Default: DefaultDescription,
 			}, &opts.Description.Value); err != nil {
 				return err
 			}
@@ -246,13 +262,36 @@ func applyDefaultsToUnspecifiedPackageOptions(opts *NuPkgCreateOptions) error {
 		opts.Include.Value = append(opts.Include.Value, "**")
 	}
 
-	if len(opts.Author.Value) > 0 {
-		if opts.Description.Value == "" {
-			opts.Description.Value = "A deployment package created from files on disk."
-		}
+	// A manifest is generated for every package now, so these two are no longer
+	// only relevant when the caller opted into metadata: the nuspec schema
+	// requires both, and leaving them out produces a package strict readers
+	// reject.
+	if opts.Description.Value == "" {
+		opts.Description.Value = DefaultDescription
+	}
+
+	if util.Empty(opts.Author.Value) {
+		opts.Author.Value = []string{defaultAuthor(opts.Id.Value)}
 	}
 
 	return nil
+}
+
+// defaultAuthor mirrors what the old Octopus CLI did, and what the Author flag
+// has always said it should do. Where the user cannot be determined the package
+// ID stands in: the element is required, and an obvious placeholder beats
+// failing the command over metadata nobody asked for.
+// currentUser is a seam: user lookup fails on some minimal container images, and
+// the fallback needs to be reachable in a test.
+var currentUser = user.Current
+
+func defaultAuthor(fallback string) string {
+	if current, err := currentUser(); err == nil {
+		if name := strings.TrimSpace(current.Username); name != "" {
+			return name
+		}
+	}
+	return fallback
 }
 
 func getReleaseNotesFromFile(filePath string) (string, error) {
@@ -269,22 +308,22 @@ func getReleaseNotesFromFile(filePath string) (string, error) {
 	return string(notes), nil
 }
 
-func shouldGenerateNuSpec(opts *NuPkgCreateOptions) bool {
-	return opts.Description.Value != "" ||
-		opts.Title.Value != "" ||
-		opts.ReleaseNotes.Value != "" ||
-		opts.ReleaseNotesFile.Value != "" ||
-		!util.Empty(opts.Author.Value)
+// hasSuppliedNuSpec reports whether the base path already contains a manifest
+// for this package. One written by hand is the user's own file: it is theirs to
+// keep, and generating over the top of it would both discard their metadata and
+// delete the file on the way out.
+func hasSuppliedNuSpec(basePath string, nuspecFileName string) (bool, error) {
+	_, err := os.Stat(filepath.Join(basePath, nuspecFileName))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func GenerateNuSpec(opts *NuPkgCreateOptions) (string, error) {
-
-	if opts.Description.Value == "" {
-		return "", errors.New("description is required when generating nuspec metadata")
-	}
-	if len(opts.Author.Value) == 0 {
-		return "", errors.New("at least one author is required when generating nuspec metadata")
-	}
 
 	releaseNotes := opts.ReleaseNotes.Value
 	if opts.ReleaseNotesFile.Value != "" {

--- a/pkg/cmd/package/nuget/create/create.go
+++ b/pkg/cmd/package/nuget/create/create.go
@@ -1,6 +1,8 @@
 package create
 
 import (
+	"bytes"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"os"
@@ -308,6 +310,18 @@ func getReleaseNotesFromFile(filePath string) (string, error) {
 	return string(notes), nil
 }
 
+// escapeXML makes a value safe to drop between two tags. Release notes and
+// descriptions are free text, and an unescaped ampersand or angle bracket is
+// enough to make the whole manifest unparseable.
+func escapeXML(value string) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(value)); err != nil {
+		// EscapeText only fails if the writer fails, and bytes.Buffer does not.
+		return value
+	}
+	return buf.String()
+}
+
 // hasSuppliedNuSpec reports whether the base path already contains a manifest
 // for this package. One written by hand is the user's own file: it is theirs to
 // keep, and generating over the top of it would both discard their metadata and
@@ -344,15 +358,15 @@ func GenerateNuSpec(opts *NuPkgCreateOptions) (string, error) {
 	sb.WriteString(`<?xml version="1.0" encoding="utf-8"?>` + "\n")
 	sb.WriteString(`<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">` + "\n")
 	sb.WriteString("  <metadata>\n")
-	sb.WriteString("    <id>" + opts.Id.Value + "</id>\n")
-	sb.WriteString("    <version>" + opts.Version.Value + "</version>\n")
+	sb.WriteString("    <id>" + escapeXML(opts.Id.Value) + "</id>\n")
+	sb.WriteString("    <version>" + escapeXML(opts.Version.Value) + "</version>\n")
 	if opts.Title.Value != "" {
-		sb.WriteString("    <title>" + opts.Title.Value + "</title>\n")
+		sb.WriteString("    <title>" + escapeXML(opts.Title.Value) + "</title>\n")
 	}
-	sb.WriteString("    <description>" + opts.Description.Value + "</description>\n")
-	sb.WriteString("    <authors>" + strings.Join(opts.Author.Value, ",") + "</authors>\n")
+	sb.WriteString("    <description>" + escapeXML(opts.Description.Value) + "</description>\n")
+	sb.WriteString("    <authors>" + escapeXML(strings.Join(opts.Author.Value, ",")) + "</authors>\n")
 	if releaseNotes != "" {
-		sb.WriteString("    <releaseNotes>" + releaseNotes + "</releaseNotes>\n")
+		sb.WriteString("    <releaseNotes>" + escapeXML(releaseNotes) + "</releaseNotes>\n")
 	}
 	sb.WriteString("  </metadata>\n")
 	sb.WriteString("</package>\n")

--- a/pkg/cmd/package/nuget/create/create_test.go
+++ b/pkg/cmd/package/nuget/create/create_test.go
@@ -1,0 +1,199 @@
+package create
+
+import (
+	"encoding/xml"
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pack "github.com/OctopusDeploy/cli/pkg/cmd/package/support"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nuspec is the subset of the manifest these tests care about, used to assert
+// against parsed XML rather than raw substrings.
+type nuspec struct {
+	Metadata struct {
+		Id           string `xml:"id"`
+		Version      string `xml:"version"`
+		Title        string `xml:"title"`
+		Description  string `xml:"description"`
+		Authors      string `xml:"authors"`
+		ReleaseNotes string `xml:"releaseNotes"`
+	} `xml:"metadata"`
+}
+
+func newTestOptions(t *testing.T, basePath string) *NuPkgCreateOptions {
+	t.Helper()
+
+	opts := &NuPkgCreateOptions{
+		NuPkgCreateFlags:     NewNuPkgCreateFlags(),
+		PackageCreateOptions: &pack.PackageCreateOptions{PackageCreateFlags: pack.NewPackageCreateFlags()},
+	}
+	opts.Id.Value = "Acme.Web"
+	opts.Version.Value = "1.2.3"
+	opts.BasePath.Value = basePath
+	return opts
+}
+
+func generateAndParse(t *testing.T, opts *NuPkgCreateOptions) (nuspec, string) {
+	t.Helper()
+
+	path, err := GenerateNuSpec(opts)
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var parsed nuspec
+	require.NoError(t, xml.Unmarshal(contents, &parsed), "generated nuspec should be well-formed XML")
+
+	return parsed, string(contents)
+}
+
+// The manifest is what makes a .nupkg a NuGet package rather than a zip, and
+// the OPC relationships part points at it by name whether or not it exists.
+func TestGeneratesNuSpecWithNoMetadataSupplied(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	parsed, _ := generateAndParse(t, opts)
+
+	assert.Equal(t, "Acme.Web", parsed.Metadata.Id)
+	assert.Equal(t, "1.2.3", parsed.Metadata.Version)
+	assert.NotEmpty(t, parsed.Metadata.Description, "description is required by the nuspec schema")
+	assert.NotEmpty(t, parsed.Metadata.Authors, "authors is required by the nuspec schema")
+}
+
+func TestDescriptionDefaultsWhenNotSupplied(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	assert.Equal(t, DefaultDescription, opts.Description.Value)
+}
+
+func TestSuppliedDescriptionIsKept(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	opts.Description.Value = "Something specific"
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	assert.Equal(t, "Something specific", opts.Description.Value)
+}
+
+func TestAuthorDefaultsToCurrentUser(t *testing.T) {
+	current, err := user.Current()
+	require.NoError(t, err)
+
+	opts := newTestOptions(t, t.TempDir())
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	assert.Equal(t, []string{current.Username}, opts.Author.Value)
+}
+
+func TestSuppliedAuthorsAreKept(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	opts.Author.Value = []string{"Ada", "Grace"}
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	parsed, _ := generateAndParse(t, opts)
+
+	assert.Equal(t, []string{"Ada", "Grace"}, opts.Author.Value)
+	assert.Equal(t, "Ada,Grace", parsed.Metadata.Authors)
+}
+
+// User lookup fails on some minimal container images. The command should still
+// produce a schema-valid manifest rather than failing over metadata nobody asked
+// for.
+func TestDefaultAuthorFallsBackWhenUserIsUnknown(t *testing.T) {
+	original := currentUser
+	t.Cleanup(func() { currentUser = original })
+	currentUser = func() (*user.User, error) { return nil, errors.New("no user") }
+
+	assert.Equal(t, "Acme.Web", defaultAuthor("Acme.Web"))
+}
+
+func TestDefaultAuthorFallsBackWhenUsernameIsBlank(t *testing.T) {
+	original := currentUser
+	t.Cleanup(func() { currentUser = original })
+	currentUser = func() (*user.User, error) { return &user.User{Username: "  "}, nil }
+
+	assert.Equal(t, "Acme.Web", defaultAuthor("Acme.Web"))
+}
+
+func TestPackageIsStillUsableWhenUserLookupFails(t *testing.T) {
+	original := currentUser
+	t.Cleanup(func() { currentUser = original })
+	currentUser = func() (*user.User, error) { return nil, errors.New("no user") }
+
+	opts := newTestOptions(t, t.TempDir())
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	parsed, _ := generateAndParse(t, opts)
+
+	assert.Equal(t, "Acme.Web", parsed.Metadata.Authors)
+}
+
+// A hand-written manifest is the user's own file. Generating over the top would
+// discard their metadata, and the cleanup step would then delete it outright.
+func TestExistingNuSpecIsDetected(t *testing.T) {
+	basePath := t.TempDir()
+	existing := filepath.Join(basePath, "Acme.Web.nuspec")
+	require.NoError(t, os.WriteFile(existing, []byte("<package><metadata><id>Acme.Web</id></metadata></package>"), 0644))
+
+	supplied, err := hasSuppliedNuSpec(basePath, "Acme.Web.nuspec")
+
+	require.NoError(t, err)
+	assert.True(t, supplied)
+}
+
+func TestMissingNuSpecIsNotMistakenForOne(t *testing.T) {
+	supplied, err := hasSuppliedNuSpec(t.TempDir(), "Acme.Web.nuspec")
+
+	require.NoError(t, err)
+	assert.False(t, supplied)
+}
+
+func TestTitleIsOmittedWhenNotSupplied(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	_, raw := generateAndParse(t, opts)
+
+	assert.NotContains(t, raw, "<title>")
+}
+
+func TestReleaseNotesAreIncludedWhenSupplied(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	opts.ReleaseNotes.Value = "Fixed a thing"
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	parsed, _ := generateAndParse(t, opts)
+
+	assert.Equal(t, "Fixed a thing", parsed.Metadata.ReleaseNotes)
+}
+
+func TestReleaseNotesAndReleaseNotesFileAreMutuallyExclusive(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	opts.ReleaseNotes.Value = "Fixed a thing"
+	opts.ReleaseNotesFile.Value = "notes.txt"
+
+	_, err := GenerateNuSpec(opts)
+
+	assert.ErrorContains(t, err, "cannot specify both")
+}
+
+func TestNuSpecIsWrittenIntoTheBasePath(t *testing.T) {
+	basePath := t.TempDir()
+	opts := newTestOptions(t, basePath)
+	require.NoError(t, applyDefaultsToUnspecifiedPackageOptions(opts))
+
+	path, err := GenerateNuSpec(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(basePath, "Acme.Web.nuspec"), path)
+	assert.True(t, strings.HasSuffix(path, ".nuspec"))
+}

--- a/pkg/cmd/package/nuget/create/create_test.go
+++ b/pkg/cmd/package/nuget/create/create_test.go
@@ -186,6 +186,28 @@ func TestReleaseNotesAndReleaseNotesFileAreMutuallyExclusive(t *testing.T) {
 	assert.ErrorContains(t, err, "cannot specify both")
 }
 
+// Descriptions and release notes are free text. An unescaped ampersand or angle
+// bracket is enough to make the whole manifest unparseable, which matters more
+// now that one is written for every package.
+func TestMetadataIsXmlEscaped(t *testing.T) {
+	opts := newTestOptions(t, t.TempDir())
+	opts.Description.Value = `Fish & chips <b>bold</b>`
+	opts.Title.Value = `A "quoted" title`
+	opts.ReleaseNotes.Value = `1 < 2 && 3 > 2`
+	opts.Author.Value = []string{"Ada & Grace"}
+
+	parsed, raw := generateAndParse(t, opts)
+
+	assert.NotContains(t, raw, "Fish & chips", "raw ampersand should have been escaped")
+	assert.Contains(t, raw, "&amp;")
+
+	// Round-tripping is the real assertion: what went in is what comes back out.
+	assert.Equal(t, `Fish & chips <b>bold</b>`, parsed.Metadata.Description)
+	assert.Equal(t, `A "quoted" title`, parsed.Metadata.Title)
+	assert.Equal(t, `1 < 2 && 3 > 2`, parsed.Metadata.ReleaseNotes)
+	assert.Equal(t, "Ada & Grace", parsed.Metadata.Authors)
+}
+
 func TestNuSpecIsWrittenIntoTheBasePath(t *testing.T) {
 	basePath := t.TempDir()
 	opts := newTestOptions(t, basePath)


### PR DESCRIPTION
Actions https://github.com/OctopusDeploy/cli/pull/632#issuecomment-5199368526, raised by @YuKitsune while reviewing #632. Pre-existing on `main`, so it is here rather than there.

## Problem

`package nuget create` only generated the `.nuspec` when the caller supplied a description, title, release notes or author. Ask for nothing but an ID and a version and the command reports success, but the `.nupkg` has no manifest in it — a valid zip, and not a valid NuGet package:

```console
$ octopus package nuget create --id Acme.Web --version 1.2.3 --base-path src --no-prompt
Successfully created package Acme.Web.1.2.3.nupkg

$ unzip -l Acme.Web.1.2.3.nupkg
        6  app.txt          <-- that is the whole package
```

Readers locate the manifest by looking for a single `.nuspec` in the archive root, so there is nothing for them to find. #632 makes this sharper: `buildOpcParts` writes `_rels/.rels` with a relationship pointing at `/{id}.nuspec` unconditionally, so the package also carries a reference to a part that was never created.

## Change

Generate a manifest for every package:

```console
$ unzip -l Acme.Web.1.2.3.nupkg
      313  Acme.Web.nuspec
        6  app.txt

$ unzip -p Acme.Web.1.2.3.nupkg Acme.Web.nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
  <metadata>
    <id>Acme.Web</id>
    <version>1.2.3</version>
    <description>A deployment package created from files on disk.</description>
    <authors>nickj</authors>
  </metadata>
</package>
```

The schema requires `description` and `authors` alongside `id` and `version`, so both now default instead of being filled in only when the caller had already opted into metadata:

| | default | note |
|---|---|---|
| `description` | `A deployment package created from files on disk.` | already what `--description` help promises |
| `authors` | the current OS user | what the `Author` flag's own comment says it should be, and what the old Octopus CLI did |

**The author default is the debatable part** — it puts a machine username into package metadata for anyone who does not pass `--author`. The alternatives were omitting the element (schema-invalid) or a placeholder. Happy to change it. If the user cannot be determined, which happens on minimal container images, the package ID stands in so the command still succeeds.

### Not clobbering a hand-written nuspec

Generating unconditionally introduced a way to destroy someone's file: `GenerateNuSpec` writes to `{basePath}/{id}.nuspec` and the caller deletes that path afterwards. Anyone keeping a hand-written manifest in their base path would have had it overwritten and then removed. A supplied nuspec is now detected, packed as-is, and never touched.

## Second commit: XML escaping

The manifest is assembled by string concatenation, so an ampersand or angle bracket in a description or release notes produced a document no XML parser would accept — `fixed A & B` is enough. Survivable while the nuspec was opt-in; now it is on the path everyone takes.

Separate commit (5d04abf) so it can be dropped if you would rather see it on its own.

## Verification

15 unit tests in `pkg/cmd/package/nuget/create/create_test.go`, asserting against parsed XML rather than substrings. They cover the manifest being generated with no metadata supplied, both defaults, a supplied nuspec being detected, the user-lookup fallback, and escaped values round-tripping.

Checked end to end against a built binary: the before/after `unzip` output above is real, a hand-written nuspec survives byte-identical (`diff -q` clean) and is the one that gets packed, and the generated file is cleaned up from the base path afterwards.

## Interaction with #632

Both touch `create.go` but in different places — this one around nuspec generation, #632 around the `BuildPackageWithContents` call. Whichever lands second may need a trivial rebase. Once both are in, `_rels/.rels` points at a part that always exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)