### PR TITLE
Feature: Add --priority to release deploy and runbook run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.116.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/OctopusDeploy/go-octodiff v1.0.0
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1 h1:7lrYQSCo2HeixFRBGGKA8a7QjuBw9L+4A4kmUDUEzSE=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d h1:iCMRfyFo2hKQ0zu95s5T9FUwQQ3ucvQxrjZ8So6uM5c=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d h1:iCMRfyFo2hKQ0zu95s5T9FUwQQ3ucvQxrjZ8So6uM5c=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.116.0 h1:kW1H9qngKgI34OkfYN6/PFpjBEQRK/tZm70MCElHOME=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.116.0/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1 h1:7lrYQSCo2HeixFRBGGKA8a7QjuBw9L+4A4kmUDUEzSE=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.114.1/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d h1:iCMRfyFo2hKQ0zu95s5T9FUwQQ3ucvQxrjZ8So6uM5c=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.115.1-0.20260819065856-b6f0f290712d/go.mod h1:VkTXDoIPbwGFi5+goo1VSwFNdMVo784cVtJdKIEvfus=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -173,7 +173,7 @@ func NewCmdDeploy(f factory.Factory) *cobra.Command {
 	flags.BoolVarP(&deployFlags.UpdateVariables.Value, deployFlags.UpdateVariables.Name, "", false, "Overwrite the release variable snapshot by re-importing variables from the project.")
 	flags.StringArrayVarP(&deployFlags.ExcludedSteps.Value, deployFlags.ExcludedSteps.Name, "", nil, "Exclude specific steps from the deployment")
 	flags.StringVarP(&deployFlags.GuidedFailureMode.Value, deployFlags.GuidedFailureMode.Name, "", "", "Enable Guided failure mode (true/false/default)")
-	flags.StringVarP(&deployFlags.Priority.Value, deployFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature.")
+	flags.StringVarP(&deployFlags.Priority.Value, deployFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature, and the TaskPrioritize permission to set true.")
 	flags.BoolVarP(&deployFlags.ForcePackageDownload.Value, deployFlags.ForcePackageDownload.Name, "", false, "Force re-download of packages")
 	flags.StringArrayVarP(&deployFlags.DeploymentTargets.Value, deployFlags.DeploymentTargets.Name, "", nil, "Deploy to this target (can be specified multiple times)")
 	flags.StringArrayVarP(&deployFlags.ExcludeTargets.Value, deployFlags.ExcludeTargets.Name, "", nil, "Deploy to targets except for this (can be specified multiple times)")
@@ -1041,7 +1041,7 @@ func PrintAdvancedSummary(stdout io.Writer, options *executor.TaskOptionsDeployR
 
 	gfmStr := executionscommon.LookupGuidedFailureModeString(options.GuidedFailureMode)
 
-	priorityStr := executionscommon.LookupPriorityString(options.Priority)
+	priorityStr := executionscommon.LookupPriorityString(options.Priority, "Use default setting from the lifecycle phase")
 
 	pkgDownloadStr := executionscommon.LookupPackageDownloadString(!options.ForcePackageDownload)
 

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -208,6 +208,10 @@ func deployRun(cmd *cobra.Command, f factory.Factory, flags *DeployFlags) error 
 		outputFormat = constants.OutputFormatTable
 	}
 
+	if _, err = executionscommon.ParsePriorityMode(flags.Priority.Value); err != nil {
+		return err
+	}
+
 	octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
 	if err != nil {
 		return err

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -173,7 +173,7 @@ func NewCmdDeploy(f factory.Factory) *cobra.Command {
 	flags.BoolVarP(&deployFlags.UpdateVariables.Value, deployFlags.UpdateVariables.Name, "", false, "Overwrite the release variable snapshot by re-importing variables from the project.")
 	flags.StringArrayVarP(&deployFlags.ExcludedSteps.Value, deployFlags.ExcludedSteps.Name, "", nil, "Exclude specific steps from the deployment")
 	flags.StringVarP(&deployFlags.GuidedFailureMode.Value, deployFlags.GuidedFailureMode.Name, "", "", "Enable Guided failure mode (true/false/default)")
-	flags.StringVarP(&deployFlags.Priority.Value, deployFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature and the TaskPrioritize permission.")
+	flags.StringVarP(&deployFlags.Priority.Value, deployFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature.")
 	flags.BoolVarP(&deployFlags.ForcePackageDownload.Value, deployFlags.ForcePackageDownload.Name, "", false, "Force re-download of packages")
 	flags.StringArrayVarP(&deployFlags.DeploymentTargets.Value, deployFlags.DeploymentTargets.Name, "", nil, "Deploy to this target (can be specified multiple times)")
 	flags.StringArrayVarP(&deployFlags.ExcludeTargets.Value, deployFlags.ExcludeTargets.Name, "", nil, "Deploy to targets except for this (can be specified multiple times)")
@@ -1041,6 +1041,8 @@ func PrintAdvancedSummary(stdout io.Writer, options *executor.TaskOptionsDeployR
 
 	gfmStr := executionscommon.LookupGuidedFailureModeString(options.GuidedFailureMode)
 
+	priorityStr := executionscommon.LookupPriorityString(options.Priority)
+
 	pkgDownloadStr := executionscommon.LookupPackageDownloadString(!options.ForcePackageDownload)
 
 	depTargetsStr := "All included"
@@ -1076,9 +1078,10 @@ func PrintAdvancedSummary(stdout io.Writer, options *executor.TaskOptionsDeployR
 		  Deploy Time: cyan(%s)
 		  Skipped Steps: cyan(%s)
 		  Guided Failure Mode: cyan(%s)
+		  Priority: cyan(%s)
 		  Package Download: cyan(%s)
 		  Deployment Targets: cyan(%s)
-	`)), deployAtStr, skipStepsStr, gfmStr, pkgDownloadStr, depTargetsStr)
+	`)), deployAtStr, skipStepsStr, gfmStr, priorityStr, pkgDownloadStr, depTargetsStr)
 }
 
 func selectRelease(octopus *octopusApiClient.Client, ask question.Asker, questionText string, space *spaces.Space, project *projects.Project, channel *channels.Channel) (*releases.Release, error) {

--- a/pkg/cmd/release/deploy/deploy.go
+++ b/pkg/cmd/release/deploy/deploy.go
@@ -70,6 +70,8 @@ const (
 	FlagAliasGuidedFailureMode       = "guided-failure-mode"
 	FlagAliasGuidedFailureModeLegacy = "guidedFailure"
 
+	FlagPriority = "priority"
+
 	FlagForcePackageDownload            = "force-package-download"
 	FlagAliasForcePackageDownloadLegacy = "forcePackageDownload"
 
@@ -107,6 +109,7 @@ type DeployFlags struct {
 	UpdateVariables                *flag.Flag[bool]
 	ExcludedSteps                  *flag.Flag[[]string]
 	GuidedFailureMode              *flag.Flag[string] // tri-state: true, false, or "use default". Can we model it with an optional bool?
+	Priority                       *flag.Flag[string] // tri-state: true, false, or "use default"
 	ForcePackageDownload           *flag.Flag[bool]
 	DeploymentTargets              *flag.Flag[[]string]
 	ExcludeTargets                 *flag.Flag[[]string]
@@ -127,6 +130,7 @@ func NewDeployFlags() *DeployFlags {
 		UpdateVariables:                flag.New[bool](FlagUpdateVariables, false),
 		ExcludedSteps:                  flag.New[[]string](FlagSkip, false),
 		GuidedFailureMode:              flag.New[string](FlagGuidedFailure, false),
+		Priority:                       flag.New[string](FlagPriority, false),
 		ForcePackageDownload:           flag.New[bool](FlagForcePackageDownload, false),
 		DeploymentTargets:              flag.New[[]string](FlagDeploymentTarget, false),
 		ExcludeTargets:                 flag.New[[]string](FlagExcludeDeploymentTarget, false),
@@ -169,6 +173,7 @@ func NewCmdDeploy(f factory.Factory) *cobra.Command {
 	flags.BoolVarP(&deployFlags.UpdateVariables.Value, deployFlags.UpdateVariables.Name, "", false, "Overwrite the release variable snapshot by re-importing variables from the project.")
 	flags.StringArrayVarP(&deployFlags.ExcludedSteps.Value, deployFlags.ExcludedSteps.Name, "", nil, "Exclude specific steps from the deployment")
 	flags.StringVarP(&deployFlags.GuidedFailureMode.Value, deployFlags.GuidedFailureMode.Name, "", "", "Enable Guided failure mode (true/false/default)")
+	flags.StringVarP(&deployFlags.Priority.Value, deployFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature and the TaskPrioritize permission.")
 	flags.BoolVarP(&deployFlags.ForcePackageDownload.Value, deployFlags.ForcePackageDownload.Name, "", false, "Force re-download of packages")
 	flags.StringArrayVarP(&deployFlags.DeploymentTargets.Value, deployFlags.DeploymentTargets.Name, "", nil, "Deploy to this target (can be specified multiple times)")
 	flags.StringArrayVarP(&deployFlags.ExcludeTargets.Value, deployFlags.ExcludeTargets.Name, "", nil, "Deploy to targets except for this (can be specified multiple times)")
@@ -223,6 +228,7 @@ func deployRun(cmd *cobra.Command, f factory.Factory, flags *DeployFlags) error 
 		ScheduledExpiryTime:            flags.MaxQueueTime.Value,
 		ExcludedSteps:                  flags.ExcludedSteps.Value,
 		GuidedFailureMode:              flags.GuidedFailureMode.Value,
+		Priority:                       flags.Priority.Value,
 		ForcePackageDownload:           flags.ForcePackageDownload.Value,
 		DeploymentTargets:              flags.DeploymentTargets.Value,
 		ExcludeTargets:                 flags.ExcludeTargets.Value,
@@ -262,6 +268,7 @@ func deployRun(cmd *cobra.Command, f factory.Factory, flags *DeployFlags) error 
 			resolvedFlags.MaxQueueTime.Value = options.ScheduledExpiryTime
 			resolvedFlags.ExcludedSteps.Value = options.ExcludedSteps
 			resolvedFlags.GuidedFailureMode.Value = options.GuidedFailureMode
+			resolvedFlags.Priority.Value = options.Priority
 			resolvedFlags.DeploymentTargets.Value = options.DeploymentTargets
 			resolvedFlags.ExcludeTargets.Value = options.ExcludeTargets
 			resolvedFlags.DeploymentFreezeNames.Value = options.DeploymentFreezeNames
@@ -297,6 +304,7 @@ func deployRun(cmd *cobra.Command, f factory.Factory, flags *DeployFlags) error 
 				resolvedFlags.MaxQueueTime,
 				resolvedFlags.ExcludedSteps,
 				resolvedFlags.GuidedFailureMode,
+				resolvedFlags.Priority,
 				resolvedFlags.ForcePackageDownload,
 				resolvedFlags.DeploymentTargets,
 				resolvedFlags.ExcludeTargets,

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -1899,7 +1899,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 			assert.Equal(t, "", stdErr.String())
 		}},
 
-		{"release deploy with --priority default omits Priority so the server uses the lifecycle setting", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+		{"release deploy with --priority default leaves Priority unset", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
 			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
 				defer api.Close()
 				rootCmd.SetArgs([]string{"release", "deploy", "--project", fireProject.Name, "--version", "1.0", "--environment", "dev", "--priority", "default", "--output-format", "basic"})

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -1861,6 +1861,99 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 			assert.Equal(t, "", stdErr.String())
 		}},
 
+		{"release deploy with --priority false sends Priority Off", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "deploy", "--project", fireProject.Name, "--version", "1.0", "--environment", "dev", "--priority", "false", "--output-format", "basic"})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
+
+			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/untenanted/v1")
+			requestBody, err := testutil.ReadJson[deployments.CreateDeploymentUntenantedCommandV1](req.Request.Body)
+			assert.Nil(t, err)
+
+			assert.Equal(t, deployments.CreateDeploymentUntenantedCommandV1{
+				ReleaseVersion:   "1.0",
+				EnvironmentNames: []string{"dev"},
+				CreateExecutionAbstractCommandV1: deployments.CreateExecutionAbstractCommandV1{
+					SpaceID:         "Spaces-1",
+					ProjectIDOrName: fireProject.Name,
+					Priority:        "Off",
+				},
+			}, requestBody)
+
+			req.RespondWith(&deployments.CreateDeploymentResponseV1{
+				DeploymentServerTasks: []*deployments.DeploymentServerTask{
+					{DeploymentID: "Deployments-203", ServerTaskID: "ServerTasks-29394"},
+				},
+			})
+
+			_, err = testutil.ReceivePair(cmdReceiver)
+			assert.Nil(t, err)
+
+			assert.Equal(t, "ServerTasks-29394\n", stdOut.String())
+			assert.Equal(t, "", stdErr.String())
+		}},
+
+		{"release deploy with --priority default omits Priority so the server uses the lifecycle setting", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "deploy", "--project", fireProject.Name, "--version", "1.0", "--environment", "dev", "--priority", "default", "--output-format", "basic"})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
+
+			req := api.ExpectRequest(t, "POST", "/api/Spaces-1/deployments/create/untenanted/v1")
+			requestBody, err := testutil.ReadJson[deployments.CreateDeploymentUntenantedCommandV1](req.Request.Body)
+			assert.Nil(t, err)
+
+			assert.Equal(t, deployments.CreateDeploymentUntenantedCommandV1{
+				ReleaseVersion:   "1.0",
+				EnvironmentNames: []string{"dev"},
+				CreateExecutionAbstractCommandV1: deployments.CreateExecutionAbstractCommandV1{
+					SpaceID:         "Spaces-1",
+					ProjectIDOrName: fireProject.Name,
+				},
+			}, requestBody)
+
+			req.RespondWith(&deployments.CreateDeploymentResponseV1{
+				DeploymentServerTasks: []*deployments.DeploymentServerTask{
+					{DeploymentID: "Deployments-203", ServerTaskID: "ServerTasks-29394"},
+				},
+			})
+
+			_, err = testutil.ReceivePair(cmdReceiver)
+			assert.Nil(t, err)
+
+			assert.Equal(t, "ServerTasks-29394\n", stdOut.String())
+			assert.Equal(t, "", stdErr.String())
+		}},
+
+		{"release deploy rejects an unrecognised --priority value", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
+				defer api.Close()
+				rootCmd.SetArgs([]string{"release", "deploy", "--project", fireProject.Name, "--version", "1.0", "--environment", "dev", "--priority", "urgent"})
+				return rootCmd.ExecuteC()
+			})
+
+			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
+			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
+
+			_, err := testutil.ReceivePair(cmdReceiver)
+			assert.EqualError(t, err, "'urgent' is not a valid value for priority")
+
+			assert.Equal(t, "", stdOut.String())
+			assert.Equal(t, "", stdErr.String())
+		}},
+
 		{"release deploy specifying all the args; untentanted", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
 			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
 				defer api.Close()
@@ -1873,6 +1966,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 					"--deploy-at-expiry", "2022-09-10 13:37:03 +10:00",
 					"--skip", "Install", "--skip", "Cleanup",
 					"--guided-failure", "true",
+					"--priority", "true",
 					"--force-package-download",
 					"--update-variables",
 					"--target", "firstMachine", "--target", "secondMachine",
@@ -1908,6 +2002,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 					ExcludedMachineNames: []string{"thirdMachine"},
 					SkipStepNames:        []string{"Install", "Cleanup"},
 					UseGuidedFailure:     &trueVal,
+					Priority:             "On",
 					RunAt:                "2022-09-10 13:32:03 +10:00",
 					NoRunAfter:           "2022-09-10 13:37:03 +10:00",
 					Variables: map[string]string{
@@ -1947,6 +2042,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 					"--tenant", "Coke", "--tenant", "Pepsi",
 					"--tenant-tag", "Region/us-east",
 					"--guided-failure", "true",
+					"--priority", "true",
 					"--force-package-download",
 					"--update-variables",
 					"--target", "firstMachine", "--target", "secondMachine",
@@ -1983,6 +2079,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 					ExcludedMachineNames: []string{"thirdMachine"},
 					SkipStepNames:        []string{"Install", "Cleanup"},
 					UseGuidedFailure:     &trueVal,
+					Priority:             "On",
 					RunAt:                "2022-09-10 13:32:03 +10:00",
 					NoRunAfter:           "2022-09-10 13:37:03 +10:00",
 					Variables: map[string]string{

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -1936,16 +1936,12 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 			assert.Equal(t, "", stdErr.String())
 		}},
 
-		{"release deploy rejects an unrecognised --priority value", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
+		{"release deploy rejects an unrecognised --priority value before contacting the server", func(t *testing.T, api *testutil.MockHttpServer, rootCmd *cobra.Command, stdOut *bytes.Buffer, stdErr *bytes.Buffer) {
 			cmdReceiver := testutil.GoBegin2(func() (*cobra.Command, error) {
 				defer api.Close()
 				rootCmd.SetArgs([]string{"release", "deploy", "--project", fireProject.Name, "--version", "1.0", "--environment", "dev", "--priority", "urgent"})
 				return rootCmd.ExecuteC()
 			})
-
-			api.ExpectRequest(t, "GET", "/api/").RespondWith(rootResource)
-			api.ExpectRequest(t, "GET", "/api/Spaces-1").RespondWith(rootResource)
-			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			_, err := testutil.ReceivePair(cmdReceiver)
 			assert.EqualError(t, err, "'urgent' is not a valid value for priority, expected true, false or default")

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -2324,7 +2324,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: Now
 			  Skipped Steps: None
 			  Guided Failure Mode: Use default setting from the target environment
-			  Priority: Use default setting
+			  Priority: Use default setting from the lifecycle phase
 			  Package Download: Use cached packages (if available)
 			  Deployment Targets: All included
 			`), stdout.String())
@@ -2364,7 +2364,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: Now
 			  Skipped Steps: None
 			  Guided Failure Mode: Use default setting from the target environment
-			  Priority: Use default setting
+			  Priority: Use default setting from the lifecycle phase
 			  Package Download: Use cached packages (if available)
 			  Deployment Targets: Include vm-2
 			`), stdout.String())
@@ -2381,7 +2381,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: Now
 			  Skipped Steps: None
 			  Guided Failure Mode: Use default setting from the target environment
-			  Priority: Use default setting
+			  Priority: Use default setting from the lifecycle phase
 			  Package Download: Use cached packages (if available)
 			  Deployment Targets: Exclude vm-4
 			`), stdout.String())

--- a/pkg/cmd/release/deploy/deploy_test.go
+++ b/pkg/cmd/release/deploy/deploy_test.go
@@ -1948,7 +1948,7 @@ func TestDeployCreate_AutomationMode(t *testing.T) {
 			api.ExpectRequest(t, "GET", "/api/Spaces-1/projects/"+fireProject.GetName()).RespondWith(fireProject)
 
 			_, err := testutil.ReceivePair(cmdReceiver)
-			assert.EqualError(t, err, "'urgent' is not a valid value for priority")
+			assert.EqualError(t, err, "'urgent' is not a valid value for priority, expected true, false or default")
 
 			assert.Equal(t, "", stdOut.String())
 			assert.Equal(t, "", stdErr.String())
@@ -2180,7 +2180,7 @@ func TestDeployCreate_GenerationOfAutomationCommand_MasksSensitiveVariables(t *t
 	// need to very it's wired up properly
 	receiver := testutil.GoBegin2(func() (*cobra.Command, error) {
 		defer testutil.Close(api, qa)
-		rootCmd.SetArgs([]string{"release", "deploy", "--project", "fire project", "--version", "2.0", "--environment", "dev"})
+		rootCmd.SetArgs([]string{"release", "deploy", "--project", "fire project", "--version", "2.0", "--environment", "dev", "--priority", "true"})
 		return rootCmd.ExecuteC()
 	})
 
@@ -2270,6 +2270,7 @@ func TestDeployCreate_GenerationOfAutomationCommand_MasksSensitiveVariables(t *t
 		CreateExecutionAbstractCommandV1: deployments.CreateExecutionAbstractCommandV1{
 			SpaceID:         "Spaces-1",
 			ProjectIDOrName: fireProject.Name,
+			Priority:        "On",
 			Variables: map[string]string{
 				"Boring Variable":      "BORING",
 				"Nuclear Launch Codes": "9001",
@@ -2296,10 +2297,11 @@ func TestDeployCreate_GenerationOfAutomationCommand_MasksSensitiveVariables(t *t
 		  Deploy Time: Now
 		  Skipped Steps: None
 		  Guided Failure Mode: Use default setting from the target environment
+		  Priority: Jump the task queue
 		  Package Download: Use cached packages (if available)
 		  Deployment Targets: All included
 		
-		Automation Command: octopus release deploy --space 'Default Space' --project 'Fire Project' --version '2.0' --environment 'dev' --variable 'Boring Variable:BORING' --variable 'Nuclear Launch Codes:*****' --variable 'Secret Password:*****' --no-prompt
+		Automation Command: octopus release deploy --space 'Default Space' --project 'Fire Project' --version '2.0' --environment 'dev' --priority 'true' --variable 'Boring Variable:BORING' --variable 'Nuclear Launch Codes:*****' --variable 'Secret Password:*****' --no-prompt
 		Warning: Command includes some sensitive variable values which have been replaced with placeholders.
 		Successfully started 2 deployment(s)
 
@@ -2322,6 +2324,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: Now
 			  Skipped Steps: None
 			  Guided Failure Mode: Use default setting from the target environment
+			  Priority: Use default setting
 			  Package Download: Use cached packages (if available)
 			  Deployment Targets: All included
 			`), stdout.String())
