### PR TITLE
fix: bump Go to 1.26.6 to clear stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OctopusDeploy/cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
govulncheck is failing on `main` with five Go standard library advisories, all fixed in 1.26.6:

`GO-2026-6218`, `GO-2026-6090`, `GO-2026-6088`, `GO-2026-5972`, `GO-2026-5026`

Verified locally against this tree:

| Toolchain | Affecting vulnerabilities |
|---|---|
| 1.26.5 | 5 |
| 1.26.6 | **0** — `No vulnerabilities found.` |

Every workflow resolves its toolchain with `go-version-file: go.mod`, so this one directive drives all of CI. Build and the full `./pkg/...` suite pass on 1.26.6.

This blocks other PRs, not just main — #609 currently fails govulncheck for this reason (worse there, at 8, because that branch is also behind on the toolchain at 1.25.5).