### PR TITLE
refactor: address channel command review feedback

### DIFF
--- a/pkg/cmd/channel/delete/delete.go
+++ b/pkg/cmd/channel/delete/delete.go
@@ -2,21 +2,15 @@ package delete
 
 import (
 	"errors"
-	"fmt"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"github.com/OctopusDeploy/cli/pkg/cmd/channel/shared"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
-	"github.com/OctopusDeploy/cli/pkg/output"
 	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/cli/pkg/util/flag"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/spf13/cobra"
 )
 
@@ -37,12 +31,17 @@ func NewDeleteFlags() *DeleteFlags {
 }
 
 type DeleteOptions struct {
-	Client   *client.Client
-	Ask      question.Asker
-	Out      *cobra.Command
-	NoPrompt bool
-	IdOrName string
 	*DeleteFlags
+	*cmd.Dependencies
+	IdOrName string
+}
+
+func NewDeleteOptions(dependencies *cmd.Dependencies, flags *DeleteFlags, idOrName string) *DeleteOptions {
+	return &DeleteOptions{
+		DeleteFlags:  flags,
+		Dependencies: dependencies,
+		IdOrName:     idOrName,
+	}
 }
 
 func NewCmdDelete(f factory.Factory) *cobra.Command {
@@ -56,27 +55,13 @@ func NewCmdDelete(f factory.Factory) *cobra.Command {
 			%[1]s channel delete "Hotfix" --project myProject
 			%[1]s channel rm Channels-123 --project myProject -y
 		`, constants.ExecutableName),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
-			if err != nil {
-				return err
-			}
-
+		RunE: func(c *cobra.Command, args []string) error {
 			idOrName := ""
 			if len(args) > 0 {
 				idOrName = args[0]
 			}
 
-			opts := &DeleteOptions{
-				Client:      c,
-				Ask:         f.Ask,
-				Out:         cmd,
-				NoPrompt:    !f.IsPromptEnabled(),
-				IdOrName:    idOrName,
-				DeleteFlags: deleteFlags,
-			}
-
-			return deleteRun(opts)
+			return deleteRun(NewDeleteOptions(cmd.NewDependencies(f, c), deleteFlags, idOrName))
 		},
 	}
 
@@ -88,32 +73,26 @@ func NewCmdDelete(f factory.Factory) *cobra.Command {
 }
 
 func deleteRun(opts *DeleteOptions) error {
+	// in automation mode we validate the flags up front, before making any API calls
+	if opts.NoPrompt {
+		if opts.Project.Value == "" {
+			return errors.New("project must be specified")
+		}
+		if opts.IdOrName == "" {
+			return errors.New("channel must be specified")
+		}
+	}
+
 	project, err := selectors.ResolveProject(opts.Client, opts.Ask, !opts.NoPrompt,
 		"Select the project containing the channel you wish to delete", opts.Project.Value)
 	if err != nil {
 		return err
 	}
 
-	if !opts.NoPrompt {
-		if err := promptMissing(opts, project); err != nil {
-			return err
-		}
-	}
-
-	if opts.IdOrName == "" {
-		return errors.New("channel name or ID must be specified")
-	}
-
-	itemToDelete, err := shared.ResolveChannel(opts.Client, project, opts.IdOrName)
+	itemToDelete, err := shared.ResolveChannel(opts.Client, opts.Ask, opts.Out, !opts.NoPrompt,
+		"Select the channel you wish to delete:", project, opts.IdOrName)
 	if err != nil {
 		return err
-	}
-
-	// In interactive mode, warn for version-controlled (CaC) projects since deleting a
-	// channel can break OCL deployments referencing it.
-	if !opts.NoPrompt && project.IsVersionControlled {
-		opts.Out.Printf("%s This project is version-controlled (Config-as-Code). Deleting this channel can break OCL deployments that reference it.\n",
-			output.Yellow("Warning:"))
 	}
 
 	doDelete := func() error {
@@ -124,39 +103,4 @@ func deleteRun(opts *DeleteOptions) error {
 		return doDelete()
 	}
 	return question.DeleteWithConfirmation(opts.Ask, "channel", itemToDelete.Name, itemToDelete.GetID(), doDelete)
-}
-
-func promptMissing(opts *DeleteOptions, project *projects.Project) error {
-	if opts.IdOrName != "" {
-		return nil
-	}
-	existing, err := opts.Client.Projects.GetChannels(project)
-	if err != nil {
-		return err
-	}
-	if len(existing) == 0 {
-		return fmt.Errorf("project %s has no channels", project.Name)
-	}
-	var chosenName string
-	if err := opts.Ask(&survey.Select{
-		Message: "Select the channel you wish to delete:",
-		Options: channelNames(existing),
-	}, &chosenName); err != nil {
-		return err
-	}
-	for _, c := range existing {
-		if c.Name == chosenName {
-			opts.IdOrName = c.GetID()
-			break
-		}
-	}
-	return nil
-}
-
-func channelNames(cs []*channels.Channel) []string {
-	out := make([]string, 0, len(cs))
-	for _, c := range cs {
-		out = append(out, c.Name)
-	}
-	return out
 }

--- a/pkg/cmd/channel/delete/delete_test.go
+++ b/pkg/cmd/channel/delete/delete_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/MakeNowJust/heredoc/v2"
 	cmdRoot "github.com/OctopusDeploy/cli/pkg/cmd/root"
 	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/test/fixtures"
@@ -144,60 +143,6 @@ func TestChannelDelete(t *testing.T) {
 			assert.Equal(t, "", stdErr.String())
 		}},
 
-		{"channel delete warns for version-controlled (CaC) projects", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
-			cacProject := fixtures.NewVersionControlledProject(spaceID, projectID, "Fire Project", "Lifecycles-1", "ProjectGroups-1", "")
-			cacProject.IsVersionControlled = true
-			cacChannel := fixtures.NewChannel(spaceID, "Channels-2", "Hotfix", projectID)
-			cacChannel.Type = channels.ChannelTypeLifecycle
-
-			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
-				defer api.Close()
-				rootCmd.SetArgs([]string{"channel", "delete", "Channels-2", "-p", "Projects-22", "-y"})
-				return rootCmd.ExecuteC()
-			})
-
-			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
-			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
-
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22").RespondWith(cacProject)
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels/Channels-2").RespondWith(cacChannel)
-			api.ExpectRequest(t, "DELETE", "/api/Spaces-1/channels/Channels-2").RespondWith(nil)
-
-			_, err := testutil.ReceivePair(cmdReceiver)
-			assert.Nil(t, err)
-
-			assert.Equal(t, heredoc.Doc(`
-				Warning: This project is version-controlled (Config-as-Code). Deleting this channel can break OCL deployments that reference it.
-				`), stdOut.String())
-			assert.Equal(t, "", stdErr.String())
-		}},
-
-		{"channel delete does not warn for CaC projects in automation mode", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
-			cacProject := fixtures.NewVersionControlledProject(spaceID, projectID, "Fire Project", "Lifecycles-1", "ProjectGroups-1", "")
-			cacProject.IsVersionControlled = true
-			cacChannel := fixtures.NewChannel(spaceID, "Channels-2", "Hotfix", projectID)
-			cacChannel.Type = channels.ChannelTypeLifecycle
-
-			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
-				defer api.Close()
-				rootCmd.SetArgs([]string{"channel", "delete", "Channels-2", "-p", "Projects-22", "--no-prompt", "-y"})
-				return rootCmd.ExecuteC()
-			})
-
-			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
-			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
-
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22").RespondWith(cacProject)
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels/Channels-2").RespondWith(cacChannel)
-			api.ExpectRequest(t, "DELETE", "/api/Spaces-1/channels/Channels-2").RespondWith(nil)
-
-			_, err := testutil.ReceivePair(cmdReceiver)
-			assert.Nil(t, err)
-
-			assert.Equal(t, "", stdOut.String())
-			assert.Equal(t, "", stdErr.String())
-		}},
-
 		{"channel delete will not delete a channel belonging to a different project", func(t *testing.T, api *testutil.MockHttpServer, qa *testutil.AskMocker, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
 			// Channels-99 exists, but belongs to Projects-99. It must not be deleted just
 			// because the caller named a project they do have access to.
@@ -252,8 +197,6 @@ func TestChannelDelete(t *testing.T) {
 				Options: []string{"Default", "Hotfix"},
 			}).AnswerWith("Hotfix")
 
-			// The selection is resolved to an ID, so the delete goes straight to GetByID.
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/channels/Channels-2").RespondWith(hotfixChannel)
 			api.ExpectRequest(t, "DELETE", "/api/Spaces-1/channels/Channels-2").RespondWith(nil)
 
 			_, err := testutil.ReceivePair(cmdReceiver)
@@ -278,7 +221,7 @@ func TestChannelDelete(t *testing.T) {
 				})
 
 			_, err := testutil.ReceivePair(cmdReceiver)
-			assert.EqualError(t, err, "project Fire Project has no channels")
+			assert.EqualError(t, err, "Select the channel you wish to delete: - no options available")
 
 			assert.Equal(t, "", stdErr.String())
 		}},
@@ -293,10 +236,9 @@ func TestChannelDelete(t *testing.T) {
 			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
 			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
 
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/Projects-22").RespondWith(fireProject)
-
+			// the flags are validated up front, so no project lookup is made
 			_, err := testutil.ReceivePair(cmdReceiver)
-			assert.EqualError(t, err, "channel name or ID must be specified")
+			assert.EqualError(t, err, "channel must be specified")
 
 			assert.Equal(t, "", stdOut.String())
 			assert.Equal(t, "", stdErr.String())

--- a/pkg/cmd/channel/list/list.go
+++ b/pkg/cmd/channel/list/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/OctopusDeploy/cli/pkg/apiclient"
+	"github.com/OctopusDeploy/cli/pkg/cmd/channel/shared"
 	"github.com/OctopusDeploy/cli/pkg/constants"
 	"github.com/OctopusDeploy/cli/pkg/factory"
 	"github.com/OctopusDeploy/cli/pkg/output"
@@ -64,7 +65,7 @@ func NewCmdList(f factory.Factory) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringVarP(&listFlags.Project.Value, listFlags.Project.Name, "p", "", "Name or ID of the project to list channels for")
-	flags.StringVarP(&listFlags.Filter.Value, listFlags.Filter.Name, "q", "", "filter channels to match only ones with a name containing the given string")
+	flags.StringVarP(&listFlags.Filter.Value, listFlags.Filter.Name, "q", "", "Filter channels to match only ones with a name containing the given string")
 	return cmd
 }
 
@@ -119,13 +120,17 @@ func listRun(cmd *cobra.Command, f factory.Factory, flags *ListFlags) error {
 			return item
 		},
 		Table: output.TableDefinition[ChannelViewModel]{
-			Header: []string{"NAME", "TYPE", "DEFAULT", "LIFECYCLE ID"},
+			Header: []string{"NAME", "TYPE", "DEFAULT", "LIFECYCLE"},
 			Row: func(item ChannelViewModel) []string {
 				def := ""
 				if item.IsDefault {
 					def = "*"
 				}
-				return []string{item.Name, item.Type, def, item.LifecycleID}
+				lifecycle := item.LifecycleID
+				if lifecycle == "" {
+					lifecycle = shared.InheritedLifecycle
+				}
+				return []string{item.Name, item.Type, def, lifecycle}
 			},
 		},
 		Basic: func(item ChannelViewModel) string {

--- a/pkg/cmd/channel/list/list_test.go
+++ b/pkg/cmd/channel/list/list_test.go
@@ -84,7 +84,7 @@ func TestChannelList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				NAME     TYPE       DEFAULT  LIFECYCLE ID
+				NAME     TYPE       DEFAULT  LIFECYCLE
 				Default  Lifecycle  *        Lifecycles-1
 				Hotfix   Lifecycle           Lifecycles-1
 				`), stdOut.String())