@@ -2331,6 +2334,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			options := &executor.TaskOptionsDeployRelease{
 				ScheduledStartTime:   "2022-09-23",
 				GuidedFailureMode:    "false",
+				Priority:             "true",
 				ForcePackageDownload: true,
 				ExcludedSteps:        []string{"Step 1", "Step 37"},
 				DeploymentTargets:    []string{"vm-1", "vm-2"},
@@ -2343,6 +2347,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: 2022-09-23
 			  Skipped Steps: Step 1,Step 37
 			  Guided Failure Mode: Do not use guided failure mode
+			  Priority: Jump the task queue
 			  Package Download: Re-download packages from feed
 			  Deployment Targets: Include vm-1,vm-2; Exclude vm-3,vm-4
 			`), stdout.String())
@@ -2359,6 +2364,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: Now
 			  Skipped Steps: None
 			  Guided Failure Mode: Use default setting from the target environment
+			  Priority: Use default setting
 			  Package Download: Use cached packages (if available)
 			  Deployment Targets: Include vm-2
 			`), stdout.String())
@@ -2375,6 +2381,7 @@ func TestDeployCreate_PrintAdvancedSummary(t *testing.T) {
 			  Deploy Time: Now
 			  Skipped Steps: None
 			  Guided Failure Mode: Use default setting from the target environment
+			  Priority: Use default setting
 			  Package Download: Use cached packages (if available)
 			  Deployment Targets: Exclude vm-4
 			`), stdout.String())

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -175,7 +175,7 @@ func NewCmdRun(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&runFlags.Snapshot.Value, runFlags.Snapshot.Name, "", "", "Name or ID of the snapshot to run. If not supplied, the command will attempt to use the published snapshot.")
 	flags.StringArrayVarP(&runFlags.ExcludedSteps.Value, runFlags.ExcludedSteps.Name, "", nil, "Exclude specific steps from the runbook")
 	flags.StringVarP(&runFlags.GuidedFailureMode.Value, runFlags.GuidedFailureMode.Name, "", "", "Enable Guided failure mode (true/false/default)")
-	flags.StringVarP(&runFlags.Priority.Value, runFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature and the TaskPrioritize permission.")
+	flags.StringVarP(&runFlags.Priority.Value, runFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature. Runbook runs have no lifecycle default, so 'default' behaves as 'false'.")
 	flags.BoolVarP(&runFlags.ForcePackageDownload.Value, runFlags.ForcePackageDownload.Name, "", false, "Force re-download of packages")
 	flags.StringArrayVarP(&runFlags.RunTargets.Value, runFlags.RunTargets.Name, "", nil, "Run on this target (can be specified multiple times)")
 	flags.StringArrayVarP(&runFlags.ExcludeTargets.Value, runFlags.ExcludeTargets.Name, "", nil, "Run on targets except for this (can be specified multiple times)")
@@ -1258,6 +1258,8 @@ func PrintAdvancedSummary(stdout io.Writer, options *executor.TaskOptionsRunbook
 
 	gfmStr := executionscommon.LookupGuidedFailureModeString(options.GuidedFailureMode)
 
+	priorityStr := executionscommon.LookupPriorityString(options.Priority)
+
 	pkgDownloadStr := executionscommon.LookupPackageDownloadString(!options.ForcePackageDownload)
 
 	runTargetsStr := "All included"
@@ -1293,9 +1295,10 @@ func PrintAdvancedSummary(stdout io.Writer, options *executor.TaskOptionsRunbook
 		  Run At: cyan(%s)
 		  Skipped Steps: cyan(%s)
 		  Guided Failure Mode: cyan(%s)
+		  Priority: cyan(%s)
 		  Package Download: cyan(%s)
 		  Run Targets: cyan(%s)
-	`)), runAtStr, skipStepsStr, gfmStr, pkgDownloadStr, runTargetsStr)
+	`)), runAtStr, skipStepsStr, gfmStr, priorityStr, pkgDownloadStr, runTargetsStr)
 }
 
 func selectRunbook(octopus *octopusApiClient.Client, ask question.Asker, questionText string, space *spaces.Space, project *projects.Project) (*runbooks.Runbook, error) {

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -175,7 +175,7 @@ func NewCmdRun(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&runFlags.Snapshot.Value, runFlags.Snapshot.Name, "", "", "Name or ID of the snapshot to run. If not supplied, the command will attempt to use the published snapshot.")
 	flags.StringArrayVarP(&runFlags.ExcludedSteps.Value, runFlags.ExcludedSteps.Name, "", nil, "Exclude specific steps from the runbook")
 	flags.StringVarP(&runFlags.GuidedFailureMode.Value, runFlags.GuidedFailureMode.Name, "", "", "Enable Guided failure mode (true/false/default)")
-	flags.StringVarP(&runFlags.Priority.Value, runFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature. Runbook runs have no lifecycle default, so 'default' behaves as 'false'.")
+	flags.StringVarP(&runFlags.Priority.Value, runFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature. For runbook runs, 'default' is the same as 'false'.")
 	flags.BoolVarP(&runFlags.ForcePackageDownload.Value, runFlags.ForcePackageDownload.Name, "", false, "Force re-download of packages")
 	flags.StringArrayVarP(&runFlags.RunTargets.Value, runFlags.RunTargets.Name, "", nil, "Run on this target (can be specified multiple times)")
 	flags.StringArrayVarP(&runFlags.ExcludeTargets.Value, runFlags.ExcludeTargets.Name, "", nil, "Run on targets except for this (can be specified multiple times)")
@@ -1258,7 +1258,7 @@ func PrintAdvancedSummary(stdout io.Writer, options *executor.TaskOptionsRunbook
 
 	gfmStr := executionscommon.LookupGuidedFailureModeString(options.GuidedFailureMode)
 
-	priorityStr := executionscommon.LookupPriorityString(options.Priority)
+	priorityStr := executionscommon.LookupPriorityString(options.Priority, "Do not jump the task queue")
 
 	pkgDownloadStr := executionscommon.LookupPackageDownloadString(!options.ForcePackageDownload)
 

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -215,6 +215,10 @@ func runbookRun(cmd *cobra.Command, f factory.Factory, flags *RunFlags) error {
 		outputFormat = constants.OutputFormatTable
 	}
 
+	if _, err = executionscommon.ParsePriorityMode(flags.Priority.Value); err != nil {
+		return err
+	}
+
 	octopus, err := f.GetSpacedClient(apiclient.NewRequester(cmd))
 	if err != nil {
 		return err

--- a/pkg/cmd/runbook/run/run.go
+++ b/pkg/cmd/runbook/run/run.go
@@ -74,6 +74,8 @@ const (
 	FlagAliasGuidedFailureMode       = "guided-failure-mode"
 	FlagAliasGuidedFailureModeLegacy = "guidedFailure"
 
+	FlagPriority = "priority"
+
 	FlagForcePackageDownload            = "force-package-download"
 	FlagAliasForcePackageDownloadLegacy = "forcePackageDownload"
 
@@ -106,6 +108,7 @@ type RunFlags struct {
 	Snapshot             *flag.Flag[string]
 	ExcludedSteps        *flag.Flag[[]string]
 	GuidedFailureMode    *flag.Flag[string] // tri-state: true, false, or "use default". Can we model it with an optional bool?
+	Priority             *flag.Flag[string] // tri-state: true, false, or "use default"
 	ForcePackageDownload *flag.Flag[bool]
 	RunTargets           *flag.Flag[[]string]
 	ExcludeTargets       *flag.Flag[[]string]
@@ -129,6 +132,7 @@ func NewRunFlags() *RunFlags {
 		Snapshot:             flag.New[string](FlagSnapshot, false),
 		ExcludedSteps:        flag.New[[]string](FlagSkip, false),
 		GuidedFailureMode:    flag.New[string](FlagGuidedFailure, false),
+		Priority:             flag.New[string](FlagPriority, false),
 		ForcePackageDownload: flag.New[bool](FlagForcePackageDownload, false),
 		RunTargets:           flag.New[[]string](FlagRunTarget, false),
 		ExcludeTargets:       flag.New[[]string](FlagExcludeRunTarget, false),
@@ -171,6 +175,7 @@ func NewCmdRun(f factory.Factory) *cobra.Command {
 	flags.StringVarP(&runFlags.Snapshot.Value, runFlags.Snapshot.Name, "", "", "Name or ID of the snapshot to run. If not supplied, the command will attempt to use the published snapshot.")
 	flags.StringArrayVarP(&runFlags.ExcludedSteps.Value, runFlags.ExcludedSteps.Name, "", nil, "Exclude specific steps from the runbook")
 	flags.StringVarP(&runFlags.GuidedFailureMode.Value, runFlags.GuidedFailureMode.Name, "", "", "Enable Guided failure mode (true/false/default)")
+	flags.StringVarP(&runFlags.Priority.Value, runFlags.Priority.Name, "", "", "Jump the task queue ahead of other queued tasks (true/false/default). Requires the Priority Tasks feature and the TaskPrioritize permission.")
 	flags.BoolVarP(&runFlags.ForcePackageDownload.Value, runFlags.ForcePackageDownload.Name, "", false, "Force re-download of packages")
 	flags.StringArrayVarP(&runFlags.RunTargets.Value, runFlags.RunTargets.Name, "", nil, "Run on this target (can be specified multiple times)")
 	flags.StringArrayVarP(&runFlags.ExcludeTargets.Value, runFlags.ExcludeTargets.Name, "", nil, "Run on targets except for this (can be specified multiple times)")
@@ -289,6 +294,7 @@ func runDbRunbook(cmd *cobra.Command, f factory.Factory, flags *RunFlags, octopu
 		ScheduledExpiryTime:  flags.MaxQueueTime.Value,
 		ExcludedSteps:        flags.ExcludedSteps.Value,
 		GuidedFailureMode:    flags.GuidedFailureMode.Value,
+		Priority:             flags.Priority.Value,
 		ForcePackageDownload: flags.ForcePackageDownload.Value,
 		RunTargets:           flags.RunTargets.Value,
 		ExcludeTargets:       flags.ExcludeTargets.Value,
@@ -330,6 +336,7 @@ func runDbRunbook(cmd *cobra.Command, f factory.Factory, flags *RunFlags, octopu
 			resolvedFlags.MaxQueueTime.Value = options.ScheduledExpiryTime
 			resolvedFlags.ExcludedSteps.Value = options.ExcludedSteps
 			resolvedFlags.GuidedFailureMode.Value = options.GuidedFailureMode
+			resolvedFlags.Priority.Value = options.Priority
 			resolvedFlags.RunTargets.Value = options.RunTargets
 			resolvedFlags.ExcludeTargets.Value = options.ExcludeTargets
 
@@ -364,6 +371,7 @@ func runDbRunbook(cmd *cobra.Command, f factory.Factory, flags *RunFlags, octopu
 				resolvedFlags.MaxQueueTime,
 				resolvedFlags.ExcludedSteps,
 				resolvedFlags.GuidedFailureMode,
+				resolvedFlags.Priority,
 				resolvedFlags.ForcePackageDownload,
 				resolvedFlags.RunTargets,
 				resolvedFlags.ExcludeTargets,
@@ -420,6 +428,7 @@ func runGitRunbook(cmd *cobra.Command, f factory.Factory, flags *RunFlags, octop
 		ScheduledExpiryTime:  flags.MaxQueueTime.Value,
 		ExcludedSteps:        flags.ExcludedSteps.Value,
 		GuidedFailureMode:    flags.GuidedFailureMode.Value,
+		Priority:             flags.Priority.Value,
 		ForcePackageDownload: flags.ForcePackageDownload.Value,
 		RunTargets:           flags.RunTargets.Value,
 		ExcludeTargets:       flags.ExcludeTargets.Value,
@@ -464,6 +473,7 @@ func runGitRunbook(cmd *cobra.Command, f factory.Factory, flags *RunFlags, octop
 			resolvedFlags.MaxQueueTime.Value = options.ScheduledExpiryTime
 			resolvedFlags.ExcludedSteps.Value = options.ExcludedSteps
 			resolvedFlags.GuidedFailureMode.Value = options.GuidedFailureMode
+			resolvedFlags.Priority.Value = options.Priority
 			resolvedFlags.RunTargets.Value = options.RunTargets
 			resolvedFlags.ExcludeTargets.Value = options.ExcludeTargets
 			resolvedFlags.GitRef.Value = options.GitReference
@@ -502,6 +512,7 @@ func runGitRunbook(cmd *cobra.Command, f factory.Factory, flags *RunFlags, octop
 				resolvedFlags.MaxQueueTime,
 				resolvedFlags.ExcludedSteps,
 				resolvedFlags.GuidedFailureMode,
+				resolvedFlags.Priority,
 				resolvedFlags.ForcePackageDownload,
 				resolvedFlags.RunTargets,
 				resolvedFlags.ExcludeTargets,

--- a/pkg/cmd/runbook/run/run_by_tag.go
+++ b/pkg/cmd/runbook/run/run_by_tag.go
@@ -364,6 +364,7 @@ func runRunbooksByTag(cmd *cobra.Command, f factory.Factory, flags *RunFlags, oc
 			ScheduledExpiryTime:  flags.MaxQueueTime.Value,
 			ExcludedSteps:        flags.ExcludedSteps.Value,
 			GuidedFailureMode:    flags.GuidedFailureMode.Value,
+			Priority:             flags.Priority.Value,
 			ForcePackageDownload: flags.ForcePackageDownload.Value,
 			RunTargets:           flags.RunTargets.Value,
 			ExcludeTargets:       flags.ExcludeTargets.Value,

--- a/pkg/cmd/runbook/run/run_test.go
+++ b/pkg/cmd/runbook/run/run_test.go
@@ -732,7 +732,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: Now
 				  Skipped Steps: None
 				  Guided Failure Mode: Use default setting from the target environment
-				  Priority: Use default setting
+				  Priority: Do not jump the task queue
 				  Package Download: Use cached packages (if available)
 				  Run Targets: All included
 				`), stdout.String())
