### PR TITLE
ci: skip integration tests on Dependabot branches

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,6 +16,13 @@ env:
   SERVER_URL: "http://localhost:8080"
 jobs:
   test:
+    # Dependabot-triggered runs cannot read Actions secrets -- GitHub scopes those
+    # to a separate Dependabot secrets store -- so SA_PASSWORD resolves to empty,
+    # SQL Server rejects every login, and the service container never turns
+    # healthy. Skip rather than fail red: the nightly run on main covers merged
+    # bumps, and `gh workflow run integration-test.yml --ref <branch>` still works
+    # on a Dependabot branch, because the triggering actor is then a human.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     services:
       sqlserver:


### PR DESCRIPTION
Fixes the red X on every Dependabot PR opened since #630 (#671, #672, #673). One line plus a comment.

## Why they fail

Not the dependency bumps. GitHub scopes secrets for Dependabot-triggered runs to a **separate Dependabot secrets store**, so `DB_IMAGE_SA_PASSWORD`, `OD_IMAGE_ADMIN_API_KEY` and `OCTOPUS_SERVER_BASE64_LICENSE` all resolve to empty strings. The log shows it unmasked — a real secret would print as `***`:

```
-e "DB_CONNECTION_STRING=Server=sqlserver;Database=OctopusDeploy;User Id=sa;Password=;"
```

SQL Server rejects every login (`Login failed for user 'sa'. Reason: An error occurred while evaluating the password`), the health check never passes, the container is marked `unhealthy`, and the job dies at **Initialize containers** before a single test runs.

The split is clean:

| Branch | Result |
|---|---|
| `dependabot/go_modules/...cobra-1.10.2` | ❌ failure |
| `dependabot/go_modules/...go-octopusdeploy-2.114.1` | ❌ failure |
| `dependabot/go_modules/...doublestar-4.10.0` | ❌ failure |
| human branches, `main`, `release-please--*`, nightly `schedule` | ✅ success |

This is a latent incompatibility in this workflow that enabling Dependabot in #630 exposed, not a regression in it.

## Why skip rather than supply the secrets

Copying those three into the Dependabot store would start the containers, but it hands an Octopus license and a test API key to a run whose dependency tree just changed and which executes third-party code via `go test`. It also **still wouldn't go green** — `dorny/test-reporter` needs `checks: write`, and the Dependabot `GITHUB_TOKEN` stays read-only no matter what the `permissions:` block says.

## Coverage is retained

- The **nightly run on `main`** (5am Brisbane, currently passing) picks up any merged bump within a day.
- `workflow_dispatch` still works on a Dependabot branch, because the triggering actor is then a human and secrets resolve normally:

```
gh workflow run integration-test.yml --ref dependabot/go_modules/github.com/OctopusDeploy/go-octopusdeploy/v2-2.114.1
```

I've kicked exactly that off against #672 — `go-octopusdeploy` is the client library these tests actually exercise, so it's the one bump where the coverage genuinely matters. Result linked in that PR.

`if: github.actor != 'dependabot[bot]'` at the job level makes the check **skipped** rather than failed, so it stays visible as not-run instead of reading as a broken build. Manual dispatch is unaffected by the condition since `github.actor` is the dispatcher.

Note `main` currently has no required status checks, so these failures were noise rather than a merge gate — but noise that trains people to ignore a red X on dependency PRs is worth removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