@@ -112,7 +112,7 @@ func TestChannelList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				NAME     TYPE       DEFAULT  LIFECYCLE ID
+				NAME     TYPE       DEFAULT  LIFECYCLE
 				Default  Lifecycle  *        Lifecycles-1
 				Hotfix   Lifecycle           Lifecycles-1
 				`), stdOut.String())
@@ -140,7 +140,7 @@ func TestChannelList(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, heredoc.Doc(`
-				NAME    TYPE       DEFAULT  LIFECYCLE ID
+				NAME    TYPE       DEFAULT  LIFECYCLE
 				Hotfix  Lifecycle           Lifecycles-1
 				`), stdOut.String())
 			assert.Equal(t, "", stdErr.String())
@@ -168,7 +168,7 @@ func TestChannelList(t *testing.T) {
 
 			// output.PrintArray always emits the header row, even with no matching items.
 			assert.Equal(t, heredoc.Doc(`
-				NAME  TYPE  DEFAULT  LIFECYCLE ID
+				NAME  TYPE  DEFAULT  LIFECYCLE
 				`), stdOut.String())
 			assert.Equal(t, "", stdErr.String())
 		}},

--- a/pkg/cmd/channel/shared/shared.go
+++ b/pkg/cmd/channel/shared/shared.go
@@ -1,17 +1,34 @@
 package shared
 
 import (
+	"errors"
+	"io"
+
+	"github.com/OctopusDeploy/cli/pkg/question"
 	"github.com/OctopusDeploy/cli/pkg/question/selectors"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 )
 
-// ResolveChannel finds a channel belonging to project, by ID or name. A direct
-// GetByID is tried first; if the caller supplied a name, or the ID belongs to a
-// channel in a different project, we fall back to the project-scoped lookup so we
-// never return a channel from a project the caller didn't ask for.
-func ResolveChannel(octopus *client.Client, project *projects.Project, idOrName string) (*channels.Channel, error) {
+// InheritedLifecycle is shown when a channel has no lifecycle of its own and
+// therefore inherits the project's lifecycle (e.g. the default channel).
+const InheritedLifecycle = "Inherited from project"
+
+// ResolveChannel finds the channel a command should operate on: looking it up by ID or
+// name when the caller named one, prompting for it in interactive mode when they didn't,
+// and failing in automation mode where there is nobody to ask.
+//
+// When looking up, a direct GetByID is tried first; if the caller supplied a name, or the
+// ID belongs to a channel in a different project, we fall back to the project-scoped
+// lookup so we never return a channel from a project the caller didn't ask for.
+func ResolveChannel(octopus *client.Client, ask question.Asker, out io.Writer, promptEnabled bool, questionText string, project *projects.Project, idOrName string) (*channels.Channel, error) {
+	if idOrName == "" {
+		if !promptEnabled {
+			return nil, errors.New("channel must be specified")
+		}
+		return selectors.Channel(octopus, ask, out, questionText, project)
+	}
 	if channel, err := octopus.Channels.GetByID(idOrName); err == nil && channel != nil && channel.ProjectID == project.GetID() {
 		return channel, nil
 	}

--- a/pkg/cmd/channel/view/view.go
+++ b/pkg/cmd/channel/view/view.go
@@ -25,10 +25,6 @@ import (
 const (
 	FlagProject = "project"
 	FlagWeb     = "web"
-
-	// inheritedLifecycle is shown when a channel has no lifecycle of its own and
-	// therefore inherits the project's lifecycle (e.g. the default channel).
-	inheritedLifecycle = "Inherited from project"
 )
 
 type ViewFlags struct {
@@ -100,7 +96,8 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	channel, err := shared.ResolveChannel(opts.Client, project, opts.idOrName)
+	channel, err := shared.ResolveChannel(opts.Client, opts.Ask, opts.out, opts.PromptEnabled,
+		"Select the channel you wish to view:", project, opts.idOrName)
 	if err != nil {
 		return err
 	}
@@ -151,7 +148,7 @@ func viewRun(opts *ViewOptions) error {
 				}
 				lifecycleDisplay := lifecycleName
 				if c.LifecycleID == "" {
-					lifecycleDisplay = inheritedLifecycle
+					lifecycleDisplay = shared.InheritedLifecycle
 				}
 				return []string{
 					output.Bold(c.Name),
@@ -200,7 +197,7 @@ func formatChannelForBasic(opts *ViewOptions, c *channels.Channel, lifecycleName
 
 	result.WriteString(fmt.Sprintf("Type: %s\n", string(c.Type)))
 	if c.LifecycleID == "" {
-		result.WriteString(fmt.Sprintf("Lifecycle: %s\n", inheritedLifecycle))
+		result.WriteString(fmt.Sprintf("Lifecycle: %s\n", shared.InheritedLifecycle))
 	} else {
 		result.WriteString(fmt.Sprintf("Lifecycle: %s %s\n", lifecycleName, output.Dimf("(%s)", c.LifecycleID)))
 	}


### PR DESCRIPTION
Actions the review feedback on #609. Stacked on that branch.

- `delete`: validate flags up front in automation mode, as `release delete` does
- `delete`: use `*cmd.Dependencies` instead of hand-rolled `Client`/`Ask`/`Out`/`NoPrompt` fields
- `delete`: drop the Config-as-Code warning — no other version-controlled command has one
- `shared.ResolveChannel`: prompt when no channel is given, fail in automation mode, mirroring `selectors.ResolveProject`. Removes the hand-rolled prompt in `delete`
- `list`: show `Inherited from project` when a channel has no lifecycle of its own
- `list`: capitalise the `--filter` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)