@@ -776,7 +776,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: Now
 				  Skipped Steps: None
 				  Guided Failure Mode: Use default setting from the target environment
-				  Priority: Use default setting
+				  Priority: Do not jump the task queue
 				  Package Download: Use cached packages (if available)
 				  Run Targets: Include vm-2
 				`), stdout.String())
@@ -795,7 +795,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: Now
 				  Skipped Steps: None
 				  Guided Failure Mode: Use default setting from the target environment
-				  Priority: Use default setting
+				  Priority: Do not jump the task queue
 				  Package Download: Use cached packages (if available)
 				  Run Targets: Exclude vm-4
 				`), stdout.String())

--- a/pkg/cmd/runbook/run/run_test.go
+++ b/pkg/cmd/runbook/run/run_test.go
@@ -732,6 +732,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: Now
 				  Skipped Steps: None
 				  Guided Failure Mode: Use default setting from the target environment
+				  Priority: Use default setting
 				  Package Download: Use cached packages (if available)
 				  Run Targets: All included
 				`), stdout.String())
@@ -742,6 +743,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				TaskOptionsRunbookRunBase: executor.TaskOptionsRunbookRunBase{
 					ScheduledStartTime:   "2022-09-23",
 					GuidedFailureMode:    "false",
+					Priority:             "true",
 					ForcePackageDownload: true,
 					ExcludedSteps:        []string{"Step 1", "Step 37"},
 					RunTargets:           []string{"vm-1", "vm-2"},
@@ -755,6 +757,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: 2022-09-23
 				  Skipped Steps: Step 1,Step 37
 				  Guided Failure Mode: Do not use guided failure mode
+				  Priority: Jump the task queue
 				  Package Download: Re-download packages from feed
 				  Run Targets: Include vm-1,vm-2; Exclude vm-3,vm-4
 				`), stdout.String())
