### PR TITLE
fix: resolve the project in release progression allow and prevent

### DIFF
--- a/pkg/cmd/release/progression/allow/allow.go
+++ b/pkg/cmd/release/progression/allow/allow.go
@@ -14,7 +14,6 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/defects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
 	"github.com/spf13/cobra"
 )
 
@@ -142,17 +141,21 @@ func PromptMissing(opts *AllowOptions) error {
 		if err != nil {
 			return err
 		}
-	}
-	opts.Project.Value = selectedProject.GetName()
-
-	var selectedRelease *releases.Release
-	if opts.Version.Value == "" {
-		selectedRelease, err = shared.SelectRelease(opts.Client, selectedProject, opts.Ask, "Allow")
+	} else { // project is already provided, fetch the object because the release prompt needs it
+		selectedProject, err = selectors.FindProject(opts.Client, opts.Project.Value)
 		if err != nil {
 			return err
 		}
 	}
-	opts.Version.Value = selectedRelease.Version
+	opts.Project.Value = selectedProject.GetName()
+
+	if opts.Version.Value == "" {
+		selectedRelease, err := shared.SelectRelease(opts.Client, selectedProject, opts.Ask, "Allow")
+		if err != nil {
+			return err
+		}
+		opts.Version.Value = selectedRelease.Version
+	}
 
 	return nil
 }

--- a/pkg/cmd/release/progression/allow/allow_test.go
+++ b/pkg/cmd/release/progression/allow/allow_test.go
@@ -1,0 +1,123 @@
+package allow_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2"
+	cmdRoot "github.com/OctopusDeploy/cli/pkg/cmd/root"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/test/fixtures"
+	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/defects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+var rootResource = testutil.NewRootResource()
+
+func TestReleaseProgressionAllow(t *testing.T) {
+	const spaceID = "Spaces-1"
+	const projectID = "Projects-22"
+	const releaseID = "Releases-9"
+
+	space1 := fixtures.NewSpace(spaceID, "Default Space")
+	fireProject := fixtures.NewProject(spaceID, projectID, "Fire Project", "Lifecycles-1", "ProjectGroups-1", "")
+
+	release := releases.NewRelease("Channels-1", projectID, "1.0")
+	release.ID = releaseID
+	release.SpaceID = spaceID
+
+	blockedDefect := &defects.Defect{Status: defects.DefectStatusUnresolved}
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer)
+	}{
+		// Regression: --project supplied interactively used to leave selectedProject nil,
+		// which panicked on selectedProject.GetName().
+		{"allow prompts for the release when the project is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "progression", "allow", "--project", projectID})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+
+			// the supplied project is looked up so the release prompt has something to work with
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22").RespondWith(fireProject)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
+				RespondWith(resources.Resources[*releases.Release]{Items: []*releases.Release{release}})
+
+			_ = qa.ExpectQuestion(t, &survey.Select{
+				Message: "Select Release to Allow Progression for",
+				Options: []string{"1.0"},
+			}).AnswerWith("1.0")
+
+			// PromptMissing normalises Project.Value to the project name, so the lookup is by name
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Fire Project").RespondWith(fireProject)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases/1.0").RespondWith(release)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/releases/Releases-9/defects").
+				RespondWith(resources.Resources[*defects.Defect]{Items: []*defects.Defect{blockedDefect}})
+			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/Releases-9/defects/resolve").
+				RespondWith(&defects.Defect{Status: defects.DefectStatusResolved})
+
+			_, err := testutil.ReceivePair(cmdReceiver)
+			assert.Nil(t, err)
+			assert.Contains(t, stdOut.String(), "Successfully allowed progression for release 1.0")
+			assert.Equal(t, "", stdErr.String())
+		}},
+
+		// Regression: --version supplied interactively used to leave selectedRelease nil,
+		// which panicked on selectedRelease.Version.
+		{"allow prompts for the project when the version is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "progression", "allow", "--version", "1.0"})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/all").RespondWith([]*projects.Project{fireProject})
+
+			_ = qa.ExpectQuestion(t, &survey.Select{
+				Message: "Select the project in which the blocked release exists",
+				Options: []string{"Fire Project"},
+			}).AnswerWith("Fire Project")
+
+			// --version was supplied, so no release prompt is shown; we go straight to the lookup
+			// PromptMissing normalises Project.Value to the project name, so the lookup is by name
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Fire Project").RespondWith(fireProject)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases/1.0").RespondWith(release)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/releases/Releases-9/defects").
+				RespondWith(resources.Resources[*defects.Defect]{Items: []*defects.Defect{blockedDefect}})
+			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/Releases-9/defects/resolve").
+				RespondWith(&defects.Defect{Status: defects.DefectStatusResolved})
+
+			_, err := testutil.ReceivePair(cmdReceiver)
+			assert.Nil(t, err)
+			assert.Contains(t, stdOut.String(), "Successfully allowed progression for release 1.0")
+			assert.Equal(t, "", stdErr.String())
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			api, qa := testutil.NewMockServerAndAsker()
+			askProvider := question.NewAskProvider(qa.AsAsker())
+			fac := testutil.NewMockFactoryWithSpaceAndPrompt(api, space1, askProvider)
+			rootCmd := cmdRoot.NewCmdRoot(fac, nil, askProvider)
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+			test.run(t, api, qa, rootCmd, stdout, stderr)
+		})
+	}
+}

