### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist/
 
 cmd/octopus/octopus
 cmd/gen-docs/gen-docs
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
macOS Finder writes `.DS_Store` into every directory it is opened in. This repo had no rule for it, so those files sit untracked in working copies and can be swept into a `git add` unnoticed — one recently reached a pull request in `OctopusDeploy/Jira` exactly that way.

One line, verified locally with `git check-ignore`.

Part of a small sweep across the Octopus repos that were missing this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)