### PR TITLE
fix: stop deployment target commands crashing for AWS ECS targets

### DIFF
--- a/pkg/cmd/target/azure-web-app/view/view.go
+++ b/pkg/cmd/target/azure-web-app/view/view.go
@@ -45,7 +45,11 @@ func ViewRun(opts *shared.ViewOptions) error {
 
 func contributeEndpoint(opts *shared.ViewOptions, targetEndpoint machines.IEndpoint) ([]*output.DataRow, error) {
 	data := []*output.DataRow{}
-	endpoint := targetEndpoint.(*machines.AzureWebAppEndpoint)
+	endpoint, err := shared.EndpointAs[*machines.AzureWebAppEndpoint](targetEndpoint, "Azure Web App")
+	if err != nil {
+		return nil, err
+	}
+
 	accountRows, err := shared.ContributeAccount(opts, endpoint.AccountID)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/target/kubernetes/view/view.go
+++ b/pkg/cmd/target/kubernetes/view/view.go
@@ -40,7 +40,10 @@ func ViewRun(opts *shared.ViewOptions) error {
 
 func contributeEndpoint(_ *shared.ViewOptions, targetEndpoint machines.IEndpoint) ([]*output.DataRow, error) {
 	data := []*output.DataRow{}
-	endpoint := targetEndpoint.(*machines.KubernetesEndpoint)
+	endpoint, err := shared.EndpointAs[*machines.KubernetesEndpoint](targetEndpoint, "Kubernetes")
+	if err != nil {
+		return nil, err
+	}
 
 	data = append(data, output.NewDataRow("Authentication Type", endpoint.Authentication.GetAuthenticationType()))
 

--- a/pkg/cmd/target/list/list.go
+++ b/pkg/cmd/target/list/list.go
@@ -80,13 +80,26 @@ func ListRun(opts *ListOptions) error {
 				environmentNames := resolveValues(item.EnvironmentIDs, environmentMap)
 				tenantNames := resolveValues(item.TenantIDs, tenantMap)
 				workerPool := shared.ResolveDefaultWorkerPool(item, workerPoolMap, "None")
-				return []string{output.Bold(item.Name), machinescommon.CommunicationStyleToDescriptionMap[item.Endpoint.GetCommunicationStyle()], output.FormatAsList(item.Roles), output.FormatAsList(environmentNames), output.FormatAsList(tenantNames), output.FormatAsList(item.TenantTags), workerPool}
+				return []string{output.Bold(item.Name), describeTargetType(item), output.FormatAsList(item.Roles), output.FormatAsList(environmentNames), output.FormatAsList(tenantNames), output.FormatAsList(item.TenantTags), workerPool}
 			},
 		},
 		Basic: func(item *machines.DeploymentTarget) string {
 			return item.Name
 		},
 	})
+}
+
+func describeTargetType(target *machines.DeploymentTarget) string {
+	communicationStyle := shared.GetCommunicationStyle(target)
+	if communicationStyle == "" {
+		return shared.UnknownValue
+	}
+
+	if description, ok := machinescommon.CommunicationStyleToDescriptionMap[communicationStyle]; ok {
+		return description
+	}
+
+	return communicationStyle
 }
 
 func resolveValues(keys []string, lookup map[string]string) []string {

--- a/pkg/cmd/target/list/list_test.go
+++ b/pkg/cmd/target/list/list_test.go
@@ -1,0 +1,30 @@
+package list
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeTargetType_KnownStyle(t *testing.T) {
+	target := machines.NewDeploymentTarget("web-01", machines.NewListeningTentacleEndpoint(&url.URL{Scheme: "https", Host: "tentacle:10933"}, "thumbprint"), nil, nil)
+
+	assert.Equal(t, "Listening Tentacle", describeTargetType(target))
+}
+
+func TestDescribeTargetType_EndpointMissing(t *testing.T) {
+	target := &machines.DeploymentTarget{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"Id": "Machines-1041",
+		"Name": "aws ecs",
+		"Endpoint": { "CommunicationStyle": "AwsEcsCluster", "ClusterName": "repro-604-cluster" }
+	}`), target))
+
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "Unknown", describeTargetType(target))
+	})
+}

--- a/pkg/cmd/target/listening-tentacle/view/view.go
+++ b/pkg/cmd/target/listening-tentacle/view/view.go
@@ -42,9 +42,13 @@ func ViewRun(opts *shared.ViewOptions) error {
 func contributeEndpoint(opts *shared.ViewOptions, targetEndpoint machines.IEndpoint) ([]*output.DataRow, error) {
 	data := []*output.DataRow{}
 
-	endpoint := targetEndpoint.(*machines.ListeningTentacleEndpoint)
-	data = append(data, output.NewDataRow("URI", endpoint.URI.String()))
-	data = append(data, output.NewDataRow("Tentacle version", endpoint.TentacleVersionDetails.Version))
+	endpoint, err := shared.EndpointAs[*machines.ListeningTentacleEndpoint](targetEndpoint, "Listening Tentacle")
+	if err != nil {
+		return nil, err
+	}
+
+	data = append(data, output.NewDataRow("URI", shared.FormatUri(endpoint.URI)))
+	data = append(data, output.NewDataRow("Tentacle version", shared.FormatTentacleVersion(endpoint.TentacleVersionDetails)))
 
 	proxyData, err := shared.ContributeProxy(opts, endpoint.ProxyID)
 	if err != nil {

--- a/pkg/cmd/target/polling-tentacle/view/view.go
+++ b/pkg/cmd/target/polling-tentacle/view/view.go
@@ -42,9 +42,13 @@ func ViewRun(opts *shared.ViewOptions) error {
 func contributeEndpoint(opts *shared.ViewOptions, targetEndpoint machines.IEndpoint) ([]*output.DataRow, error) {
 	data := []*output.DataRow{}
 
-	endpoint := targetEndpoint.(*machines.PollingTentacleEndpoint)
-	data = append(data, output.NewDataRow("URI", endpoint.URI.String()))
-	data = append(data, output.NewDataRow("Tentacle version", endpoint.TentacleVersionDetails.Version))
+	endpoint, err := shared.EndpointAs[*machines.PollingTentacleEndpoint](targetEndpoint, "Polling Tentacle")
+	if err != nil {
+		return nil, err
+	}
+
+	data = append(data, output.NewDataRow("URI", shared.FormatUri(endpoint.URI)))
+	data = append(data, output.NewDataRow("Tentacle version", shared.FormatTentacleVersion(endpoint.TentacleVersionDetails)))
 
 	return data, nil
 }

--- a/pkg/cmd/target/shared/json.go
+++ b/pkg/cmd/target/shared/json.go
@@ -41,7 +41,7 @@ func GetDeploymentTargetAsJson(deps *cmd.Dependencies, target *machines.Deployme
 		Name:               target.Name,
 		HealthStatus:       target.HealthStatus,
 		StatusSummary:      target.StatusSummary,
-		CommunicationStyle: target.Endpoint.GetCommunicationStyle(),
+		CommunicationStyle: GetCommunicationStyle(target),
 		Environments:       environments,
 		Roles:              target.Roles,
 		Tenants:            tenants,

--- a/pkg/cmd/target/shared/target.go
+++ b/pkg/cmd/target/shared/target.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 	"math"
+	"net/url"
 
 	"github.com/OctopusDeploy/cli/pkg/cmd"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
@@ -41,10 +42,39 @@ func GetAllTargets(client client.Client, query machines.MachinesQuery) ([]*machi
 	return res.Items, nil
 }
 
+// Displayed wherever the API or the SDK left us nothing to report.
+const UnknownValue = "Unknown"
+
+// Returns an empty string when the SDK left us no endpoint to read the style from.
+func GetCommunicationStyle(target *machines.DeploymentTarget) string {
+	if target == nil || machines.IsNil(target.Endpoint) {
+		return ""
+	}
+
+	return target.Endpoint.GetCommunicationStyle()
+}
+
+func FormatUri(uri *url.URL) string {
+	if uri == nil {
+		return UnknownValue
+	}
+
+	return uri.String()
+}
+
+// The API omits the version for a Tentacle it has never contacted.
+func FormatTentacleVersion(details *machines.TentacleVersionDetails) string {
+	if details == nil {
+		return UnknownValue
+	}
+
+	return details.Version
+}
+
 func GetEndpointDetails(target *machines.DeploymentTarget) map[string]string {
 	details := make(map[string]string)
 
-	switch target.Endpoint.GetCommunicationStyle() {
+	switch GetCommunicationStyle(target) {
 	case "AzureWebApp":
 		if endpoint, ok := target.Endpoint.(*machines.AzureWebAppEndpoint); ok {
 			webApp := endpoint.WebAppName
@@ -59,7 +89,7 @@ func GetEndpointDetails(target *machines.DeploymentTarget) map[string]string {
 		}
 	case "Ssh":
 		if endpoint, ok := target.Endpoint.(*machines.SSHEndpoint); ok {
-			details["URI"] = endpoint.URI.String()
+			details["URI"] = FormatUri(endpoint.URI)
 			runtime := "Mono"
 			if endpoint.DotNetCorePlatform != "" {
 				runtime = endpoint.DotNetCorePlatform
@@ -68,13 +98,13 @@ func GetEndpointDetails(target *machines.DeploymentTarget) map[string]string {
 		}
 	case "TentaclePassive":
 		if endpoint, ok := target.Endpoint.(*machines.ListeningTentacleEndpoint); ok {
-			details["URI"] = endpoint.URI.String()
-			details["Tentacle version"] = endpoint.TentacleVersionDetails.Version
+			details["URI"] = FormatUri(endpoint.URI)
+			details["Tentacle version"] = FormatTentacleVersion(endpoint.TentacleVersionDetails)
 		}
 	case "TentacleActive":
 		if endpoint, ok := target.Endpoint.(*machines.PollingTentacleEndpoint); ok {
-			details["URI"] = endpoint.URI.String()
-			details["Tentacle version"] = endpoint.TentacleVersionDetails.Version
+			details["URI"] = FormatUri(endpoint.URI)
+			details["Tentacle version"] = FormatTentacleVersion(endpoint.TentacleVersionDetails)
 		}
 	case "None":
 		// Cloud regions typically don't have additional endpoint details

--- a/pkg/cmd/target/shared/target_test.go
+++ b/pkg/cmd/target/shared/target_test.go
@@ -1,0 +1,128 @@
+package shared_test
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/cli/pkg/cmd/target/shared"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An AWS ECS target as the API returns it, trimmed to the fields the CLI reads.
+// Captured from /api/Spaces-1/machines on a server with an ECS target configured.
+const ecsTargetJson = `{
+  "Id": "Machines-1041",
+  "Name": "aws ecs",
+  "SpaceId": "Spaces-1",
+  "EnvironmentIds": ["Environments-1"],
+  "Roles": ["ecs"],
+  "TenantIds": [],
+  "TenantTags": [],
+  "HealthStatus": "Healthy",
+  "StatusSummary": "This machine was successfully health checked.",
+  "IsDisabled": false,
+  "Endpoint": {
+    "CommunicationStyle": "AwsEcsCluster",
+    "DefaultWorkerPoolId": "WorkerPools-1",
+    "ClusterName": "repro-604-cluster",
+    "Region": "ap-southeast-2",
+    "AccountId": "",
+    "UseInstanceRole": true,
+    "AssumeRole": false,
+    "AssumedRoleArn": null,
+    "AssumedRoleSession": null,
+    "AssumeRoleSessionDurationSeconds": null,
+    "AssumeRoleExternalId": null,
+    "Id": null,
+    "LastModifiedOn": null,
+    "LastModifiedBy": null,
+    "Links": {}
+  }
+}`
+
+// If this fails because the SDK learned to deserialise "AwsEcsCluster", the
+// unknown-type fallbacks below can start reporting real detail.
+func TestEcsTargetDeserialisesWithoutAnEndpoint(t *testing.T) {
+	target := parseTarget(t, ecsTargetJson)
+
+	assert.True(t, machines.IsNil(target.Endpoint), "expected the SDK to leave the endpoint nil for an AwsEcsCluster target")
+}
+
+func TestGetCommunicationStyle_EndpointMissing(t *testing.T) {
+	target := parseTarget(t, ecsTargetJson)
+
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "", shared.GetCommunicationStyle(target))
+	})
+}
+
+func TestGetCommunicationStyle_NilTarget(t *testing.T) {
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "", shared.GetCommunicationStyle(nil))
+	})
+}
+
+func TestGetCommunicationStyle_KnownEndpoint(t *testing.T) {
+	target := machines.NewDeploymentTarget("web-01", machines.NewListeningTentacleEndpoint(&url.URL{Scheme: "https", Host: "tentacle:10933"}, "thumbprint"), []string{"Environments-1"}, []string{"web"})
+
+	assert.Equal(t, "TentaclePassive", shared.GetCommunicationStyle(target))
+}
+
+func TestGetEndpointDetails_EndpointMissing(t *testing.T) {
+	target := parseTarget(t, ecsTargetJson)
+
+	var details map[string]string
+	assert.NotPanics(t, func() {
+		details = shared.GetEndpointDetails(target)
+	})
+	assert.Empty(t, details)
+}
+
+func TestGetEndpointDetails_KnownEndpoint(t *testing.T) {
+	endpoint := machines.NewListeningTentacleEndpoint(&url.URL{Scheme: "https", Host: "tentacle:10933"}, "thumbprint")
+	endpoint.TentacleVersionDetails = &machines.TentacleVersionDetails{Version: "6.3.1"}
+	target := machines.NewDeploymentTarget("web-01", endpoint, []string{"Environments-1"}, []string{"web"})
+
+	details := shared.GetEndpointDetails(target)
+
+	assert.Equal(t, "https://tentacle:10933", details["URI"])
+	assert.Equal(t, "6.3.1", details["Tentacle version"])
+}
+
+func TestGetEndpointDetails_TentacleNeverHealthChecked(t *testing.T) {
+	endpoint := machines.NewListeningTentacleEndpoint(&url.URL{Scheme: "https", Host: "tentacle:10933"}, "thumbprint")
+	target := machines.NewDeploymentTarget("web-01", endpoint, []string{"Environments-1"}, []string{"web"})
+
+	var details map[string]string
+	assert.NotPanics(t, func() {
+		details = shared.GetEndpointDetails(target)
+	})
+	assert.Equal(t, "Unknown", details["Tentacle version"])
+	assert.Equal(t, "https://tentacle:10933", details["URI"])
+}
+
+func TestFormatUri_Missing(t *testing.T) {
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "Unknown", shared.FormatUri(nil))
+	})
+}
+
+func TestResolveDefaultWorkerPool_EndpointMissing(t *testing.T) {
+	target := parseTarget(t, ecsTargetJson)
+
+	assert.NotPanics(t, func() {
+		assert.Equal(t, "N/A", shared.ResolveDefaultWorkerPool(target, map[string]string{}, "None"))
+	})
+}
+
+func parseTarget(t *testing.T, payload string) *machines.DeploymentTarget {
+	t.Helper()
+
+	target := &machines.DeploymentTarget{}
+	require.NoError(t, json.Unmarshal([]byte(payload), target))
+
+	return target
+}

--- a/pkg/cmd/target/shared/view.go
+++ b/pkg/cmd/target/shared/view.go
@@ -40,6 +40,16 @@ func NewViewOptions(viewFlags *ViewFlags, dependencies *cmd.Dependencies, args [
 	}
 }
 
+func EndpointAs[T machines.IEndpoint](endpoint machines.IEndpoint, description string) (T, error) {
+	typedEndpoint, ok := endpoint.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("this deployment target is not a %s deployment target", description)
+	}
+
+	return typedEndpoint, nil
+}
+
 func ViewRun(opts *ViewOptions, contributeEndpoint ContributeEndpointCallback, description string) error {
 	var target, err = opts.Client.Machines.GetByIdentifier(opts.IdOrName)
 	if err != nil {
@@ -53,6 +63,10 @@ func ViewRun(opts *ViewOptions, contributeEndpoint ContributeEndpointCallback, d
 	data = append(data, output.NewDataRow("Current status", target.StatusSummary))
 
 	if contributeEndpoint != nil {
+		if machines.IsNil(target.Endpoint) {
+			return fmt.Errorf("cannot view '%s' as a %s deployment target: its target type is not supported by this version of the CLI", target.Name, description)
+		}
+
 		newRows, err := contributeEndpoint(opts, target.Endpoint)
 		if err != nil {
 			return err

--- a/pkg/cmd/target/shared/view_test.go
+++ b/pkg/cmd/target/shared/view_test.go
@@ -1,0 +1,35 @@
+package shared_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/OctopusDeploy/cli/pkg/cmd/target/shared"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointAs_MatchingType(t *testing.T) {
+	endpoint := machines.NewListeningTentacleEndpoint(&url.URL{Scheme: "https", Host: "tentacle:10933"}, "thumbprint")
+
+	typedEndpoint, err := shared.EndpointAs[*machines.ListeningTentacleEndpoint](endpoint, "Listening Tentacle")
+
+	require.NoError(t, err)
+	assert.Equal(t, endpoint, typedEndpoint)
+}
+
+func TestEndpointAs_MismatchedType(t *testing.T) {
+	endpoint := machines.NewCloudRegionEndpoint()
+
+	_, err := shared.EndpointAs[*machines.ListeningTentacleEndpoint](endpoint, "Listening Tentacle")
+
+	assert.EqualError(t, err, "this deployment target is not a Listening Tentacle deployment target")
+}
+
+func TestEndpointAs_MissingEndpoint(t *testing.T) {
+	assert.NotPanics(t, func() {
+		_, err := shared.EndpointAs[*machines.ListeningTentacleEndpoint](nil, "Listening Tentacle")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cmd/target/ssh/view/view.go
+++ b/pkg/cmd/target/ssh/view/view.go
@@ -41,9 +41,12 @@ func ViewRun(opts *shared.ViewOptions) error {
 
 func contributeEndpoint(opts *shared.ViewOptions, targetEndpoint machines.IEndpoint) ([]*output.DataRow, error) {
 	data := []*output.DataRow{}
-	endpoint := targetEndpoint.(*machines.SSHEndpoint)
+	endpoint, err := shared.EndpointAs[*machines.SSHEndpoint](targetEndpoint, "SSH")
+	if err != nil {
+		return nil, err
+	}
 
-	data = append(data, output.NewDataRow("URI", endpoint.URI.String()))
+	data = append(data, output.NewDataRow("URI", shared.FormatUri(endpoint.URI)))
 	data = append(data, output.NewDataRow("Runtime architecture", getRuntimeArchitecture(endpoint)))
 	accountRows, err := shared.ContributeAccount(opts, endpoint.AccountID)
 	if err != nil {

--- a/pkg/cmd/target/view/view.go
+++ b/pkg/cmd/target/view/view.go
@@ -75,7 +75,7 @@ func getDeploymentTargetAsJson(deps *cmd.Dependencies, target *machines.Deployme
 		Name:               target.Name,
 		HealthStatus:       target.HealthStatus,
 		StatusSummary:      target.StatusSummary,
-		CommunicationStyle: target.Endpoint.GetCommunicationStyle(),
+		CommunicationStyle: shared.GetCommunicationStyle(target),
 		Environments:       environments,
 		Roles:              target.Roles,
 		Tenants:            tenants,
@@ -97,7 +97,7 @@ func getDeploymentTargetAsJson(deps *cmd.Dependencies, target *machines.Deployme
 func getDeploymentTargetAsTableRow(opts *shared.ViewOptions, target *machines.DeploymentTarget, environmentMap map[string]string, tenantMap map[string]string, workerPoolMap map[string]string) []string {
 	environments := resolveValues(target.EnvironmentIDs, environmentMap)
 	healthStatus := getHealthStatusFormatted(target.HealthStatus)
-	targetType := getTargetTypeDisplayName(target.Endpoint.GetCommunicationStyle())
+	targetType := getTargetTypeDisplayName(shared.GetCommunicationStyle(target))
 
 	// Handle tenants
 	tenants := "None"
@@ -176,6 +176,8 @@ func getTargetTypeDisplayName(communicationStyle string) string {
 		return "Kubernetes"
 	case "StepPackage":
 		return "Step Package"
+	case "":
+		return shared.UnknownValue
 	default:
 		return communicationStyle
 	}
@@ -195,7 +197,7 @@ func getDeploymentTargetAsBasic(opts *shared.ViewOptions, target *machines.Deplo
 	result.WriteString(fmt.Sprintf("Current status: %s\n", target.StatusSummary))
 
 	// Target type and endpoint details
-	targetType := getTargetTypeDisplayName(target.Endpoint.GetCommunicationStyle())
+	targetType := getTargetTypeDisplayName(shared.GetCommunicationStyle(target))
 	result.WriteString(fmt.Sprintf("Type: %s\n", output.Cyan(targetType)))
 
 	// Add endpoint-specific details

--- a/pkg/cmd/target/view/view_ecs_test.go
+++ b/pkg/cmd/target/view/view_ecs_test.go
@@ -1,0 +1,155 @@
+package view_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/OctopusDeploy/cli/pkg/cmd/target/view"
+	"github.com/OctopusDeploy/cli/pkg/constants"
+	"github.com/OctopusDeploy/cli/test/testutil"
+	octopusApiClient "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	octopusConstants "github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/constants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/workerpools"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The shared root resource has no infrastructure links; the target commands need them.
+var rootResource = newRootResourceWithInfrastructureLinks()
+
+func newRootResourceWithInfrastructureLinks() *octopusApiClient.RootResource {
+	root := testutil.NewRootResource()
+	root.Links[octopusConstants.LinkMachines] = octopusConstants.TestURIMachines
+	root.Links[octopusConstants.LinkWorkerPools] = octopusConstants.TestURIWorkerPools
+
+	return root
+}
+
+// Sent verbatim: the SDK has no type that can represent an ECS endpoint.
+var ecsTargetResponse = json.RawMessage(`{
+  "Id": "Machines-1041",
+  "Name": "aws ecs",
+  "SpaceId": "Spaces-1",
+  "EnvironmentIds": ["Environments-1"],
+  "Roles": ["ecs"],
+  "TenantIds": [],
+  "TenantTags": [],
+  "HealthStatus": "Healthy",
+  "StatusSummary": "This machine was successfully health checked.",
+  "IsDisabled": false,
+  "Endpoint": {
+    "CommunicationStyle": "AwsEcsCluster",
+    "DefaultWorkerPoolId": "WorkerPools-1",
+    "ClusterName": "repro-604-cluster",
+    "Region": "ap-southeast-2",
+    "AccountId": "",
+    "UseInstanceRole": true,
+    "AssumeRole": false,
+    "AssumedRoleArn": null,
+    "AssumedRoleSession": null,
+    "AssumeRoleSessionDurationSeconds": null,
+    "AssumeRoleExternalId": null,
+    "Id": null,
+    "LastModifiedOn": null,
+    "LastModifiedBy": null,
+    "Links": {}
+  }
+}`)
+
+// Regression test for #604.
+func TestViewEcsTarget_DoesNotPanic(t *testing.T) {
+	api, rootCmd, stdOut := setupViewCommand(t)
+
+	cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+		defer api.Close()
+		rootCmd.SetArgs([]string{"view", "Machines-1041", "-f", "basic"})
+		return rootCmd.ExecuteC()
+	})
+
+	api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+	api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/machines/Machines-1041").RespondWith(ecsTargetResponse)
+	expectEnvironmentRequest(t, api)
+	expectWorkerPoolRequest(t, api)
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/tenants/all").RespondWith(resources.Resources[*tenants.Tenant]{})
+	// The basic formatter resolves the same names again, minus tenants.
+	expectEnvironmentRequest(t, api)
+	expectWorkerPoolRequest(t, api)
+
+	_, err := testutil.ReceivePair(cmdReceiver)
+	assert.NoError(t, err)
+
+	output := stdOut.String()
+	assert.Contains(t, output, "aws ecs")
+	assert.Contains(t, output, "Healthy")
+	assert.Contains(t, output, "Environments: Development")
+	assert.Contains(t, output, "Roles: ecs")
+	assert.Contains(t, output, "Type: Unknown")
+}
+
+func TestViewEcsTarget_Json(t *testing.T) {
+	api, rootCmd, stdOut := setupViewCommand(t)
+
+	cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+		defer api.Close()
+		rootCmd.SetArgs([]string{"view", "Machines-1041", "-f", "json"})
+		return rootCmd.ExecuteC()
+	})
+
+	api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+	api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/machines/Machines-1041").RespondWith(ecsTargetResponse)
+	expectEnvironmentRequest(t, api)
+	expectWorkerPoolRequest(t, api)
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/tenants/all").RespondWith(resources.Resources[*tenants.Tenant]{})
+
+	_, err := testutil.ReceivePair(cmdReceiver)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(stdOut.Bytes(), &result))
+	assert.Equal(t, "aws ecs", result["Name"])
+	assert.Equal(t, "Machines-1041", result["Id"])
+	assert.Equal(t, []any{"Development"}, result["Environments"])
+	assert.Equal(t, "", result["CommunicationStyle"])
+}
+
+func setupViewCommand(t *testing.T) (*testutil.MockHttpServer, *cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	api := testutil.NewMockHttpServer()
+	space := spaces.NewSpace("Default")
+	space.ID = "Spaces-1"
+
+	stdOut := &bytes.Buffer{}
+	stdErr := &bytes.Buffer{}
+
+	rootCmd := &cobra.Command{Use: "deployment-target"}
+	rootCmd.PersistentFlags().StringP(constants.FlagOutputFormat, "f", constants.OutputFormatTable, "")
+	rootCmd.AddCommand(view.NewCmdView(testutil.NewMockFactoryWithSpace(api, space)))
+	rootCmd.SetOut(stdOut)
+	rootCmd.SetErr(stdErr)
+
+	return api, rootCmd, stdOut
+}
+
+func expectEnvironmentRequest(t *testing.T, api *testutil.MockHttpServer) {
+	t.Helper()
+
+	development := environments.NewEnvironment("Development")
+	development.ID = "Environments-1"
+
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/environments/all").RespondWith([]*environments.Environment{development})
+}
+
+func expectWorkerPoolRequest(t *testing.T, api *testutil.MockHttpServer) {
+	t.Helper()
+
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/workerpools/all").RespondWith([]*workerpools.WorkerPoolListResult{})
+}

--- a/pkg/cmd/target/view/view_test.go
+++ b/pkg/cmd/target/view/view_test.go
@@ -1,0 +1,14 @@
+package view
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTargetTypeDisplayName(t *testing.T) {
+	assert.Equal(t, "Listening Tentacle", getTargetTypeDisplayName("TentaclePassive"))
+	assert.Equal(t, "Step Package", getTargetTypeDisplayName("StepPackage"))
+	assert.Equal(t, "SomeFutureTargetType", getTargetTypeDisplayName("SomeFutureTargetType"))
+	assert.Equal(t, "Unknown", getTargetTypeDisplayName(""))
+}


### PR DESCRIPTION
Fixes #604

## Problem

`deployment-target view` and `deployment-target list` panic with a nil pointer dereference for AWS ECS targets.

An ECS target's endpoint has the communication style `AwsEcsCluster`, which the SDK does not model. `machine.UnmarshalJSON` deserialises only the endpoints it knows by name, and its `switch` has no `default`, so an ECS target arrives with `DeploymentTarget.Endpoint` left silently nil and every read of it panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18]
github.com/OctopusDeploy/cli/pkg/cmd/target/view.getDeploymentTargetAsBasic
```

Two things worth knowing beyond the report:

- **It isn't ECS-specific.** Any target type Server gains after the SDK was last updated arrives the same way.
- **`list` is hit harder than `view`.** It reads the endpoint of every target, so a single ECS target takes down the listing for the whole space, not just its own row.

## Change

Endpoint reads go through `shared.GetCommunicationStyle`, and the target is reported as type `Unknown` when there is no endpoint to name it from. Everything the target itself carries — name, health, environments, roles, tenants, worker pool — still reports correctly.

Two adjacent crashes in the same code paths are fixed too:

- `GetEndpointDetails` dereferenced `TentacleVersionDetails`, which is `omitempty` and absent for a Tentacle the server has never contacted — so a target awaiting its first health check crashed identically. A test caught this one.
- The type-specific views (`deployment-target listening-tentacle view` and the other four) asserted the endpoint to their own type unchecked, so pointing one at a target of a different type panicked. They now report the mismatch.

## Verification

Confirmed against a live server with two ECS targets configured, not just against the mock:

| build | `deployment-target view "aws ecs"` |
|---|---|
| `main` | panics — same signature, same `addr=0x18`, same `getDeploymentTargetAsBasic → ViewRun.func3 → PrintResource` stack as the issue |
| this branch | reports the target, `Type: Unknown` |

`TestViewEcsTarget_DoesNotPanic` drives `deployment-target view` through the mock API with the ECS payload captured verbatim from that server's `/api/Spaces-1/machines`. Unit tests cover every function that dereferences the endpoint.

`TestEcsTargetDeserialisesWithoutAnEndpoint` is a deliberate canary: it asserts the SDK still leaves the endpoint nil, so whoever bumps the SDK past OctopusDeploy/go-octopusdeploy#457 gets told that these fallbacks can start reporting real detail.

## Follow-ups

- **The SDK needs to deserialise the endpoint** for the CLI to name the type or show cluster and region. Raised as OctopusDeploy/go-octopusdeploy#457 (draft) — with that branch, the same command reports `Type: AwsEcsCluster` and resolves the worker pool.
- **The worker commands have the same latent crash** in ~10 places. Raised as #706 (draft), which sits on top of #705 — the `machinescommon` move the worker fixes need, split out so it reviews on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