--- a/pkg/cmd/release/progression/prevent/prevent.go
+++ b/pkg/cmd/release/progression/prevent/prevent.go
@@ -15,7 +15,6 @@ import (
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/defects"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
 	"github.com/spf13/cobra"
 )
 
@@ -160,12 +159,16 @@ func PromptMissing(opts *PreventOptions) error {
 		if err != nil {
 			return err
 		}
-		opts.Project.Value = selectedProject.GetName()
+	} else { // project is already provided, fetch the object because the release prompt needs it
+		selectedProject, err = selectors.FindProject(opts.Client, opts.Project.Value)
+		if err != nil {
+			return err
+		}
 	}
+	opts.Project.Value = selectedProject.GetName()
 
-	var selectedRelease *releases.Release
 	if opts.Version.Value == "" {
-		selectedRelease, err = shared.SelectRelease(opts.Client, selectedProject, opts.Ask, "Prevent")
+		selectedRelease, err := shared.SelectRelease(opts.Client, selectedProject, opts.Ask, "Prevent")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/release/progression/prevent/prevent_test.go
+++ b/pkg/cmd/release/progression/prevent/prevent_test.go
@@ -1,0 +1,118 @@
+package prevent_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2"
+	cmdRoot "github.com/OctopusDeploy/cli/pkg/cmd/root"
+	"github.com/OctopusDeploy/cli/pkg/question"
+	"github.com/OctopusDeploy/cli/test/fixtures"
+	"github.com/OctopusDeploy/cli/test/testutil"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/defects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+var rootResource = testutil.NewRootResource()
+
+func TestReleaseProgressionPrevent(t *testing.T) {
+	const spaceID = "Spaces-1"
+	const projectID = "Projects-22"
+	const releaseID = "Releases-9"
+
+	space1 := fixtures.NewSpace(spaceID, "Default Space")
+	fireProject := fixtures.NewProject(spaceID, projectID, "Fire Project", "Lifecycles-1", "ProjectGroups-1", "")
+
+	release := releases.NewRelease("Channels-1", projectID, "1.0")
+	release.ID = releaseID
+	release.SpaceID = spaceID
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer)
+	}{
+		// Regression: --project supplied interactively used to leave selectedProject nil, which
+		// was then handed to SelectRelease and failed with "invalid parameter project".
+		{"prevent prompts for the release when the project is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "progression", "prevent", "--project", projectID, "--reason", "It's broken"})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+
+			// the supplied project is looked up so the release prompt has something to work with
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22").RespondWith(fireProject)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases").
+				RespondWith(resources.Resources[*releases.Release]{Items: []*releases.Release{release}})
+
+			_ = qa.ExpectQuestion(t, &survey.Select{
+				Message: "Select Release to Prevent Progression for",
+				Options: []string{"1.0"},
+			}).AnswerWith("1.0")
+
+			// PromptMissing normalises Project.Value to the project name, so the lookup is by name
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Fire Project").RespondWith(fireProject)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases/1.0").RespondWith(release)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/releases/Releases-9/defects").
+				RespondWith(resources.Resources[*defects.Defect]{Items: []*defects.Defect{}})
+			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/Releases-9/defects").
+				RespondWith(&defects.Defect{Status: defects.DefectStatusUnresolved})
+
+			_, err := testutil.ReceivePair(cmdReceiver)
+			assert.Nil(t, err)
+			assert.Contains(t, stdOut.String(), "Successfully prevented progression for release 1.0")
+			assert.Equal(t, "", stdErr.String())
+		}},
+
+		{"prevent prompts for the project when the version is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "progression", "prevent", "--version", "1.0", "--reason", "It's broken"})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/all").RespondWith([]*projects.Project{fireProject})
+
+			_ = qa.ExpectQuestion(t, &survey.Select{
+				Message: "Selected the project in which the release to be blocked exists",
+				Options: []string{"Fire Project"},
+			}).AnswerWith("Fire Project")
+
+			// --version was supplied, so no release prompt is shown
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Fire Project").RespondWith(fireProject)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22/releases/1.0").RespondWith(release)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/releases/Releases-9/defects").
+				RespondWith(resources.Resources[*defects.Defect]{Items: []*defects.Defect{}})
+			api.ExpectRequest(t, "POST", "/api/Spaces-1/releases/Releases-9/defects").
+				RespondWith(&defects.Defect{Status: defects.DefectStatusUnresolved})
+
+			_, err := testutil.ReceivePair(cmdReceiver)
+			assert.Nil(t, err)
+			assert.Contains(t, stdOut.String(), "Successfully prevented progression for release 1.0")
+			assert.Equal(t, "", stdErr.String())
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			api, qa := testutil.NewMockServerAndAsker()
+			askProvider := question.NewAskProvider(qa.AsAsker())
+			fac := testutil.NewMockFactoryWithSpaceAndPrompt(api, space1, askProvider)
+			rootCmd := cmdRoot.NewCmdRoot(fac, nil, askProvider)
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+			test.run(t, api, qa, rootCmd, stdout, stderr)
+		})
+	}
+}

