### PR TITLE
Report AWS ECS target detail now the SDK deserialises the endpoint

### DIFF
--- a/pkg/cmd/target/list/list_test.go
+++ b/pkg/cmd/target/list/list_test.go
@@ -16,12 +16,22 @@ func TestDescribeTargetType_KnownStyle(t *testing.T) {
 	assert.Equal(t, "Listening Tentacle", describeTargetType(target))
 }
 
-func TestDescribeTargetType_EndpointMissing(t *testing.T) {
+func TestDescribeTargetType_EcsCluster(t *testing.T) {
 	target := &machines.DeploymentTarget{}
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"Id": "Machines-1041",
 		"Name": "aws ecs",
 		"Endpoint": { "CommunicationStyle": "AwsEcsCluster", "ClusterName": "repro-604-cluster" }
+	}`), target))
+
+	assert.Equal(t, "AWS ECS Cluster", describeTargetType(target))
+}
+
+func TestDescribeTargetType_EndpointMissing(t *testing.T) {
+	target := &machines.DeploymentTarget{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"Id": "Machines-1042",
+		"Name": "no endpoint"
 	}`), target))
 
 	assert.NotPanics(t, func() {

--- a/pkg/cmd/target/shared/target.go
+++ b/pkg/cmd/target/shared/target.go
@@ -54,6 +54,11 @@ func GetEndpointDetails(target *machines.DeploymentTarget) map[string]string {
 			}
 			details["Web App"] = webApp
 		}
+	case "AwsEcsCluster":
+		if endpoint, ok := target.Endpoint.(*machines.AwsEcsClusterEndpoint); ok {
+			details["Cluster"] = endpoint.ClusterName
+			details["Region"] = endpoint.Region
+		}
 	case "Kubernetes":
 		if endpoint, ok := target.Endpoint.(*machines.KubernetesEndpoint); ok {
 			details["Authentication Type"] = endpoint.Authentication.GetAuthenticationType()

--- a/pkg/cmd/target/shared/target_test.go
+++ b/pkg/cmd/target/shared/target_test.go
@@ -43,22 +43,43 @@ const ecsTargetJson = `{
   }
 }`
 
-// If this fails because the SDK learned to deserialise "AwsEcsCluster", the
-// unknown-type fallbacks below can start reporting real detail.
-func TestEcsTargetDeserialisesWithoutAnEndpoint(t *testing.T) {
+// The #604 crash was a nil endpoint reaching code that dereferenced it. The SDK
+// types ECS endpoints now, so this stands in for any target it still cannot.
+const endpointlessTargetJson = `{
+  "Id": "Machines-1042",
+  "Name": "no endpoint",
+  "SpaceId": "Spaces-1",
+  "EnvironmentIds": ["Environments-1"],
+  "Roles": ["unknown"]
+}`
+
+func TestEcsTargetDeserialisesIntoAnEcsEndpoint(t *testing.T) {
 	target := parseTarget(t, ecsTargetJson)
 
-	assert.True(t, machines.IsNil(target.Endpoint), "expected the SDK to leave the endpoint nil for an AwsEcsCluster target")
+	endpoint, ok := target.Endpoint.(*machines.AwsEcsClusterEndpoint)
+	require.True(t, ok, "expected the SDK to deserialise an AwsEcsCluster endpoint")
+	assert.Equal(t, "repro-604-cluster", endpoint.ClusterName)
+	assert.Equal(t, "ap-southeast-2", endpoint.Region)
+	assert.Equal(t, "WorkerPools-1", endpoint.GetDefaultWorkerPoolID())
 }
 
 func TestGetEndpointDetails_EndpointMissing(t *testing.T) {
-	target := parseTarget(t, ecsTargetJson)
+	target := parseTarget(t, endpointlessTargetJson)
 
 	var details map[string]string
 	assert.NotPanics(t, func() {
 		details = shared.GetEndpointDetails(target)
 	})
 	assert.Empty(t, details)
+}
+
+func TestGetEndpointDetails_EcsEndpoint(t *testing.T) {
+	target := parseTarget(t, ecsTargetJson)
+
+	details := shared.GetEndpointDetails(target)
+
+	assert.Equal(t, "repro-604-cluster", details["Cluster"])
+	assert.Equal(t, "ap-southeast-2", details["Region"])
 }
 
 func TestGetEndpointDetails_KnownEndpoint(t *testing.T) {
@@ -85,11 +106,19 @@ func TestGetEndpointDetails_TentacleNeverHealthChecked(t *testing.T) {
 }
 
 func TestResolveDefaultWorkerPool_EndpointMissing(t *testing.T) {
-	target := parseTarget(t, ecsTargetJson)
+	target := parseTarget(t, endpointlessTargetJson)
 
 	assert.NotPanics(t, func() {
 		assert.Equal(t, "N/A", shared.ResolveDefaultWorkerPool(target, map[string]string{}, "None"))
 	})
+}
+
+func TestResolveDefaultWorkerPool_EcsEndpoint(t *testing.T) {
+	target := parseTarget(t, ecsTargetJson)
+
+	workerPools := map[string]string{"WorkerPools-1": "Default Worker Pool"}
+
+	assert.Equal(t, "Default Worker Pool", shared.ResolveDefaultWorkerPool(target, workerPools, "None"))
 }
 
 func parseTarget(t *testing.T, payload string) *machines.DeploymentTarget {

--- a/pkg/cmd/target/view/view.go
+++ b/pkg/cmd/target/view/view.go
@@ -176,6 +176,8 @@ func getTargetTypeDisplayName(communicationStyle string) string {
 		return "Kubernetes"
 	case "StepPackage":
 		return "Step Package"
+	case "AwsEcsCluster":
+		return "AWS ECS Cluster"
 	case "":
 		return machinescommon.UnknownValue
 	default:

--- a/pkg/cmd/target/view/view_ecs_test.go
+++ b/pkg/cmd/target/view/view_ecs_test.go
@@ -31,7 +31,7 @@ func newRootResourceWithInfrastructureLinks() *octopusApiClient.RootResource {
 	return root
 }
 
-// Sent verbatim: the SDK has no type that can represent an ECS endpoint.
+// Sent verbatim so the SDK does the deserialising the CLI relies on.
 var ecsTargetResponse = json.RawMessage(`{
   "Id": "Machines-1041",
   "Name": "aws ecs",
@@ -90,7 +90,10 @@ func TestViewEcsTarget_DoesNotPanic(t *testing.T) {
 	assert.Contains(t, output, "Healthy")
 	assert.Contains(t, output, "Environments: Development")
 	assert.Contains(t, output, "Roles: ecs")
-	assert.Contains(t, output, "Type: Unknown")
+	assert.Contains(t, output, "AWS ECS Cluster")
+	assert.Contains(t, output, "Cluster: repro-604-cluster")
+	assert.Contains(t, output, "Region: ap-southeast-2")
+	assert.Contains(t, output, "Default Worker Pool: Windows Pool")
 }
 
 func TestViewEcsTarget_Json(t *testing.T) {
@@ -117,7 +120,9 @@ func TestViewEcsTarget_Json(t *testing.T) {
 	assert.Equal(t, "aws ecs", result["Name"])
 	assert.Equal(t, "Machines-1041", result["Id"])
 	assert.Equal(t, []any{"Development"}, result["Environments"])
-	assert.Equal(t, "", result["CommunicationStyle"])
+	assert.Equal(t, "AwsEcsCluster", result["CommunicationStyle"])
+	assert.Equal(t, "WorkerPools-1", result["DefaultWorkerPool"])
+	assert.Equal(t, map[string]any{"Cluster": "repro-604-cluster", "Region": "ap-southeast-2"}, result["EndpointDetails"])
 }
 
 func setupViewCommand(t *testing.T) (*testutil.MockHttpServer, *cobra.Command, *bytes.Buffer) {
@@ -151,5 +156,7 @@ func expectEnvironmentRequest(t *testing.T, api *testutil.MockHttpServer) {
 func expectWorkerPoolRequest(t *testing.T, api *testutil.MockHttpServer) {
 	t.Helper()
 
-	api.ExpectRequest(t, "GET", "/api/Spaces-1/workerpools/all").RespondWith([]*workerpools.WorkerPoolListResult{})
+	pool := &workerpools.WorkerPoolListResult{ID: "WorkerPools-1", Name: "Windows Pool"}
+
+	api.ExpectRequest(t, "GET", "/api/Spaces-1/workerpools/all").RespondWith([]*workerpools.WorkerPoolListResult{pool})
 }

--- a/pkg/machinescommon/comms.go
+++ b/pkg/machinescommon/comms.go
@@ -11,6 +11,7 @@ var CommunicationStyleToDescriptionMap = map[string]string{
 	"Kubernetes":                "Kubernetes Cluster",
 	"None":                      "Cloud Region",
 	"StepPackage":               "Step Package",
+	"AwsEcsCluster":             "AWS ECS Cluster",
 }
 
 var CommunicationStyleToDeploymentTargetTypeMap = map[string]string{


### PR DESCRIPTION
Unit tests have been failing on `main` since the go-octopusdeploy bump to v2.116.0 in #708. That release added `AwsEcsClusterEndpoint`, so AWS ECS deployment targets no longer arrive with a nil endpoint, and five tests asserting the old unknown-type fallbacks started failing.

The target commands now name the type as "AWS ECS Cluster", show the cluster and region as endpoint details, and resolve the default worker pool. Tests that covered the nil-endpoint path now use a target with no endpoint at all, so the #604 regression stays guarded.

Verified with `go test ./...` from `./pkg`: the three target packages that fail on `main` pass on this branch, and no other package changed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)