### PR TITLE
docs: fix typos in README Makefile section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ If successful, the go compiler does not output anything. You should now have an 
 
 **Makefile**
 
-If you are using a sytem that has `make` installed, then you can also simpl run `make` in the cli root folder.
+If you are using a system that has `make` installed, then you can also simply run `make` in the cli root folder.
 The default action for the `Makefile` is to run `go build`, as above.
 
 ## Running the CLI


### PR DESCRIPTION
Fixes two typos in the Makefile section of the README: `sytem` → `system` and `simpl` → `simply`.

This is the one still-applicable change from #328, which is otherwise superseded by #533 (`project view -f`) and #555 (`project variable view -f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)