--- a/pkg/cmd/release/progression/prevent/prevent_test.go
+++ b/pkg/cmd/release/progression/prevent/prevent_test.go
@@ -71,7 +71,7 @@ func TestReleaseProgressionPrevent(t *testing.T) {
 			assert.Equal(t, "", stdErr.String())
 		}},
 
-		{"prevent prompts for the project when the version is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+		{"prevent prompts for the release when the version is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
 			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
 				defer api.Close()
 				rootCmd.SetArgs([]string{"release", "progression", "prevent", "--version", "1.0", "--reason", "It's broken"})

--- a/pkg/cmd/release/progression/prevent/prevent_test.go
+++ b/pkg/cmd/release/progression/prevent/prevent_test.go
@@ -37,7 +37,7 @@ func TestReleaseProgressionPrevent(t *testing.T) {
 	}{
 		// Regression: --project supplied interactively used to leave selectedProject nil, which
 		// was then handed to SelectRelease and failed with "invalid parameter project".
-		{"prevent prompts for the release when the project is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+		{"prevent prompts for the project when the project is supplied", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
 			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
 				defer api.Close()
 				rootCmd.SetArgs([]string{"release", "progression", "prevent", "--project", projectID, "--reason", "It's broken"})


### PR DESCRIPTION
`octopus release progression allow --project X` panics.

Both commands only assign `selectedProject` when `--project` is absent, then use it regardless:

```go
if opts.Project.Value == "" {
    selectedProject, err = selectors.Project(...)   // only assigned when empty
}
opts.Project.Value = selectedProject.GetName()      // nil when --project was given
```

`PromptMissing` runs whenever prompting is enabled, so supplying `--project` interactively dereferences nil. The same shape makes `--version` panic on `selectedRelease.Version`.

`prevent` keeps its assignments inside the `if`, so it doesn't panic — but it hands the nil project to `SelectRelease`, which fails with `invalid parameter project` instead of listing releases.

## Fix

Look the project up when it was supplied, so the release prompt has a real project, and only assign the version on the path that prompts for it.

## Tests

First tests for either command. Both directions covered: `--project` supplied with the release prompted, and `--version` supplied with the project prompted.

Verified they fail without the fix — `allow` panics on `(*Project).GetName`, `prevent` hangs waiting for a project lookup that never happens.

Found while auditing `selectors.Project` call sites for #667, which deliberately left these two alone because adopting the shared helper there would change behaviour rather than just deduplicate. Independent of #609/#667 and mergeable on its own.