@@ -773,6 +776,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: Now
 				  Skipped Steps: None
 				  Guided Failure Mode: Use default setting from the target environment
+				  Priority: Use default setting
 				  Package Download: Use cached packages (if available)
 				  Run Targets: Include vm-2
 				`), stdout.String())
@@ -791,6 +795,7 @@ func TestRunbookRun_PrintAdvancedSummary(t *testing.T) {
 				  Run At: Now
 				  Skipped Steps: None
 				  Guided Failure Mode: Use default setting from the target environment
+				  Priority: Use default setting
 				  Package Download: Use cached packages (if available)
 				  Run Targets: Exclude vm-4
 				`), stdout.String())

--- a/pkg/cmd/runbook/run/run_test.go
+++ b/pkg/cmd/runbook/run/run_test.go
@@ -287,6 +287,7 @@ func TestRunbookRun_AutomationMode(t *testing.T) {
 					"--skip", "Install", "--skip", "Cleanup",
 					"--snapshot", "Snapshot FWKMLUX",
 					"--guided-failure", "true",
+					"--priority", "true",
 					"--force-package-download",
 					"--target", "firstMachine", "--target", "secondMachine",
 					"--exclude-target", "thirdMachine",
@@ -317,6 +318,7 @@ func TestRunbookRun_AutomationMode(t *testing.T) {
 					ExcludedMachineNames: []string{"thirdMachine"},
 					SkipStepNames:        []string{"Install", "Cleanup"},
 					UseGuidedFailure:     &trueVar,
+					Priority:             "On",
 					RunAt:                "2022-09-10 13:32:03 +10:00",
 					NoRunAfter:           "2022-09-10 13:37:03 +10:00",
 					Variables: map[string]string{
@@ -636,6 +638,7 @@ func TestGitRunbookRun_AutomationMode(t *testing.T) {
 					"--run-at-expiry", "2022-09-10 13:37:03 +10:00",
 					"--skip", "Install", "--skip", "Cleanup",
 					"--guided-failure", "true",
+					"--priority", "true",
 					"--force-package-download",
 					"--target", "firstMachine", "--target", "secondMachine",
 					"--exclude-target", "thirdMachine",
@@ -669,6 +672,7 @@ func TestGitRunbookRun_AutomationMode(t *testing.T) {
 					ExcludedMachineNames: []string{"thirdMachine"},
 					SkipStepNames:        []string{"Install", "Cleanup"},
 					UseGuidedFailure:     &trueVar,
+					Priority:             "On",
 					RunAt:                "2022-09-10 13:32:03 +10:00",
 					NoRunAfter:           "2022-09-10 13:37:03 +10:00",
 					Variables: map[string]string{

--- a/pkg/executionscommon/executionscommon.go
+++ b/pkg/executionscommon/executionscommon.go
@@ -338,16 +338,34 @@ func LookupGuidedFailureModeString(value string) string {
 	}
 }
 
+// ParsePriorityMode maps the CLI's tri-state priority value onto the server's PriorityMode.
+// An empty result is omitted from the request, leaving the server to apply its own default.
+func ParsePriorityMode(value string) (string, error) {
+	b, err := strconv.ParseBool(value)
+	if err == nil {
+		if b {
+			return "On", nil
+		}
+		return "Off", nil
+	}
+	if value == "" || strings.EqualFold("default", value) {
+		return "", nil
+	}
+	return "", fmt.Errorf("'%s' is not a valid value for priority, expected true, false or default", value)
+}
+
 func LookupPriorityString(value string, defaultDescription string) string {
-	switch value {
-	case "", "default":
-		return defaultDescription
-	case "true", "True":
+	priority, err := ParsePriorityMode(value)
+	if err != nil {
+		return fmt.Sprintf("Unknown %s", value)
+	}
+	switch priority {
+	case "On":
 		return "Jump the task queue"
-	case "false", "False":
+	case "Off":
 		return "Do not jump the task queue"
 	default:
-		return fmt.Sprintf("Unknown %s", value)
+		return defaultDescription
 	}
 }
 

--- a/pkg/executionscommon/executionscommon.go
+++ b/pkg/executionscommon/executionscommon.go
@@ -338,6 +338,19 @@ func LookupGuidedFailureModeString(value string) string {
 	}
 }
 
+func LookupPriorityString(value string) string {
+	switch value {
+	case "", "default":
+		return "Use default setting"
+	case "true", "True":
+		return "Jump the task queue"
+	case "false", "False":
+		return "Do not jump the task queue"
+	default:
+		return fmt.Sprintf("Unknown %s", value)
+	}
+}
+
 func LookupPackageDownloadString(value bool) string {
 	if value {
 		return "Use cached packages (if available)"

--- a/pkg/executionscommon/executionscommon.go
+++ b/pkg/executionscommon/executionscommon.go
@@ -338,10 +338,10 @@ func LookupGuidedFailureModeString(value string) string {
 	}
 }
 
-func LookupPriorityString(value string) string {
+func LookupPriorityString(value string, defaultDescription string) string {
 	switch value {
 	case "", "default":
-		return "Use default setting"
+		return defaultDescription
 	case "true", "True":
 		return "Jump the task queue"
 	case "false", "False":

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
@@ -32,6 +34,22 @@ func NewTask(taskType TaskType, options any) *Task {
 		Type:    taskType,
 		Options: options,
 	}
+}
+
+// parsePriorityMode maps the CLI's tri-state priority value onto the server's PriorityMode.
+// An empty result means 'not specified', which leaves the server to apply the lifecycle default.
+func parsePriorityMode(value string) (string, error) {
+	b, err := strconv.ParseBool(value)
+	if err == nil {
+		if b {
+			return "On", nil
+		}
+		return "Off", nil
+	}
+	if value == "" || strings.EqualFold("default", value) {
+		return "", nil
+	}
+	return "", fmt.Errorf("'%s' is not a valid value for priority", value)
 }
 
 // ProcessTasks iterates over the list of tasks and attempts to run them all.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -2,8 +2,6 @@ package executor
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
@@ -34,22 +32,6 @@ func NewTask(taskType TaskType, options any) *Task {
 		Type:    taskType,
 		Options: options,
 	}
-}
-
-// parsePriorityMode maps the CLI's tri-state priority value onto the server's PriorityMode.
-// An empty result is omitted from the request, leaving the server to apply its own default.
-func parsePriorityMode(value string) (string, error) {
-	b, err := strconv.ParseBool(value)
-	if err == nil {
-		if b {
-			return "On", nil
-		}
-		return "Off", nil
-	}
-	if value == "" || strings.EqualFold("default", value) {
-		return "", nil
-	}
-	return "", fmt.Errorf("'%s' is not a valid value for priority, expected true, false or default", value)
 }
 
 // ProcessTasks iterates over the list of tasks and attempts to run them all.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -37,7 +37,7 @@ func NewTask(taskType TaskType, options any) *Task {
 }
 
 // parsePriorityMode maps the CLI's tri-state priority value onto the server's PriorityMode.
-// An empty result means 'not specified', which leaves the server to apply the lifecycle default.
+// An empty result is omitted from the request, leaving the server to apply its own default.
 func parsePriorityMode(value string) (string, error) {
 	b, err := strconv.ParseBool(value)
 	if err == nil {
@@ -49,7 +49,7 @@ func parsePriorityMode(value string) (string, error) {
 	if value == "" || strings.EqualFold("default", value) {
 		return "", nil
 	}
-	return "", fmt.Errorf("'%s' is not a valid value for priority", value)
+	return "", fmt.Errorf("'%s' is not a valid value for priority, expected true, false or default", value)
 }
 
 // ProcessTasks iterates over the list of tasks and attempts to run them all.

--- a/pkg/executor/release.go
+++ b/pkg/executor/release.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/OctopusDeploy/cli/pkg/executionscommon"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/releases"
@@ -172,7 +173,7 @@ func releaseDeploy(octopus *client.Client, space *spaces.Space, input any) error
 		}
 	}
 
-	abstractCmd.Priority, err = parsePriorityMode(params.Priority)
+	abstractCmd.Priority, err = executionscommon.ParsePriorityMode(params.Priority)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/release.go
+++ b/pkg/executor/release.go
@@ -101,6 +101,7 @@ type TaskOptionsDeployRelease struct {
 	ScheduledExpiryTime            string
 	ExcludedSteps                  []string
 	GuidedFailureMode              string // ["", "true", "false", "default"]. Note default and "" are the same, the only difference is whether interactive mode prompts you
+	Priority                       string // ["", "true", "false", "default"]. "" and "default" both defer to the lifecycle's priority setting
 	ForcePackageDownload           bool
 	DeploymentTargets              []string
 	ExcludeTargets                 []string
@@ -169,6 +170,11 @@ func releaseDeploy(octopus *client.Client, space *spaces.Space, input any) error
 		if params.GuidedFailureMode != "" && !strings.EqualFold("default", params.GuidedFailureMode) {
 			return fmt.Errorf("'%s' is not a valid value for guided failure mode", params.GuidedFailureMode)
 		}
+	}
+
+	abstractCmd.Priority, err = parsePriorityMode(params.Priority)
+	if err != nil {
+		return err
 	}
 
 	// If either tenants or tenantTags are specified then it must be a tenanted deployment.

--- a/pkg/executor/runbook.go
+++ b/pkg/executor/runbook.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/OctopusDeploy/cli/pkg/executionscommon"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
@@ -97,7 +98,7 @@ func runbookRun(octopus *client.Client, space *spaces.Space, input any) error {
 		}
 	}
 
-	abstractCmd.Priority, err = parsePriorityMode(params.Priority)
+	abstractCmd.Priority, err = executionscommon.ParsePriorityMode(params.Priority)
 	if err != nil {
 		return err
 	}
@@ -177,7 +178,7 @@ func gitRunbookRun(octopus *client.Client, space *spaces.Space, input any) error
 		}
 	}
 
-	abstractCmd.Priority, err = parsePriorityMode(params.Priority)
+	abstractCmd.Priority, err = executionscommon.ParsePriorityMode(params.Priority)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/runbook.go
+++ b/pkg/executor/runbook.go
@@ -31,6 +31,7 @@ type TaskOptionsRunbookRunBase struct {
 	ScheduledExpiryTime  string
 	ExcludedSteps        []string
 	GuidedFailureMode    string // ["", "true", "false", "default"]. Note default and "" are the same, the only difference is whether interactive mode prompts you
+	Priority             string // ["", "true", "false", "default"]. "" and "default" both leave the server to decide
 	ForcePackageDownload bool
 	RunTargets           []string
 	ExcludeTargets       []string
@@ -95,6 +96,12 @@ func runbookRun(octopus *client.Client, space *spaces.Space, input any) error {
 			return fmt.Errorf("'%s' is not a valid value for guided failure mode", params.GuidedFailureMode)
 		}
 	}
+
+	abstractCmd.Priority, err = parsePriorityMode(params.Priority)
+	if err != nil {
+		return err
+	}
+
 	runCommand := runbooks.NewRunbookRunCommandV1(space.ID, params.ProjectName)
 	runCommand.RunbookName = params.RunbookName
 	runCommand.EnvironmentNames = params.Environments
@@ -169,6 +176,12 @@ func gitRunbookRun(octopus *client.Client, space *spaces.Space, input any) error
 			return fmt.Errorf("'%s' is not a valid value for guided failure mode", params.GuidedFailureMode)
 		}
 	}
+
+	abstractCmd.Priority, err = parsePriorityMode(params.Priority)
+	if err != nil {
+		return err
+	}
+
 	runCommand := runbooks.NewGitRunbookRunCommandV1(space.ID, params.ProjectName)
 	runCommand.RunbookName = params.RunbookName
 	runCommand.EnvironmentNames = params.Environments


### PR DESCRIPTION
# Background

Task priority has been a server feature for a while, but there was no way to set it from the CLI. A customer asked about triggering priority deployments from automation they already had, and there was nothing to point them at.

Two gaps: `release deploy` and `runbook run` had no flag, and the SDK command struct had no field to put one in.

# Results

Adds `--priority` to `release deploy` and `runbook run`. It behaves like `--guided-failure`: `true`, `false` or `default`.

Fixes HPY-1553

Depends on https://github.com/OctopusDeploy/go-octopusdeploy/pull/460.

That SDK change is merged and released, so go.mod is on the tagged `v2.116.0`. The earlier pseudo-version pin is gone.

## Before

```
$ octopus release deploy --project X --version 1.0 --environment Dev --priority true
unknown flag: --priority
```

## After

```
$ octopus release deploy --project X --version 1.0 --environment Dev --priority true
ServerTasks-41
```

| Flag | Sent as | Server behaviour |
| --- | --- | --- |
| `--priority true` | `"priority": "On"` | jumps the task queue |
| `--priority false` | `"priority": "Off"` | never prioritised, even on a priority lifecycle phase |
| `--priority default` | field omitted | server default |
| flag not given | field omitted | unchanged from today |
| anything else | no request sent | CLI errors before it calls the API |

Priority also now appears in the Additional Options summary that interactive mode prints. It listed every other advanced option, so passing `--priority` read as though the flag had been ignored. There is still no prompt for it; the flag is aimed at automation, and adding a sixth advanced question for an Enterprise-gated setting seemed like the wrong trade.

Checked against a local server with the priority feature licensed. Deployments read back as `On`, `Off` and `LifecycleDefault`.

## Two things worth knowing about the runbook side

**`default` is the same as `false` for runbooks.** `RunbookRun.ChangePriority` seeds `Off` and then collapses `LifecycleDefault` to `Off`, because runbooks have no lifecycle phase to defer to. `Deployment.ChangePriority` seeds `LifecycleDefault` and does not collapse. So the tri-state is only genuinely tri-state on `release deploy`. The flag help on `runbook run` says so.

**Git-stored runbooks drop the priority server-side.** `CreateGitRunbookRunCommandV1Handler` never copied `Priority` onto `RunGitRunbookRun`, so the value was accepted and discarded. Fixed in https://github.com/OctopusDeploy/OctopusDeploy/pull/46537. This is pre-existing and also affects the REST API and the MCP tool, but it does mean `--priority` on `runbook run` is only fully honoured against a server carrying that fix.

## On licence and permission enforcement

An earlier version of this description claimed the server rejects the request when the licence or permission is missing, so the CLI needs no check of its own. That is true for `release deploy` only. `PriorityTaskLicenseChecker` has no runbook overload and `TaskPriority.IsPriorityRunbookRun` does no access check, so runbook runs skip both gates. The flag help no longer asserts a permission requirement it cannot keep, and I have raised the enforcement asymmetry separately rather than paper over it here.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
  - Automated testing / Exploratory testing / Nothing required?
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.


